### PR TITLE
Add a generic StandardShapeParser

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -13,6 +13,9 @@ let package = Package(
         .library(
             name: "QueryCoder",
             targets: ["QueryCoder"]),
+        .library(
+            name: "ShapeCoding",
+            targets: ["ShapeCoding"]),
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
@@ -29,11 +32,17 @@ let package = Package(
         .target(
             name: "QueryCoder",
             dependencies: ["LoggerAPI"]),
+        .target(
+            name: "ShapeCoding",
+            dependencies: ["LoggerAPI"]),
         .testTarget(
             name: "SmokeHTTPClientTests",
             dependencies: ["SmokeHTTPClient"]),
         .testTarget(
             name: "QueryCoderTests",
             dependencies: ["QueryCoder"]),
+        .testTarget(
+            name: "ShapeCodingTests",
+            dependencies: ["ShapeCoding"]),
     ]
 )

--- a/Sources/ShapeCoding/MutableShape.swift
+++ b/Sources/ShapeCoding/MutableShape.swift
@@ -17,24 +17,52 @@
 
 import Foundation
 
-/// An enumeration of possible types of MutableShapes.
+/// An enumeration of possible types of a shape that can be muted.
 public enum MutableShape {
     case dictionary(MutableShapeDictionary)
+    case string(String)
+    case null
     
     /**
-     Finalizes this MutableShapeAttribute as a ShapeAttribute.
+     Finalizes this MutableShape as a Shape.
      */
-    public func asShapeAttribute() -> ShapeAttribute {
+    public func asShape() -> Shape {
         switch self {
         case .dictionary(let innerDictionary):
-            return innerDictionary.asShapeAttribute()
+            return innerDictionary.asShape()
+        case .string(let value):
+            return .string(value)
+        case .null:
+            return .null
         }
     }
 }
 
-/// A MutableShape type for a dictionary of MutableShapeAttributes
+/// An enumeration of possible types of a shape.
+public enum Shape: Equatable {
+    case dictionary([String: Shape])
+    case string(String)
+    case null
+}
+
+/// An enumeration of possible types of MutableShapes that can have nested shapes.
+public enum NestedableMutableShape {
+    case dictionary(MutableShapeDictionary)
+    
+    /**
+     Finalizes this MutableShape as a Shape.
+     */
+    public func asShape() -> Shape {
+        switch self {
+        case .dictionary(let innerDictionary):
+            return innerDictionary.asShape()
+        }
+    }
+}
+
+/// A MutableShape type for a dictionary of MutableShapes
 public class MutableShapeDictionary {
-    private var values: [String: MutableShapeAttribute] = [:]
+    private var values: [String: MutableShape] = [:]
     
     /**
      Initializer with an empty dictionary.
@@ -50,7 +78,7 @@ public class MutableShapeDictionary {
         - key: the key of the value to retrieve
         - Returns: the value of the provided key or nil if there is no such value
      */
-    public subscript(key: String) -> MutableShapeAttribute? {
+    public subscript(key: String) -> MutableShape? {
         get {
             return values[key]
         }
@@ -60,41 +88,13 @@ public class MutableShapeDictionary {
     }
     
     /**
-     Finalizes this MutableShapeDictionary as a ShapeAttribute.
+     Finalizes this MutableShapeDictionary as a Shape.
      */
-    public func asShapeAttribute() -> ShapeAttribute {
-        let transformedValues: [String: ShapeAttribute] = values.mapValues { value in
-            return value.asShapeAttribute()
+    public func asShape() -> Shape {
+        let transformedValues: [String: Shape] = values.mapValues { value in
+            return value.asShape()
         }
         
         return .dictionary(transformedValues)
     }
-}
-
-/// An enumeration of possible values of a shape that can be mutated.
-public enum MutableShapeAttribute {
-    case dictionary(MutableShapeDictionary)
-    case string(String)
-    case null
-    
-    /**
-     Finalizes this MutableShapeAttribute as a ShapeAttribute.
-     */
-    public func asShapeAttribute() -> ShapeAttribute {
-        switch self {
-        case .dictionary(let innerDictionary):
-            return innerDictionary.asShapeAttribute()
-        case .string(let value):
-            return .string(value)
-        case .null:
-            return .null
-        }
-    }
-}
-
-/// An enumeration of the possible types of attributes for a shape
-public enum ShapeAttribute: Equatable {
-    case dictionary([String: ShapeAttribute])
-    case string(String)
-    case null
 }

--- a/Sources/ShapeCoding/MutableShape.swift
+++ b/Sources/ShapeCoding/MutableShape.swift
@@ -46,7 +46,7 @@ public enum Shape: Equatable {
 }
 
 /// An enumeration of possible types of MutableShapes that can have nested shapes.
-public enum NestedableMutableShape {
+public enum NestableMutableShape {
     case dictionary(MutableShapeDictionary)
     
     /**

--- a/Sources/ShapeCoding/MutableShape.swift
+++ b/Sources/ShapeCoding/MutableShape.swift
@@ -1,0 +1,100 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+//  MutableShape.swift
+//  ShapeCoding
+//
+
+import Foundation
+
+/// An enumeration of possible types of MutableShapes.
+public enum MutableShape {
+    case dictionary(MutableShapeDictionary)
+    
+    /**
+     Finalizes this MutableShapeAttribute as a ShapeAttribute.
+     */
+    public func asShapeAttribute() -> ShapeAttribute {
+        switch self {
+        case .dictionary(let innerDictionary):
+            return innerDictionary.asShapeAttribute()
+        }
+    }
+}
+
+/// A MutableShape type for a dictionary of MutableShapeAttributes
+public class MutableShapeDictionary {
+    private var values: [String: MutableShapeAttribute] = [:]
+    
+    /**
+     Initializer with an empty dictionary.
+     */
+    public init() {
+        
+    }
+    
+    /**
+     Get a value from the current state of the dictionary.
+ 
+     - Parameters:
+        - key: the key of the value to retrieve
+        - Returns: the value of the provided key or nil if there is no such value
+     */
+    public subscript(key: String) -> MutableShapeAttribute? {
+        get {
+            return values[key]
+        }
+        set(newValue) {
+            values[key] = newValue
+        }
+    }
+    
+    /**
+     Finalizes this MutableShapeDictionary as a ShapeAttribute.
+     */
+    public func asShapeAttribute() -> ShapeAttribute {
+        let transformedValues: [String: ShapeAttribute] = values.mapValues { value in
+            return value.asShapeAttribute()
+        }
+        
+        return .dictionary(transformedValues)
+    }
+}
+
+/// An enumeration of possible values of a shape that can be mutated.
+public enum MutableShapeAttribute {
+    case dictionary(MutableShapeDictionary)
+    case string(String)
+    case null
+    
+    /**
+     Finalizes this MutableShapeAttribute as a ShapeAttribute.
+     */
+    public func asShapeAttribute() -> ShapeAttribute {
+        switch self {
+        case .dictionary(let innerDictionary):
+            return innerDictionary.asShapeAttribute()
+        case .string(let value):
+            return .string(value)
+        case .null:
+            return .null
+        }
+    }
+}
+
+/// An enumeration of the possible types of attributes for a shape
+public enum ShapeAttribute: Equatable {
+    case dictionary([String: ShapeAttribute])
+    case string(String)
+    case null
+}

--- a/Sources/ShapeCoding/ShapeDecodingStorage.swift
+++ b/Sources/ShapeCoding/ShapeDecodingStorage.swift
@@ -19,7 +19,7 @@ import Foundation
 
 /// Helper class to store a stack of the current MutableShape to use when decoding a shape.
 class ShapeDecodingStorage {
-    private(set) internal var shapes: [MutableShape] = []
+    private(set) internal var shapes: [NestedableMutableShape] = []
 
     /// Initializer with no shapes.
     public init() {}
@@ -30,12 +30,12 @@ class ShapeDecodingStorage {
     }
 
     /// Retreive the current top shape
-    public var topShape: MutableShape? {
+    public var topShape: NestedableMutableShape? {
         return self.shapes.last
     }
 
     /// Push a new stack into the stack
-    public func push(shape: MutableShape) {
+    public func push(shape: NestedableMutableShape) {
         self.shapes.append(shape)
     }
 

--- a/Sources/ShapeCoding/ShapeDecodingStorage.swift
+++ b/Sources/ShapeCoding/ShapeDecodingStorage.swift
@@ -19,7 +19,7 @@ import Foundation
 
 /// Helper class to store a stack of the current MutableShape to use when decoding a shape.
 class ShapeDecodingStorage {
-    private(set) internal var shapes: [NestedableMutableShape] = []
+    private(set) internal var shapes: [NestableMutableShape] = []
 
     /// Initializer with no shapes.
     public init() {}
@@ -30,12 +30,12 @@ class ShapeDecodingStorage {
     }
 
     /// Retreive the current top shape
-    public var topShape: NestedableMutableShape? {
+    public var topShape: NestableMutableShape? {
         return self.shapes.last
     }
 
     /// Push a new stack into the stack
-    public func push(shape: NestedableMutableShape) {
+    public func push(shape: NestableMutableShape) {
         self.shapes.append(shape)
     }
 

--- a/Sources/ShapeCoding/ShapeDecodingStorage.swift
+++ b/Sources/ShapeCoding/ShapeDecodingStorage.swift
@@ -1,0 +1,47 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+//  ShapeDecodingStorage.swift
+//  ShapeCoding
+//
+
+import Foundation
+
+/// Helper class to store a stack of the current MutableShape to use when decoding a shape.
+class ShapeDecodingStorage {
+    private(set) internal var shapes: [MutableShape] = []
+
+    /// Initializer with no shapes.
+    public init() {}
+
+    /// The current number of shapes
+    public var count: Int {
+        return self.shapes.count
+    }
+
+    /// Retreive the current top shape
+    public var topShape: MutableShape? {
+        return self.shapes.last
+    }
+
+    /// Push a new stack into the stack
+    public func push(shape: MutableShape) {
+        self.shapes.append(shape)
+    }
+
+    /// Pop the top shape off the stack.
+    public func popShape() {
+        precondition(self.shapes.count > 0, "Empty shape stack.")
+        self.shapes.removeLast()
+    }
+}

--- a/Sources/ShapeCoding/StandardDecodingOptions.swift
+++ b/Sources/ShapeCoding/StandardDecodingOptions.swift
@@ -1,0 +1,62 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+//  StandardDecodingOptions.swift
+//  ShapeCoding
+//
+
+import Foundation
+
+/// The strategy to use for decoding stack keys.
+public enum ShapeKeyDecodingStrategy {
+    /// The decoder will spilt stack keys on the specified character to indicate a
+    /// nested structure that could include nested types, dictionaries and arrays. This is the default.
+    ///
+    /// Array entries are indicated by a 1-based index
+    /// ie. ["theArray.1": "Value1", "theArray.2": "Value2] --> ShapeOutput(theArray: ["Value1", "Value2"])
+    /// Nested type attributes are indicated by the attribute keys
+    /// ie. ["theArray.foo": "Value1", "theArray.bar": "Value2] --> ShapeOutput(theType: TheType(foo: "Value1", bar: "Value2"))
+    /// Dictionary entries are indicated based on the provided `ShapeMapDecodingStrategy`
+    case useAsShapeSeparator(Character)
+    
+    case useShapePrefix
+    
+    /// The decoder will decode stack keys into the attributes
+    /// of the provided type. No nested types, lists or dictionaries are possible.
+    case flatStructure
+}
+
+/// The strategy to use for decoding maps.
+public enum ShapeMapDecodingStrategy {
+    /// The decoder will expect a single stack entry for
+    /// each entry of the map. This is the default.
+    /// ie. ["theMap.Key": "Value"] --> ShapeOutput(theMap: ["Key": "Value"])
+    case singleShapeEntry
+
+    /// The decoder will expect separate entries for the key and value
+    /// of each entry of the map, specified as a list.
+    /// ie. ["theMap.1.KeyTag": "Key", "theMap.1.ValueTag": "Value"] -> ShapeOutput(theMap: ["Key": "Value"])
+    case separateShapeEntriesWith(keyTag: String, valueTag: String)
+}
+
+// Structure that hold the options to use during decoding
+public struct StandardDecodingOptions {
+    public let stackKeyDecodingStrategy: ShapeKeyDecodingStrategy
+    public let stackMapDecodingStrategy: ShapeMapDecodingStrategy
+    
+    public init(stackKeyDecodingStrategy: ShapeKeyDecodingStrategy,
+                stackMapDecodingStrategy: ShapeMapDecodingStrategy) {
+        self.stackKeyDecodingStrategy = stackKeyDecodingStrategy
+        self.stackMapDecodingStrategy = stackMapDecodingStrategy
+    }
+}

--- a/Sources/ShapeCoding/StandardDecodingOptions.swift
+++ b/Sources/ShapeCoding/StandardDecodingOptions.swift
@@ -17,9 +17,9 @@
 
 import Foundation
 
-/// The strategy to use for decoding stack keys.
+/// The strategy to use for decoding shape keys.
 public enum ShapeKeyDecodingStrategy {
-    /// The decoder will spilt stack keys on the specified character to indicate a
+    /// The decoder will spilt shape keys on the specified character to indicate a
     /// nested structure that could include nested types, dictionaries and arrays. This is the default.
     ///
     /// Array entries are indicated by a 1-based index
@@ -31,14 +31,14 @@ public enum ShapeKeyDecodingStrategy {
     
     case useShapePrefix
     
-    /// The decoder will decode stack keys into the attributes
+    /// The decoder will decode shape keys into the attributes
     /// of the provided type. No nested types, lists or dictionaries are possible.
     case flatStructure
 }
 
 /// The strategy to use for decoding maps.
 public enum ShapeMapDecodingStrategy {
-    /// The decoder will expect a single stack entry for
+    /// The decoder will expect a single shape entry for
     /// each entry of the map. This is the default.
     /// ie. ["theMap.Key": "Value"] --> ShapeOutput(theMap: ["Key": "Value"])
     case singleShapeEntry
@@ -51,12 +51,12 @@ public enum ShapeMapDecodingStrategy {
 
 // Structure that hold the options to use during decoding
 public struct StandardDecodingOptions {
-    public let stackKeyDecodingStrategy: ShapeKeyDecodingStrategy
-    public let stackMapDecodingStrategy: ShapeMapDecodingStrategy
+    public let shapeKeyDecodingStrategy: ShapeKeyDecodingStrategy
+    public let shapeMapDecodingStrategy: ShapeMapDecodingStrategy
     
-    public init(stackKeyDecodingStrategy: ShapeKeyDecodingStrategy,
-                stackMapDecodingStrategy: ShapeMapDecodingStrategy) {
-        self.stackKeyDecodingStrategy = stackKeyDecodingStrategy
-        self.stackMapDecodingStrategy = stackMapDecodingStrategy
+    public init(shapeKeyDecodingStrategy: ShapeKeyDecodingStrategy,
+                shapeMapDecodingStrategy: ShapeMapDecodingStrategy) {
+        self.shapeKeyDecodingStrategy = shapeKeyDecodingStrategy
+        self.shapeMapDecodingStrategy = shapeMapDecodingStrategy
     }
 }

--- a/Sources/ShapeCoding/StandardDecodingOptions.swift
+++ b/Sources/ShapeCoding/StandardDecodingOptions.swift
@@ -29,6 +29,18 @@ public enum ShapeKeyDecodingStrategy {
     /// Dictionary entries are indicated based on the provided `ShapeMapDecodingStrategy`
     case useAsShapeSeparator(Character)
     
+    /// The decoder will spilt the shape keys on the expected name of an attribute to indicate a
+    /// nested structure that could include nested types, dictionaries and arrays.
+    ///
+    /// Array entries are indicated by a 1-based index
+    /// ie. ["theArray1": "Value1", "theArray2": "Value2] --> ShapeOutput(theArray: ["Value1", "Value2"])
+    /// Nested type attributes are indicated by the attribute keys
+    /// ie. ["theTypefoo": "Value1", "theTypebar": "Value2] --> ShapeOutput(theType: TheType(foo: "Value1", bar: "Value2"))
+    /// Dictionaries have dynamic membership based on what is present in the payload and therefore have no expected
+    /// attribute names. Dictionaries cannot use this strategy to indicate a nested structure beyond their own attributes.
+    /// ie. ["theMapfoo": "Value1", "theMapbar": "Value2] --> ShapeOutput(theMap: [foo: "Value1", bar: "Value2"])
+    /// The above transformation is possible with this strategy. This strategy cannot be used if the map's attributes
+    /// contains nested attributes. In these scenarios, a specific shape separator will need to be used.
     case useShapePrefix
     
     /// The decoder will decode shape keys into the attributes

--- a/Sources/ShapeCoding/StandardShapeParser.swift
+++ b/Sources/ShapeCoding/StandardShapeParser.swift
@@ -20,7 +20,7 @@ import Foundation
 /// Parses a [String: String] into an Shape structure.
 public struct StandardShapeParser {
     let storage = ShapeDecodingStorage()
-    var rootShape: NestedableMutableShape?
+    var rootShape: NestableMutableShape?
     var codingPath: [CodingKey] = []
     
     let decoderOptions: StandardDecodingOptions

--- a/Sources/ShapeCoding/StandardShapeParser.swift
+++ b/Sources/ShapeCoding/StandardShapeParser.swift
@@ -1,0 +1,138 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+//  StandardShapeParser.swift
+//  ShapeCoding
+//
+
+import Foundation
+
+/// Parses a [String: String] into an ShapeAttribute structure.
+public struct StandardShapeParser {
+    let storage = ShapeDecodingStorage()
+    var rootShape: MutableShape?
+    var codingPath: [CodingKey] = []
+    
+    let decoderOptions: StandardDecodingOptions
+    
+    private init(decoderOptions: StandardDecodingOptions) {
+        self.decoderOptions = decoderOptions
+    }
+    
+    /// Parses a query into an ShapeAttribute structure.
+    public static func parse(with headers: [(String, String?)], decoderOptions: StandardDecodingOptions) throws -> ShapeAttribute {
+        
+        var parser = StandardShapeParser(decoderOptions: decoderOptions)
+        try parser.parse(shapeName: nil, with: headers)
+        
+        return parser.rootShape?.asShapeAttribute() ?? .null
+    }
+    
+    mutating func parse(shapeName: String?, with entries: [(String, String?)]) throws {
+        // create a dictionary for the array
+        let mutableShapeDictionary = MutableShapeDictionary()
+
+        // either this is the root shape or
+        // add it to the current shape
+        if rootShape == nil {
+            rootShape = .dictionary(mutableShapeDictionary)
+        } else {
+            try addChildMutableShapeAttribute(shapeName: shapeName, mutableShapeAttribute: .dictionary(mutableShapeDictionary))
+        }
+        
+        // add as the new top shape
+        storage.push(shape: .dictionary(mutableShapeDictionary))
+        
+        switch decoderOptions.stackKeyDecodingStrategy {
+        case .flatStructure, .useShapePrefix:
+            try parseWithoutShapeSeparator(with: entries)
+        case .useAsShapeSeparator(let separatorCharacter):
+            try parseWithShapeSeparator(with: entries,
+                                            separatorCharacter: separatorCharacter)
+        }
+        
+        // remove the top shape
+        storage.popShape()
+    }
+    
+    mutating func parseWithoutShapeSeparator(with entries: [(String, String?)]) throws {
+        try entries.forEach { try addEntry($0) }
+    }
+    
+    mutating func parseWithShapeSeparator(with entries: [(String, String?)],
+                                          separatorCharacter: Character) throws {
+        var nonNestedShapeEntries: [(String, String?)] = []
+        var nestedShapeEntries: [String: [(String, String?)]] = [:]
+        
+        entries.forEach { entry in
+            let components = entry.0.split(separator: separatorCharacter, maxSplits: 1, omittingEmptySubsequences: true)
+            
+            // if this is part of a nested shape
+            if components.count > 1 {
+                // add to the nested shape
+                let shapeName = String(components[0])
+                let nestedEntryName = String(components[1])
+                if var currentShape = nestedShapeEntries[shapeName] {
+                    currentShape.append((nestedEntryName, entry.1))
+                    nestedShapeEntries[shapeName] = currentShape
+                } else {
+                    nestedShapeEntries[shapeName] = [(nestedEntryName, entry.1)]
+                }
+            } else {
+                nonNestedShapeEntries.append(entry)
+            }
+        }
+        
+        // add any non nested shape entries as normal
+        try nonNestedShapeEntries.forEach { try addEntry($0) }
+        
+        // iterate through the nested shape entries
+        try nestedShapeEntries.forEach { shape in
+            try parse(shapeName: shape.key, with: shape.value)
+        }
+    }
+    
+    mutating func addEntry(_ entry: (String, String?)) throws {
+        if let value = entry.1 {
+            guard let removedPercentEncoding = value.removingPercentEncoding else {
+                throw DecodingError.dataCorrupted(DecodingError.Context(
+                    codingPath: codingPath,
+                    debugDescription: "Unable to remove percent encoding from value '\(value)'"))
+            }
+            try addChildMutableShapeAttribute(shapeName: entry.0, mutableShapeAttribute: .string(removedPercentEncoding))
+        } else {
+            try addChildMutableShapeAttribute(shapeName: entry.0, mutableShapeAttribute: .null)
+        }
+    }
+    
+    /// Add a child value to the shape
+    mutating func addChildMutableShapeAttribute(shapeName: String?, mutableShapeAttribute: MutableShapeAttribute) throws {
+        if let topShape = storage.topShape {
+            switch topShape {
+            case .dictionary(let dictionary):
+                guard let fieldName = shapeName else {
+                    throw DecodingError.dataCorrupted(DecodingError.Context(
+                        codingPath: codingPath,
+                        debugDescription: "Attempted to add to dictionary without a field name."))
+                }
+
+                // add to the existing dictionary
+                dictionary[fieldName] = mutableShapeAttribute
+            }
+        } else {
+            throw DecodingError.dataCorrupted(DecodingError.Context(
+                        codingPath: codingPath,
+                        debugDescription: "Attempted to add a child value without an enclosing shape"))
+        }
+    }
+}

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -17,8 +17,10 @@
 import XCTest
 @testable import SmokeHTTPClientTests
 @testable import QueryCoderTests
+@testable import ShapeCodingTests
 
 XCTMain([
+    testCase(StandardShapeParserTests.allTests),
     testCase(SmokeHTTPClientTests.allTests),
     testCase(QueryEncoderTests.allTests),
 ])

--- a/Tests/ShapeCodingTests/StandardShapeParserTests.swift
+++ b/Tests/ShapeCodingTests/StandardShapeParserTests.swift
@@ -1,0 +1,148 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// StandardShapeParserTests.swift
+// ShapeCodingTests
+//
+
+import XCTest
+@testable import ShapeCoding
+
+fileprivate let useDotDecoderOptions = StandardDecodingOptions(
+    stackKeyDecodingStrategy: .useAsShapeSeparator("."),
+    stackMapDecodingStrategy: .singleShapeEntry)
+fileprivate let flatStructureDecoderOptions = StandardDecodingOptions(
+    stackKeyDecodingStrategy: .flatStructure,
+    stackMapDecodingStrategy: .singleShapeEntry)
+
+class StandardShapeParserTests: XCTestCase {
+
+    func testEncodeBasicType() throws {
+        let input: [(String, String?)] = [("firstly", "value1"),
+                                          ("secondly", "value2"),
+                                          ("thirdly", "value3")]
+        let stackValue = try StandardShapeParser.parse(with: input,
+                                                       decoderOptions: useDotDecoderOptions)
+        
+        let expected = ShapeAttribute.dictionary([
+            "firstly": .string("value1"),
+            "secondly": .string("value2"),
+            "thirdly": .string("value3")])
+        
+        XCTAssertEqual(expected, stackValue)
+    }
+
+    func testEncodeBasicTypeWithEncoding() throws {
+        let input: [(String, String?)] = [("firstly", "value1%3D"),
+                                          ("secondly", "value2%3D"),
+                                          ("thirdly", "value3%3D")]
+        let stackValue = try StandardShapeParser.parse(with: input,
+                                                          decoderOptions: useDotDecoderOptions)
+        
+        let expected = ShapeAttribute.dictionary([
+            "firstly": .string("value1="),
+            "secondly": .string("value2="),
+            "thirdly": .string("value3=")])
+        
+        XCTAssertEqual(expected, stackValue)
+    }
+
+    func testEncodeNoValues() throws {
+        let input: [(String, String?)] = [("firstly", nil),
+                                          ("secondly", nil),
+                                          ("thirdly", nil)]
+        let stackValue = try StandardShapeParser.parse(with: input,
+                                                      decoderOptions: useDotDecoderOptions)
+    
+        let expected = ShapeAttribute.dictionary([
+            "firstly": .null,
+            "secondly": .null,
+            "thirdly": .null])
+    
+        XCTAssertEqual(expected, stackValue)
+    }
+
+    func testEncodeTypeWithMap() throws {
+        let input: [(String, String?)] = [("action", "myAction"),
+                                          ("map.id1", "value1"),
+                                          ("map.id2", "value2")]
+        let stackValue = try StandardShapeParser.parse(with: input,
+                                                      decoderOptions: useDotDecoderOptions)
+        
+        let expected = ShapeAttribute.dictionary([
+            "action": .string("myAction"),
+            "map": .dictionary(["id1": .string("value1"),
+                                "id2": .string("value2")])])
+        
+        XCTAssertEqual(expected, stackValue)
+    }
+    
+    func testEncodeTypeWithMapLikeFlatStructure() throws {
+        let input: [(String, String?)] = [("action", "myAction"),
+                                          ("map.id1", "value1"),
+                                          ("map.id2", "value2")]
+        let stackValue = try StandardShapeParser.parse(with: input,
+                                                      decoderOptions: flatStructureDecoderOptions)
+        
+        let expected = ShapeAttribute.dictionary([
+            "action": .string("myAction"),
+            "map.id1": .string("value1"),
+            "map.id2": .string("value2")])
+        
+        XCTAssertEqual(expected, stackValue)
+    }
+
+    func testEncodeTypeWithMapWithMapDecodingStrategy() throws {
+        let input: [(String, String?)] = [("action", "myAction"),
+                                          ("map.1.Name", "id1"),
+                                          ("map.1.Value", "value1"),
+                                          ("map.2.Name", "id2"),
+                                          ("map.2.Value", "value2")]
+        let stackValue = try StandardShapeParser.parse(with: input,
+                                                      decoderOptions: useDotDecoderOptions)
+        
+        let expected = ShapeAttribute.dictionary([
+            "action": .string("myAction"),
+            "map": .dictionary(["1": .dictionary(["Name": .string("id1"),
+                                                  "Value": .string("value1")]),
+                                "2": .dictionary(["Name": .string("id2"),
+                                                  "Value": .string("value2")])])])
+        
+        XCTAssertEqual(expected, stackValue)
+    }
+
+    func testEncodeTypeWithMapWithEncoding() throws {
+        let input: [(String, String?)] = [("action", "myAction"),
+                                          ("map.id1", "value1%3D"),
+                                          ("map.id2", "value2%3D")]
+        let stackValue = try StandardShapeParser.parse(with: input,
+                                                      decoderOptions: useDotDecoderOptions)
+        
+        let expected = ShapeAttribute.dictionary([
+            "action": .string("myAction"),
+            "map": .dictionary(["id1": .string("value1="),
+                                "id2": .string("value2=")])])
+        
+        XCTAssertEqual(expected, stackValue)
+    }
+
+    static var allTests = [
+        ("testEncodeBasicType", testEncodeBasicType),
+        ("testEncodeBasicTypeWithEncoding", testEncodeBasicTypeWithEncoding),
+        ("testEncodeNoValues", testEncodeNoValues),
+        ("testEncodeTypeWithMap", testEncodeTypeWithMap),
+        ("testEncodeTypeWithMapLikeFlatStructure", testEncodeTypeWithMapLikeFlatStructure),
+        ("testEncodeTypeWithMapWithMapDecodingStrategy", testEncodeTypeWithMapWithMapDecodingStrategy),
+        ("testEncodeTypeWithMapWithEncoding", testEncodeTypeWithMapWithEncoding),
+    ]
+}

--- a/Tests/ShapeCodingTests/StandardShapeParserTests.swift
+++ b/Tests/ShapeCodingTests/StandardShapeParserTests.swift
@@ -19,11 +19,11 @@ import XCTest
 @testable import ShapeCoding
 
 fileprivate let useDotDecoderOptions = StandardDecodingOptions(
-    stackKeyDecodingStrategy: .useAsShapeSeparator("."),
-    stackMapDecodingStrategy: .singleShapeEntry)
+    shapeKeyDecodingStrategy: .useAsShapeSeparator("."),
+    shapeMapDecodingStrategy: .singleShapeEntry)
 fileprivate let flatStructureDecoderOptions = StandardDecodingOptions(
-    stackKeyDecodingStrategy: .flatStructure,
-    stackMapDecodingStrategy: .singleShapeEntry)
+    shapeKeyDecodingStrategy: .flatStructure,
+    shapeMapDecodingStrategy: .singleShapeEntry)
 
 class StandardShapeParserTests: XCTestCase {
 
@@ -31,75 +31,75 @@ class StandardShapeParserTests: XCTestCase {
         let input: [(String, String?)] = [("firstly", "value1"),
                                           ("secondly", "value2"),
                                           ("thirdly", "value3")]
-        let stackValue = try StandardShapeParser.parse(with: input,
+        let shape = try StandardShapeParser.parse(with: input,
                                                        decoderOptions: useDotDecoderOptions)
         
-        let expected = ShapeAttribute.dictionary([
+        let expected = Shape.dictionary([
             "firstly": .string("value1"),
             "secondly": .string("value2"),
             "thirdly": .string("value3")])
         
-        XCTAssertEqual(expected, stackValue)
+        XCTAssertEqual(expected, shape)
     }
 
     func testEncodeBasicTypeWithEncoding() throws {
         let input: [(String, String?)] = [("firstly", "value1%3D"),
                                           ("secondly", "value2%3D"),
                                           ("thirdly", "value3%3D")]
-        let stackValue = try StandardShapeParser.parse(with: input,
+        let shape = try StandardShapeParser.parse(with: input,
                                                           decoderOptions: useDotDecoderOptions)
         
-        let expected = ShapeAttribute.dictionary([
+        let expected = Shape.dictionary([
             "firstly": .string("value1="),
             "secondly": .string("value2="),
             "thirdly": .string("value3=")])
         
-        XCTAssertEqual(expected, stackValue)
+        XCTAssertEqual(expected, shape)
     }
 
     func testEncodeNoValues() throws {
         let input: [(String, String?)] = [("firstly", nil),
                                           ("secondly", nil),
                                           ("thirdly", nil)]
-        let stackValue = try StandardShapeParser.parse(with: input,
+        let shape = try StandardShapeParser.parse(with: input,
                                                       decoderOptions: useDotDecoderOptions)
     
-        let expected = ShapeAttribute.dictionary([
+        let expected = Shape.dictionary([
             "firstly": .null,
             "secondly": .null,
             "thirdly": .null])
     
-        XCTAssertEqual(expected, stackValue)
+        XCTAssertEqual(expected, shape)
     }
 
     func testEncodeTypeWithMap() throws {
         let input: [(String, String?)] = [("action", "myAction"),
                                           ("map.id1", "value1"),
                                           ("map.id2", "value2")]
-        let stackValue = try StandardShapeParser.parse(with: input,
+        let shape = try StandardShapeParser.parse(with: input,
                                                       decoderOptions: useDotDecoderOptions)
         
-        let expected = ShapeAttribute.dictionary([
+        let expected = Shape.dictionary([
             "action": .string("myAction"),
             "map": .dictionary(["id1": .string("value1"),
                                 "id2": .string("value2")])])
         
-        XCTAssertEqual(expected, stackValue)
+        XCTAssertEqual(expected, shape)
     }
     
     func testEncodeTypeWithMapLikeFlatStructure() throws {
         let input: [(String, String?)] = [("action", "myAction"),
                                           ("map.id1", "value1"),
                                           ("map.id2", "value2")]
-        let stackValue = try StandardShapeParser.parse(with: input,
+        let shape = try StandardShapeParser.parse(with: input,
                                                       decoderOptions: flatStructureDecoderOptions)
         
-        let expected = ShapeAttribute.dictionary([
+        let expected = Shape.dictionary([
             "action": .string("myAction"),
             "map.id1": .string("value1"),
             "map.id2": .string("value2")])
         
-        XCTAssertEqual(expected, stackValue)
+        XCTAssertEqual(expected, shape)
     }
 
     func testEncodeTypeWithMapWithMapDecodingStrategy() throws {
@@ -108,32 +108,32 @@ class StandardShapeParserTests: XCTestCase {
                                           ("map.1.Value", "value1"),
                                           ("map.2.Name", "id2"),
                                           ("map.2.Value", "value2")]
-        let stackValue = try StandardShapeParser.parse(with: input,
+        let shape = try StandardShapeParser.parse(with: input,
                                                       decoderOptions: useDotDecoderOptions)
         
-        let expected = ShapeAttribute.dictionary([
+        let expected = Shape.dictionary([
             "action": .string("myAction"),
             "map": .dictionary(["1": .dictionary(["Name": .string("id1"),
                                                   "Value": .string("value1")]),
                                 "2": .dictionary(["Name": .string("id2"),
                                                   "Value": .string("value2")])])])
         
-        XCTAssertEqual(expected, stackValue)
+        XCTAssertEqual(expected, shape)
     }
 
     func testEncodeTypeWithMapWithEncoding() throws {
         let input: [(String, String?)] = [("action", "myAction"),
                                           ("map.id1", "value1%3D"),
                                           ("map.id2", "value2%3D")]
-        let stackValue = try StandardShapeParser.parse(with: input,
+        let shape = try StandardShapeParser.parse(with: input,
                                                       decoderOptions: useDotDecoderOptions)
         
-        let expected = ShapeAttribute.dictionary([
+        let expected = Shape.dictionary([
             "action": .string("myAction"),
             "map": .dictionary(["id1": .string("value1="),
                                 "id2": .string("value2=")])])
         
-        XCTAssertEqual(expected, stackValue)
+        XCTAssertEqual(expected, shape)
     }
 
     static var allTests = [


### PR DESCRIPTION
Add a generic StandardShapeParser that can be shared across different Codable decoders.

*Issue #, if available:* #1  and #6 

*Description of changes:* This provide a parser that can be used for Codable decoders for query strings, headers and path tokens.

*Testing performed:* Added unit tests to verify output. Along with other changes that I will submit for future PRs, I have verified encoders and decoders for query strings, http headers and http paths using these classes.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
