### PR TITLE
Add a generic Shape decoder

### DIFF
--- a/Sources/ShapeCoding/DateISO8601Extensions.swift
+++ b/Sources/ShapeCoding/DateISO8601Extensions.swift
@@ -1,0 +1,39 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+//  DateISO8601Extensions.swift
+//  ShapeCoding
+//
+
+import Foundation
+
+private let iso8601DateFormatter: DateFormatter = {
+     let formatter = DateFormatter()
+     formatter.calendar = Calendar(identifier: .iso8601)
+     formatter.locale = Locale(identifier: "en_US_POSIX")
+     formatter.timeZone = TimeZone(secondsFromGMT: 0)
+     formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSXXXXX"
+     return formatter
+ }()
+
+ extension Date {
+     var iso8601: String {
+         return iso8601DateFormatter.string(from: self)
+     }
+ }
+
+ extension String {
+     var dateFromISO8601: Date? {
+         return iso8601DateFormatter.date(from: self)   // "Mar 22, 2017, 10:22 AM"
+     }
+ }

--- a/Sources/ShapeCoding/DecodingErrorExtension.swift
+++ b/Sources/ShapeCoding/DecodingErrorExtension.swift
@@ -1,0 +1,45 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+//  DecodingErrorExtension.swift
+//  ShapeCoding
+//
+
+import Foundation
+
+internal extension DecodingError {
+    /// Returns a `.typeMismatch` error describing the expected type.
+    ///
+    /// - parameter path: The path of `CodingKey`s taken to decode a value of this type.
+    /// - parameter expectation: The type expected to be encountered.
+    /// - parameter reality: The value that was encountered instead of the expected type.
+    /// - returns: A `DecodingError` with the appropriate path and debug description.
+    internal static func typeMismatch(at path: [CodingKey], expectation: Any.Type, reality: Any) -> DecodingError {
+        let description = "Expected to decode \(expectation) but found \(typeDescription(of: reality)) instead."
+        return .typeMismatch(expectation, Context(codingPath: path, debugDescription: description))
+    }
+
+    /// Returns a description of the type of `value` appropriate for an error message.
+    ///
+    /// - parameter value: The value whose type to describe.
+    /// - returns: A string describing `value`.
+    internal static func typeDescription(of value: Any) -> String {
+        if value is [Any] {
+            return "an array"
+        } else if value is [AnyHashable: Any] {
+            return "a dictionary"
+        } else {
+            return "\(type(of: value))"
+        }
+    }
+}

--- a/Sources/ShapeCoding/ShapeCodingKey.swift
+++ b/Sources/ShapeCoding/ShapeCodingKey.swift
@@ -1,0 +1,45 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+//  ShapeCodingKey.swift
+//  ShapeCoding
+//
+
+import Foundation
+
+public struct ShapeCodingKey: CodingKey {
+    public var stringValue: String
+    public var intValue: Int?
+
+    public init?(stringValue: String) {
+        self.stringValue = stringValue
+        self.intValue = nil
+    }
+
+    public init?(intValue: Int) {
+        self.stringValue = "\(intValue)"
+        self.intValue = intValue
+    }
+    
+    public init(stringValue: String, intValue: Int?) {
+        self.stringValue = stringValue
+        self.intValue = intValue
+    }
+
+    public init(index: Int) {
+        self.stringValue = "\(index)"
+        self.intValue = index
+    }
+
+    static let `super` = ShapeCodingKey(stringValue: "super")!
+}

--- a/Sources/ShapeCoding/ShapeDecoder+unbox.swift
+++ b/Sources/ShapeCoding/ShapeDecoder+unbox.swift
@@ -1,0 +1,324 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+//  ShapeDecoder+unbox.swift
+//  ShapeCoding
+//
+
+import Foundation
+
+public extension ShapeDecoder {
+    
+    /// Returns the given value unboxed from a container.
+    public func unbox(_ value: Shape?, as type: Bool.Type) throws -> Bool? {
+        guard let currentValue = value else { return nil }
+        
+        guard case .string(let unboxedValue) = currentValue else {
+            return nil
+        }
+        
+        guard let convertedValue = Bool(unboxedValue) else {
+            throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: self.codingPath,
+                                                                    debugDescription: "Expected \(type) but found '\(unboxedValue)' instead."))
+        }
+        
+        return convertedValue
+    }
+    
+    public func unbox(_ value: Shape?, as type: Int.Type) throws -> Int? {
+        guard let currentValue = value else { return nil }
+        
+        guard case .string(let unboxedValue) = currentValue else {
+            return nil
+        }
+        
+        guard let convertedValue = Int(unboxedValue) else {
+            throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: self.codingPath,
+                                                                    debugDescription: "Expected \(type) but found '\(unboxedValue)' instead."))
+        }
+        
+        return convertedValue
+    }
+    
+    public func unbox(_ value: Shape?, as type: Int8.Type) throws -> Int8? {
+        guard let currentValue = value else { return nil }
+        
+        guard case .string(let unboxedValue) = currentValue else {
+            return nil
+        }
+        
+        guard let convertedValue = Int8(unboxedValue) else {
+            throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: self.codingPath,
+                                                                    debugDescription: "Expected \(type) but found '\(unboxedValue)' instead."))
+        }
+        
+        return convertedValue
+    }
+    
+    public func unbox(_ value: Shape?, as type: Int16.Type) throws -> Int16? {
+        guard let currentValue = value else { return nil }
+        
+        guard case .string(let unboxedValue) = currentValue else {
+            return nil
+        }
+        
+        guard let convertedValue = Int16(unboxedValue) else {
+            throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: self.codingPath,
+                                                                    debugDescription: "Expected \(type) but found '\(unboxedValue)' instead."))
+        }
+        
+        return convertedValue
+    }
+    
+    public func unbox(_ value: Shape?, as type: Int32.Type) throws -> Int32? {
+        guard let currentValue = value else { return nil }
+        
+        guard case .string(let unboxedValue) = currentValue else {
+            return nil
+        }
+        
+        guard let convertedValue = Int32(unboxedValue) else {
+            throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: self.codingPath,
+                                                                    debugDescription: "Expected \(type) but found '\(unboxedValue)' instead."))
+        }
+        
+        return convertedValue
+    }
+    
+    public func unbox(_ value: Shape?, as type: Int64.Type) throws -> Int64? {
+        guard let currentValue = value else { return nil }
+        
+        guard case .string(let unboxedValue) = currentValue else {
+            return nil
+        }
+        
+        guard let convertedValue = Int64(unboxedValue) else {
+            throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: self.codingPath,
+                                                                    debugDescription: "Expected \(type) but found '\(unboxedValue)' instead."))
+        }
+        
+        return convertedValue
+    }
+    
+    public func unbox(_ value: Shape?, as type: UInt.Type) throws -> UInt? {
+        guard let currentValue = value else { return nil }
+        
+        guard case .string(let unboxedValue) = currentValue else {
+            return nil
+        }
+        
+        guard let convertedValue = UInt(unboxedValue) else {
+            throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: self.codingPath,
+                                                                    debugDescription: "Expected \(type) but found '\(unboxedValue)' instead."))
+        }
+        
+        return convertedValue
+    }
+    
+    public func unbox(_ value: Shape?, as type: UInt8.Type) throws -> UInt8? {
+        guard let currentValue = value else { return nil }
+        
+        guard case .string(let unboxedValue) = currentValue else {
+            return nil
+        }
+        
+        guard let convertedValue = UInt8(unboxedValue) else {
+            throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: self.codingPath,
+                                                                    debugDescription: "Expected \(type) but found '\(unboxedValue)' instead."))
+        }
+        
+        return convertedValue
+    }
+    
+    public func unbox(_ value: Shape?, as type: UInt16.Type) throws -> UInt16? {
+        guard let currentValue = value else { return nil }
+        
+        guard case .string(let unboxedValue) = currentValue else {
+            return nil
+        }
+        
+        guard let convertedValue = UInt16(unboxedValue) else {
+            throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: self.codingPath,
+                                                                    debugDescription: "Expected \(type) but found '\(unboxedValue)' instead."))
+        }
+        
+        return convertedValue
+    }
+    
+    public func unbox(_ value: Shape?, as type: UInt32.Type) throws -> UInt32? {
+        guard let currentValue = value else { return nil }
+        
+        guard case .string(let unboxedValue) = currentValue else {
+            return nil
+        }
+        
+        guard let convertedValue = UInt32(unboxedValue) else {
+            throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: self.codingPath,
+                                                                    debugDescription: "Expected \(type) but found '\(unboxedValue)' instead."))
+        }
+        
+        return convertedValue
+    }
+    
+    public func unbox(_ value: Shape?, as type: UInt64.Type) throws -> UInt64? {
+        guard let currentValue = value else { return nil }
+        
+        guard case .string(let unboxedValue) = currentValue else {
+            return nil
+        }
+        
+        guard let convertedValue = UInt64(unboxedValue) else {
+            throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: self.codingPath,
+                                                                    debugDescription: "Expected \(type) but found '\(unboxedValue)' instead."))
+        }
+        
+        return convertedValue
+    }
+    
+    public func unbox(_ value: Shape?, as type: Float.Type) throws -> Float? {
+        guard let currentValue = value else { return nil }
+        
+        guard case .string(let unboxedValue) = currentValue else {
+            return nil
+        }
+        
+        guard let convertedValue = Float(unboxedValue) else {
+            throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: self.codingPath,
+                                                                    debugDescription: "Expected \(type) but found '\(unboxedValue)' instead."))
+        }
+        
+        return convertedValue
+    }
+    
+    public func unbox(_ value: Shape?, as type: Double.Type) throws -> Double? {
+        guard let currentValue = value else { return nil }
+        
+        guard case .string(let unboxedValue) = currentValue else {
+            return nil
+        }
+        
+        guard let convertedValue = Double(unboxedValue) else {
+            throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: self.codingPath,
+                                                                    debugDescription: "Expected \(type) but found '\(unboxedValue)' instead."))
+        }
+        
+        return convertedValue
+    }
+    
+    public func unbox(_ value: Shape?, as type: String.Type) throws -> String? {
+        guard let currentValue = value else { return nil }
+        
+        guard case .string(let unboxedValue) = currentValue else {
+            return nil
+        }
+        
+        return unboxedValue
+    }
+    
+    public func unbox(_ value: Shape?, as type: Date.Type) throws -> Date? {
+        guard let currentValue = value else {
+            return nil
+        }
+        
+        guard case .string(let unboxedValue) = currentValue else {
+            return nil
+        }
+        
+        guard let convertedValue = unboxedValue.dateFromISO8601 else {
+            throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: self.codingPath,
+                                                                    debugDescription: "Expected \(type) but found '\(unboxedValue)' instead."))
+        }
+        
+        return convertedValue
+    }
+    
+    public func unbox(_ value: Shape?, as type: Data.Type) throws -> Data? {
+        guard let currentValue = value else { return nil }
+        
+        guard case .string(let unboxedValue) = currentValue else {
+            return nil
+        }
+        
+        guard let convertedValue = Data(base64Encoded: unboxedValue) else {
+            throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: self.codingPath,
+                                                                    debugDescription: "Expected \(type) but found '\(unboxedValue)' instead."))
+        }
+        
+        return convertedValue
+    }
+    
+    public func unbox(_ value: Shape?, as type: Decimal.Type) throws -> Decimal? {
+        guard let currentValue = value else { return nil }
+        
+        guard case .string(let unboxedValue) = currentValue else {
+            return nil
+        }
+        
+        guard let convertedDoubleValue = Double(unboxedValue) else {
+            throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: self.codingPath,
+                                                                    debugDescription: "Expected \(type) but found '\(unboxedValue)' instead."))
+        }
+        
+        return Decimal(convertedDoubleValue)
+    }
+    
+    public func unbox<T: Decodable>(_ value: Shape?, as type: T.Type, isRoot: Bool = false) throws -> T? {
+        let decoded: T
+        if type == Date.self {
+            guard let date = try self.unbox(value, as: Date.self) else { return nil }
+            guard let convertedValue = date as? T else {
+                fatalError("Unable to convert '\(date)' to expected generic type '\(type)'.")
+            }
+            
+            decoded = convertedValue
+        } else if type == Data.self {
+            guard let data = try self.unbox(value, as: Data.self) else { return nil }
+            guard let convertedValue = data as? T else {
+                fatalError("Unable to convert '\(data)' to expected generic type '\(type)'.")
+            }
+            
+            decoded = convertedValue
+        } else if type == URL.self {
+            guard let urlString = try self.unbox(value, as: String.self) else {
+                return nil
+            }
+            
+            guard let url = URL(string: urlString) else {
+                throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: self.codingPath,
+                                                                        debugDescription: "Invalid URL string."))
+            }
+            
+            guard let convertedValue = url as? T else {
+                fatalError("Unable to convert '\(url)' to expected generic type '\(type)'.")
+            }
+            
+            decoded = convertedValue
+        } else if type == Decimal.self {
+            guard let decimal = try self.unbox(value, as: Decimal.self) else { return nil }
+            guard let convertedValue = decimal as? T else {
+                fatalError("Unable to convert '\(decimal)' to expected generic type '\(type)'.")
+            }
+            
+            decoded = convertedValue
+        } else {
+            let newDecoder = ShapeDecoder(decoderValue: value,
+                                          isRoot: isRoot,
+                                          at: codingPath,
+                                          userInfo: userInfo,
+                                          delegate: delegate)
+            decoded = try type.init(from: newDecoder)
+        }
+        
+        return decoded
+    }
+}

--- a/Sources/ShapeCoding/ShapeDecoder.swift
+++ b/Sources/ShapeCoding/ShapeDecoder.swift
@@ -1,0 +1,250 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+//  ShapeDecoder.swift
+//  ShapeCoding
+//
+
+import Foundation
+
+/// Internal Decoder instance used to decode Shapes into a Swift object.
+public class ShapeDecoder: Decoder {
+    public var userInfo: [CodingUserInfoKey: Any]
+    internal(set) public var codingPath: [CodingKey]
+    
+    internal var decoderValue: Shape?
+    internal let delegate: ShapeDecoderDelegate
+    internal let isRoot: Bool
+    
+    /**
+     Initializer.
+     */
+    public init(decoderValue: Shape?, isRoot: Bool, at codingPath: [CodingKey] = [],
+                  userInfo: [CodingUserInfoKey: Any],
+                  delegate: ShapeDecoderDelegate) {
+        self.decoderValue = decoderValue
+        self.codingPath = codingPath
+        self.userInfo = userInfo
+        self.delegate = delegate
+        self.isRoot = isRoot
+    }
+    
+    // MARK: - Decoder Methods
+    
+    public func container<Key>(keyedBy type: Key.Type) throws -> KeyedDecodingContainer<Key> {
+        guard let currentValue = decoderValue else {
+            let debugDescription = "Cannot get keyed decoding container -- found null value instead."
+            throw DecodingError.valueNotFound(KeyedDecodingContainer<Key>.self,
+                                              DecodingError.Context(codingPath: self.codingPath,
+                                                                    debugDescription: debugDescription))
+        }
+        
+        guard case .dictionary(let dictionary) = currentValue else {
+            throw DecodingError.typeMismatch(at: self.codingPath, expectation: [String: Any].self, reality: currentValue)
+        }
+        
+        let container = try ShapeKeyedDecodingContainer<Key>(referencing: self, wrapping: dictionary, isRoot: isRoot)
+        return KeyedDecodingContainer(container)
+    }
+    
+    public func unkeyedContainer() throws -> UnkeyedDecodingContainer {
+        guard let currentValue = decoderValue else {
+            let debugDescription = "Cannot get unkeyed decoding container -- found null value instead."
+            throw DecodingError.valueNotFound(UnkeyedDecodingContainer.self,
+                                              DecodingError.Context(codingPath: self.codingPath,
+                                                                    debugDescription: debugDescription))
+        }
+        
+        guard case .dictionary(let dictionary) = currentValue else {
+            throw DecodingError.typeMismatch(at: self.codingPath, expectation: [String: Any].self, reality: currentValue)
+        }
+                
+        return try ShapeUnkeyedDecodingContainer(referencing: self, wrapping: dictionary, isRoot: isRoot)
+    }
+    
+    public func singleValueContainer() -> SingleValueDecodingContainer {
+        return self
+    }
+}
+
+extension ShapeDecoder: SingleValueDecodingContainer {
+    // MARK: SingleValueDecodingContainer Methods
+    
+    private func expectNonNull<T>(_ type: T.Type) throws {
+        guard !self.decodeNil() else {
+            throw DecodingError.valueNotFound(type, DecodingError.Context(codingPath: self.codingPath,
+                                                                          debugDescription: "Expected \(type) but found null value instead."))
+        }
+    }
+    
+    public func decodeNil() -> Bool {
+        guard let currentValue = decoderValue else {
+            return false
+        }
+        
+        if case .null = currentValue {
+            return true
+        }
+        return false
+    }
+    
+    public func decode(_ type: Bool.Type) throws -> Bool {
+        guard let decoded = try self.unbox(decoderValue, as: Bool.self) else {
+            let context = DecodingError.Context(
+                codingPath: self.codingPath,
+                debugDescription: "Expected Bool but found nil instead.")
+            throw DecodingError.valueNotFound(type, context)
+        }
+        return decoded
+    }
+    
+    public func decode(_ type: Int.Type) throws -> Int {
+        guard let decoded = try self.unbox(decoderValue, as: Int.self) else {
+            let context = DecodingError.Context(
+                codingPath: self.codingPath,
+                debugDescription: "Expected Int but found nil instead.")
+            throw DecodingError.valueNotFound(type, context)
+        }
+        return decoded
+    }
+    
+    public func decode(_ type: Int8.Type) throws -> Int8 {
+        guard let decoded = try self.unbox(decoderValue, as: Int8.self) else {
+            let context = DecodingError.Context(
+                codingPath: self.codingPath,
+                debugDescription: "Expected Int8 but found nil instead.")
+            throw DecodingError.valueNotFound(type, context)
+        }
+        return decoded
+    }
+    
+    public func decode(_ type: Int16.Type) throws -> Int16 {
+        guard let decoded = try self.unbox(decoderValue, as: Int16.self) else {
+            let context = DecodingError.Context(
+                codingPath: self.codingPath,
+                debugDescription: "Expected Int16 but found nil instead.")
+            throw DecodingError.valueNotFound(type, context)
+        }
+        return decoded
+    }
+    
+    public func decode(_ type: Int32.Type) throws -> Int32 {
+        guard let decoded = try self.unbox(decoderValue, as: Int32.self) else {
+            let context = DecodingError.Context(
+                codingPath: self.codingPath,
+                debugDescription: "Expected Int32 but found nil instead.")
+            throw DecodingError.valueNotFound(type, context)
+        }
+        return decoded
+    }
+    
+    public func decode(_ type: Int64.Type) throws -> Int64 {
+        guard let decoded = try self.unbox(decoderValue, as: Int64.self) else {
+            let context = DecodingError.Context(
+                codingPath: self.codingPath,
+                debugDescription: "Expected Int64 but found nil instead.")
+            throw DecodingError.valueNotFound(type, context)
+        }
+        return decoded
+    }
+    
+    public func decode(_ type: UInt.Type) throws -> UInt {
+        guard let decoded = try self.unbox(decoderValue, as: UInt.self) else {
+            let context = DecodingError.Context(
+                codingPath: self.codingPath,
+                debugDescription: "Expected UInt but found nil instead.")
+            throw DecodingError.valueNotFound(type, context)
+        }
+        return decoded
+    }
+    
+    public func decode(_ type: UInt8.Type) throws -> UInt8 {
+        guard let decoded = try self.unbox(decoderValue, as: UInt8.self) else {
+            let context = DecodingError.Context(
+                codingPath: self.codingPath,
+                debugDescription: "Expected UInt8 but found nil instead.")
+            throw DecodingError.valueNotFound(type, context)
+        }
+        return decoded
+    }
+    
+    public func decode(_ type: UInt16.Type) throws -> UInt16 {
+        guard let decoded = try self.unbox(decoderValue, as: UInt16.self) else {
+            let context = DecodingError.Context(
+                codingPath: self.codingPath,
+                debugDescription: "Expected UInt16 but found nil instead.")
+            throw DecodingError.valueNotFound(type, context)
+        }
+        return decoded
+    }
+    
+    public func decode(_ type: UInt32.Type) throws -> UInt32 {
+        guard let decoded = try self.unbox(decoderValue, as: UInt32.self) else {
+            let context = DecodingError.Context(
+                codingPath: self.codingPath,
+                debugDescription: "Expected UInt32 but found nil instead.")
+            throw DecodingError.valueNotFound(type, context)
+        }
+        return decoded
+    }
+    
+    public func decode(_ type: UInt64.Type) throws -> UInt64 {
+        guard let decoded = try self.unbox(decoderValue, as: UInt64.self) else {
+            let context = DecodingError.Context(
+                codingPath: self.codingPath,
+                debugDescription: "Expected UInt64 but found nil instead.")
+            throw DecodingError.valueNotFound(type, context)
+        }
+        return decoded
+    }
+    
+    public func decode(_ type: Float.Type) throws -> Float {
+        guard let decoded = try self.unbox(decoderValue, as: Float.self) else {
+            let context = DecodingError.Context(
+                codingPath: self.codingPath,
+                debugDescription: "Expected Float but found nil instead.")
+            throw DecodingError.valueNotFound(type, context)
+        }
+        return decoded
+    }
+    
+    public func decode(_ type: Double.Type) throws -> Double {
+        guard let decoded = try self.unbox(decoderValue, as: Double.self) else {
+            let context = DecodingError.Context(
+                codingPath: self.codingPath,
+                debugDescription: "Expected Double but found nil instead.")
+            throw DecodingError.valueNotFound(type, context)
+        }
+        return decoded
+    }
+    
+    public func decode(_ type: String.Type) throws -> String {
+        guard let decoded = try self.unbox(decoderValue, as: String.self) else {
+            let context = DecodingError.Context(
+                codingPath: self.codingPath,
+                debugDescription: "Expected String but found nil instead.")
+            throw DecodingError.valueNotFound(type, context)
+        }
+        return decoded
+    }
+    
+    public func decode<T: Decodable>(_ type: T.Type) throws -> T {
+        guard let decoded = try self.unbox(decoderValue, as: type) else {
+            let context = DecodingError.Context(
+                codingPath: self.codingPath,
+                debugDescription: "Expected \(type) but found nil instead.")
+            throw DecodingError.valueNotFound(type, context)
+        }
+        return decoded
+    }
+}

--- a/Sources/ShapeCoding/ShapeDecoderDelegate.swift
+++ b/Sources/ShapeCoding/ShapeDecoderDelegate.swift
@@ -1,0 +1,42 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+//  ShapeDecoderDelegate.swift
+//  ShapeCoding
+//
+
+import Foundation
+
+public protocol ShapeDecoderDelegate {
+    
+    func getEntriesForKeyedContainer(parentContainer: [String: Shape],
+                                     containerKey: CodingKey,
+                                     isRoot: Bool,
+                                     codingPath: [CodingKey]) throws -> [String: Shape]
+    
+    func getEntriesForKeyedContainer(wrapping: [String: Shape],
+                                     isRoot: Bool,
+                                     codingPath: [CodingKey]) throws -> [String: Shape]
+    
+    func getEntriesForUnkeyedContainer(parentContainer: [String: Shape],
+                                       containerKey: CodingKey,
+                                       isRoot: Bool,
+                                       codingPath: [CodingKey]) throws -> [Shape]
+    
+    func getEntriesForUnkeyedContainer(wrapping: [String: Shape],
+                                       isRoot: Bool,
+                                       codingPath: [CodingKey]) throws -> [Shape]
+    
+    func getNestedShape(parentContainer: [String : Shape],
+                             containerKey: CodingKey) throws -> Shape?
+}

--- a/Sources/ShapeCoding/ShapeDecoderDelegate.swift
+++ b/Sources/ShapeCoding/ShapeDecoderDelegate.swift
@@ -17,26 +17,85 @@
 
 import Foundation
 
+/**
+ Delegate type to provide custom logic for a ShapeDecoder.
+ */
 public protocol ShapeDecoderDelegate {
     
+    /**
+     Extension point that can provide custom logic for providing the entries
+     for a keyed container that is being created.
+ 
+     - Parameters:
+        - parentContainer: the entries of the parent container.
+        - containerKey: the key corresponding to the container the
+                        entries are being retrieved for.
+        - isRoot: if this container represents the root of the type being decoded.
+        - codingPath: the coding path of the kayed container being created.
+     - Returns: the dictionary of entries for the keyed container being created.
+     */
     func getEntriesForKeyedContainer(parentContainer: [String: Shape],
                                      containerKey: CodingKey,
                                      isRoot: Bool,
                                      codingPath: [CodingKey]) throws -> [String: Shape]
     
+    /**
+     Extension point that can provide custom logic for providing the entries
+     for a keyed container that is being created. This overload variant is
+     called when there isn't a parent keyed container.
+ 
+     - Parameters:
+        - wrapping: the raw keyed entries of the container being created.
+        - isRoot: if this container represents the root of the type being decoded.
+        - codingPath: the coding path of the kayed container being created.
+     - Returns: the dictionary of entries for the keyed container being created.
+     */
     func getEntriesForKeyedContainer(wrapping: [String: Shape],
                                      isRoot: Bool,
                                      codingPath: [CodingKey]) throws -> [String: Shape]
     
+    /**
+     Extension point that can provide custom logic for providing the entries
+     for an unkeyed container that is being created.
+ 
+     - Parameters:
+        - parentContainer: the entries of the parent container.
+        - containerKey: the key corresponding to the container the
+                        entries are being retrieved for.
+        - isRoot: if this container represents the root of the type being decoded.
+        - codingPath: the coding path of the kayed container being created.
+     - Returns: the array of entries for the keyed container being created.
+     */
     func getEntriesForUnkeyedContainer(parentContainer: [String: Shape],
                                        containerKey: CodingKey,
                                        isRoot: Bool,
                                        codingPath: [CodingKey]) throws -> [Shape]
     
+    /**
+     Extension point that can provide custom logic for providing the entries
+     for an unkeyed container that is being created. This overload variant is
+     called when there isn't a parent keyed container.
+ 
+     - Parameters:
+        - wrapping: the raw keyed entries of the container being created.
+        - isRoot: if this container represents the root of the type being decoded.
+        - codingPath: the coding path of the kayed container being created.
+     - Returns: the dictionary of entries for the keyed container being created.
+     */
     func getEntriesForUnkeyedContainer(wrapping: [String: Shape],
                                        isRoot: Bool,
                                        codingPath: [CodingKey]) throws -> [Shape]
     
+    /**
+     Extension point that retrieves the Shape instance from a dictionary
+     of container entries for the specified key.
+     
+     - Parameters:
+        - parentContainer: the entries of the parent container.
+        - containerKey: the key corresponding to the entry the
+                        Shape is being retrieved for.
+     - Returns: Shape for the specified key or nil if there is no such Shape.
+     */
     func getNestedShape(parentContainer: [String : Shape],
-                             containerKey: CodingKey) throws -> Shape?
+                        containerKey: CodingKey) throws -> Shape?
 }

--- a/Sources/ShapeCoding/ShapeKeyedDecodingContainer+KeyedDecodingContainerProtocol.swift
+++ b/Sources/ShapeCoding/ShapeKeyedDecodingContainer+KeyedDecodingContainerProtocol.swift
@@ -1,0 +1,356 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+//  ShapeKeyedDecodingContainer+KeyedDecodingContainerProtocol.swift
+//  ShapeCoding
+//
+
+import Foundation
+
+// MARK: Decoding Containers
+extension ShapeKeyedDecodingContainer: KeyedDecodingContainerProtocol {
+    
+    // MARK: - KeyedDecodingContainerProtocol Methods
+    
+    public var allKeys: [Key] {
+        return container.keys.compactMap { Key(stringValue: $0) }
+    }
+    
+    public func contains(_ key: Key) -> Bool {
+        let nestedEntry = try? decoder.delegate.getNestedShape(
+                parentContainer: container,
+                containerKey: key)
+        return nestedEntry != nil
+    }
+    
+    public func decodeNil(forKey key: Key) throws -> Bool {
+        let nestedEntry = try decoder.delegate.getNestedShape(
+                parentContainer: container,
+                containerKey: key)
+        if let entry = nestedEntry {
+            if case .null = entry {
+                return true
+            }
+            
+            return false
+        } else {
+            return true
+        }
+    }
+    
+    internal func decodeIfPresentIntoType<ValueType: Decodable>(
+        _ type: ValueType.Type, forKey key: Key,
+        decodeFunction: (_ value: Shape?, _ decoder: ShapeDecoder) throws -> ValueType?) throws
+        -> ValueType? {
+            let nestedEntry = try decoder.delegate.getNestedShape(
+                parentContainer: container,
+                containerKey: key)
+            guard let entry = nestedEntry else {
+                return nil
+            }
+            
+            self.decoder.codingPath.append(key)
+            defer { self.decoder.codingPath.removeLast() }
+            
+            return try decodeFunction(entry, self.decoder)
+    }
+    
+    internal func decodeIntoType<ValueType: Decodable>(
+        _ type: ValueType.Type, forKey key: Key,
+        decodeFunction: (_ value: Shape?, _ decoder: ShapeDecoder) throws -> ValueType?) throws
+        -> ValueType {
+            let nestedEntry = try decoder.delegate.getNestedShape(
+                parentContainer: container,
+                containerKey: key)
+            guard let entry = nestedEntry else {
+                let decodingContext = DecodingError.Context(codingPath: self.decoder.codingPath,
+                                                            debugDescription: "No value associated with key \(key) (\"\(key.stringValue)\").")
+                throw DecodingError.keyNotFound(key, decodingContext)
+            }
+            
+            self.decoder.codingPath.append(key)
+            defer { self.decoder.codingPath.removeLast() }
+            
+            guard let value = try decodeFunction(entry, self.decoder) else {
+                let decodingContext = DecodingError.Context(codingPath: self.decoder.codingPath,
+                                                            debugDescription: "Expected \(type) value but found nil instead.")
+                throw DecodingError.valueNotFound(type, decodingContext)
+            }
+            
+            return value
+    }
+    
+    public func decodeIfPresent(_ type: Bool.Type, forKey key: Key) throws -> Bool? {
+        return try decodeIfPresentIntoType(type, forKey: key) { (value, decoder) in
+            return try decoder.unbox(value, as: Bool.self)
+        }
+    }
+    
+    public func decode(_ type: Bool.Type, forKey key: Key) throws -> Bool {
+        return try decodeIntoType(type, forKey: key) { (value, decoder) in
+            return try decoder.unbox(value, as: Bool.self)
+        }
+    }
+    
+    public func decodeIfPresent(_ type: Int.Type, forKey key: Key) throws -> Int? {
+        return try decodeIfPresentIntoType(type, forKey: key) { (value, decoder) in
+            return try decoder.unbox(value, as: Int.self)
+        }
+    }
+    
+    public func decode(_ type: Int.Type, forKey key: Key) throws -> Int {
+        return try decodeIntoType(type, forKey: key) { (value, decoder) in
+            return try decoder.unbox(value, as: Int.self)
+        }
+    }
+    
+    public func decodeIfPresent(_ type: Int8.Type, forKey key: Key) throws -> Int8? {
+        return try decodeIfPresentIntoType(type, forKey: key) { (value, decoder) in
+            return try decoder.unbox(value, as: Int8.self)
+        }
+    }
+    
+    public func decode(_ type: Int8.Type, forKey key: Key) throws -> Int8 {
+        return try decodeIntoType(type, forKey: key) { (value, decoder) in
+            return try decoder.unbox(value, as: Int8.self)
+        }
+    }
+    
+    public func decodeIfPresent(_ type: Int16.Type, forKey key: Key) throws -> Int16? {
+        return try decodeIfPresentIntoType(type, forKey: key) { (value, decoder) in
+            return try decoder.unbox(value, as: Int16.self)
+        }
+    }
+    
+    public func decode(_ type: Int16.Type, forKey key: Key) throws -> Int16 {
+        return try decodeIntoType(type, forKey: key) { (value, decoder) in
+            return try decoder.unbox(value, as: Int16.self)
+        }
+    }
+    
+    public func decodeIfPresent(_ type: Int32.Type, forKey key: Key) throws -> Int32? {
+        return try decodeIfPresentIntoType(type, forKey: key) { (value, decoder) in
+            return try decoder.unbox(value, as: Int32.self)
+        }
+    }
+    
+    public func decode(_ type: Int32.Type, forKey key: Key) throws -> Int32 {
+        return try decodeIntoType(type, forKey: key) { (value, decoder) in
+            return try decoder.unbox(value, as: Int32.self)
+        }
+    }
+    
+    public func decodeIfPresent(_ type: Int64.Type, forKey key: Key) throws -> Int64? {
+        return try decodeIfPresentIntoType(type, forKey: key) { (value, decoder) in
+            return try decoder.unbox(value, as: Int64.self)
+        }
+    }
+    
+    public func decode(_ type: Int64.Type, forKey key: Key) throws -> Int64 {
+        return try decodeIntoType(type, forKey: key) { (value, decoder) in
+            return try decoder.unbox(value, as: Int64.self)
+        }
+    }
+    
+    public func decodeIfPresent(_ type: UInt.Type, forKey key: Key) throws -> UInt? {
+        return try decodeIfPresentIntoType(type, forKey: key) { (value, decoder) in
+            return try decoder.unbox(value, as: UInt.self)
+        }
+    }
+    
+    public func decode(_ type: UInt.Type, forKey key: Key) throws -> UInt {
+        return try decodeIntoType(type, forKey: key) { (value, decoder) in
+            return try decoder.unbox(value, as: UInt.self)
+        }
+    }
+    
+    public func decodeIfPresent(_ type: UInt8.Type, forKey key: Key) throws -> UInt8? {
+        return try decodeIfPresentIntoType(type, forKey: key) { (value, decoder) in
+            return try decoder.unbox(value, as: UInt8.self)
+        }
+    }
+    
+    public func decode(_ type: UInt8.Type, forKey key: Key) throws -> UInt8 {
+        return try decodeIntoType(type, forKey: key) { (value, decoder) in
+            return try decoder.unbox(value, as: UInt8.self)
+        }
+    }
+    
+    public func decodeIfPresent(_ type: UInt16.Type, forKey key: Key) throws -> UInt16? {
+        return try decodeIfPresentIntoType(type, forKey: key) { (value, decoder) in
+            return try decoder.unbox(value, as: UInt16.self)
+        }
+    }
+    
+    public func decode(_ type: UInt16.Type, forKey key: Key) throws -> UInt16 {
+        return try decodeIntoType(type, forKey: key) { (value, decoder) in
+            return try decoder.unbox(value, as: UInt16.self)
+        }
+    }
+    
+    public func decodeIfPresent(_ type: UInt32.Type, forKey key: Key) throws -> UInt32? {
+        return try decodeIfPresentIntoType(type, forKey: key) { (value, decoder) in
+            return try decoder.unbox(value, as: UInt32.self)
+        }
+    }
+    
+    public func decode(_ type: UInt32.Type, forKey key: Key) throws -> UInt32 {
+        return try decodeIntoType(type, forKey: key) { (value, decoder) in
+            return try decoder.unbox(value, as: UInt32.self)
+        }
+    }
+    
+    public func decodeIfPresent(_ type: UInt64.Type, forKey key: Key) throws -> UInt64? {
+        return try decodeIfPresentIntoType(type, forKey: key) { (value, decoder) in
+            return try decoder.unbox(value, as: UInt64.self)
+        }
+    }
+    
+    public func decode(_ type: UInt64.Type, forKey key: Key) throws -> UInt64 {
+        return try decodeIntoType(type, forKey: key) { (value, decoder) in
+            return try decoder.unbox(value, as: UInt64.self)
+        }
+    }
+    
+    public func decodeIfPresent(_ type: Float.Type, forKey key: Key) throws -> Float? {
+        return try decodeIfPresentIntoType(type, forKey: key) { (value, decoder) in
+            return try decoder.unbox(value, as: Float.self)
+        }
+    }
+    
+    public func decode(_ type: Float.Type, forKey key: Key) throws -> Float {
+        return try decodeIntoType(type, forKey: key) { (value, decoder) in
+            return try decoder.unbox(value, as: Float.self)
+        }
+    }
+    
+    public func decodeIfPresent(_ type: Double.Type, forKey key: Key) throws -> Double? {
+        return try decodeIfPresentIntoType(type, forKey: key) { (value, decoder) in
+            return try decoder.unbox(value, as: Double.self)
+        }
+    }
+    
+    public func decode(_ type: Double.Type, forKey key: Key) throws -> Double {
+        return try decodeIntoType(type, forKey: key) { (value, decoder) in
+            return try decoder.unbox(value, as: Double.self)
+        }
+    }
+    
+    public func decodeIfPresent(_ type: String.Type, forKey key: Key) throws -> String? {
+        return try decodeIfPresentIntoType(type, forKey: key) { (value, decoder) in
+            return try decoder.unbox(value, as: String.self)
+        }
+    }
+    
+    public func decode(_ type: String.Type, forKey key: Key) throws -> String {
+        let nestedEntry = try decoder.delegate.getNestedShape(
+                parentContainer: container,
+                containerKey: key)
+        guard let entry = nestedEntry else {
+            let decodingContext = DecodingError.Context(codingPath: self.decoder.codingPath,
+                                                        debugDescription: "No value associated with key \(key) (\"\(key.stringValue)\").")
+            throw DecodingError.keyNotFound(key, decodingContext)
+        }
+        
+        self.decoder.codingPath.append(key)
+        defer { self.decoder.codingPath.removeLast() }
+        
+        guard let value = try self.decoder.unbox(entry, as: String.self) else {
+            // treat a missing but required string as an empty string
+            return ""
+        }
+        
+        return value
+    }
+    
+    public func decodeIfPresent<T: Decodable>(_ type: T.Type, forKey key: Key) throws -> T? {
+        return try decodeIfPresentIntoType(type, forKey: key) { (value, decoder) in
+            return try decoder.unbox(value, as: type)
+        }
+    }
+    
+    public func decode<T: Decodable>(_ type: T.Type, forKey key: Key) throws -> T {
+        let nestedEntry = try decoder.delegate.getNestedShape(
+                parentContainer: container,
+                containerKey: key)
+        guard let entry = nestedEntry else {
+            let debugDescription = "No value associated with key \(key) (\"\(key.stringValue)\")."
+            let decodingContext = DecodingError.Context(codingPath: self.decoder.codingPath,
+                                                        debugDescription: debugDescription)
+            throw DecodingError.keyNotFound(key, decodingContext)
+        }
+        
+        self.decoder.codingPath.append(key)
+        defer { self.decoder.codingPath.removeLast() }
+        
+        guard let value = try self.decoder.unbox(entry, as: type) else {
+            if type == Data.self {
+                // treat a missing but required Data as an empty Data
+                guard let convertedValue = Data() as? T else {
+                    fatalError("Unable to convert empty data to expected generic type '\(type)'.")
+                }
+                
+                return convertedValue
+            }
+            
+            let decodingContext = DecodingError.Context(codingPath: self.decoder.codingPath,
+                                                        debugDescription: "Expected \(type) value but found nil instead.")
+            throw DecodingError.valueNotFound(type, decodingContext)
+        }
+        
+        return value
+    }
+    
+    public func nestedContainer<NestedKey>(keyedBy type: NestedKey.Type, forKey key: Key) throws -> KeyedDecodingContainer<NestedKey> {
+        self.decoder.codingPath.append(key)
+        defer { self.decoder.codingPath.removeLast() }
+        
+        let container = try ShapeKeyedDecodingContainer<NestedKey>(
+            referencing: self.decoder,
+            containerKey: key,
+            parentContainer: self.container,
+            isRoot: false)
+        return KeyedDecodingContainer(container)
+    }
+    
+    public func nestedUnkeyedContainer(forKey key: Key) throws -> UnkeyedDecodingContainer {
+        self.decoder.codingPath.append(key)
+        defer { self.decoder.codingPath.removeLast() }
+        
+        return try ShapeUnkeyedDecodingContainer(
+            referencing: self.decoder,
+            containerKey: key,
+            parentContainer: self.container,
+            isRoot: false)
+    }
+    
+    private func _superDecoder(forKey key: CodingKey) throws -> Decoder {
+        self.decoder.codingPath.append(key)
+        defer { self.decoder.codingPath.removeLast() }
+        
+        let nestedEntry = try decoder.delegate.getNestedShape(
+                parentContainer: container,
+                containerKey: key)
+        return ShapeDecoder(decoderValue: nestedEntry, isRoot: false, at: self.decoder.codingPath,
+                           userInfo: self.decoder.userInfo,
+                           delegate: self.decoder.delegate)
+    }
+    
+    public func superDecoder() throws -> Decoder {
+        return try _superDecoder(forKey: ShapeCodingKey.super)
+    }
+    
+    public func superDecoder(forKey key: Key) throws -> Decoder {
+        return try _superDecoder(forKey: key)
+    }
+}

--- a/Sources/ShapeCoding/ShapeKeyedDecodingContainer.swift
+++ b/Sources/ShapeCoding/ShapeKeyedDecodingContainer.swift
@@ -1,0 +1,54 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+//  ShapeKeyedDecodingContainer.swift
+//  ShapeCoding
+//
+
+import Foundation
+
+// MARK: Decoding Containers
+internal struct ShapeKeyedDecodingContainer<K: CodingKey> {
+    typealias Key = K
+    
+    let decoder: ShapeDecoder
+    let container: [String: Shape]
+    private(set) public var codingPath: [CodingKey]
+    
+    // MARK: - Initialization
+    
+    /// Initializes `self` by referencing the given decoder and container.
+    internal init(referencing decoder: ShapeDecoder,
+                  wrapping container: [String: Shape],
+                  isRoot: Bool) throws {
+        self.decoder = decoder
+        self.codingPath = decoder.codingPath
+        self.container = try decoder.delegate.getEntriesForKeyedContainer(
+                wrapping: container,
+                isRoot: isRoot,
+                codingPath: decoder.codingPath)
+    }
+    
+    internal init(referencing decoder: ShapeDecoder,
+                  containerKey: CodingKey,
+                  parentContainer: [String: Shape],
+                  isRoot: Bool) throws {
+        self.decoder = decoder
+        self.codingPath = decoder.codingPath
+        self.container = try decoder.delegate.getEntriesForKeyedContainer(
+                parentContainer: parentContainer,
+                containerKey: containerKey,
+                isRoot: isRoot,
+                codingPath: decoder.codingPath)
+    }
+}

--- a/Sources/ShapeCoding/ShapeUnkeyedDecodingContainer.swift
+++ b/Sources/ShapeCoding/ShapeUnkeyedDecodingContainer.swift
@@ -1,0 +1,259 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+//  ShapeUnkeyedDecodingContainer.swift
+//  ShapeCoding
+//
+
+import Foundation
+
+internal struct ShapeUnkeyedDecodingContainer: UnkeyedDecodingContainer {
+    // MARK: Properties
+    
+    /// A reference to the decoder we're reading from.
+    private let decoder: ShapeDecoder
+    
+    /// A reference to the container we're reading from.
+    private let container: [Shape]
+    
+    /// The path of coding keys taken to get to this point in decoding.
+    private(set) public var codingPath: [CodingKey]
+    
+    /// The index of the element we're about to decode.
+    private(set) public var currentIndex: Int
+    
+    // MARK: - Initialization
+    
+    /// Initializes `self` by referencing the given decoder and container.
+    internal init(referencing decoder: ShapeDecoder, wrapping container: [String: Shape],
+                  isRoot: Bool) throws {
+        self.decoder = decoder
+        self.codingPath = decoder.codingPath
+        self.currentIndex = 0
+        self.container = try decoder.delegate.getEntriesForUnkeyedContainer(
+            wrapping: container,
+            isRoot: isRoot,
+            codingPath: decoder.codingPath)
+    }
+    
+    internal init(referencing decoder: ShapeDecoder,
+                  containerKey: CodingKey,
+                  parentContainer: [String: Shape],
+                  isRoot: Bool) throws {
+        self.decoder = decoder
+        self.codingPath = decoder.codingPath
+        self.currentIndex = 0
+        self.container = try decoder.delegate.getEntriesForUnkeyedContainer(
+            parentContainer: parentContainer,
+            containerKey: containerKey,
+            isRoot: isRoot,
+            codingPath: decoder.codingPath)
+    }
+    
+    // MARK: - UnkeyedDecodingContainer Methods
+    
+    public var count: Int? {
+        return self.container.count
+    }
+    
+    public var isAtEnd: Bool {
+        return self.currentIndex >= self.count!
+    }
+    
+    public mutating func decodeNil() throws -> Bool {
+        guard !self.isAtEnd else {
+            let decodingContext = DecodingError.Context(codingPath: self.decoder.codingPath + [ShapeCodingKey(index: self.currentIndex)],
+                                                        debugDescription: "Unkeyed container is at end.")
+            throw DecodingError.valueNotFound(Any?.self, decodingContext)
+        }
+        
+        if case .null = self.container[self.currentIndex] {
+            self.currentIndex += 1
+            return true
+        } else {
+            return false
+        }
+    }
+    
+    internal mutating func decodeIntoType<ValueType: Decodable>(
+        _ type: ValueType.Type,
+        decodeFunction: (_ value: Shape?, _ decoder: ShapeDecoder) throws -> ValueType?) throws
+        -> ValueType {
+            guard !self.isAtEnd else {
+                let decodingContext = DecodingError.Context(codingPath: self.decoder.codingPath + [ShapeCodingKey(index: self.currentIndex)],
+                                                            debugDescription: "Unkeyed container is at end.")
+                throw DecodingError.valueNotFound(type, decodingContext)
+            }
+            
+            self.decoder.codingPath.append(ShapeCodingKey(index: self.currentIndex))
+            defer { self.decoder.codingPath.removeLast() }
+            
+            guard let decoded = try decodeFunction(self.container[self.currentIndex], self.decoder) else {
+                let decodingContext = DecodingError.Context(codingPath: self.decoder.codingPath + [ShapeCodingKey(index: self.currentIndex)],
+                                                            debugDescription: "Expected \(type) but found nil instead.")
+                throw DecodingError.valueNotFound(type, decodingContext)
+            }
+            
+            self.currentIndex += 1
+            return decoded
+    }
+    
+    public mutating func decode(_ type: Bool.Type) throws -> Bool {
+        return try decodeIntoType(type) { (value, decoder) in
+            return try decoder.unbox(value, as: Bool.self)
+        }
+    }
+    
+    public mutating func decode(_ type: Int.Type) throws -> Int {
+        return try decodeIntoType(type) { (value, decoder) in
+            return try decoder.unbox(value, as: Int.self)
+        }
+    }
+    
+    public mutating func decode(_ type: Int8.Type) throws -> Int8 {
+        return try decodeIntoType(type) { (value, decoder) in
+            return try decoder.unbox(value, as: Int8.self)
+        }
+    }
+    
+    public mutating func decode(_ type: Int16.Type) throws -> Int16 {
+        return try decodeIntoType(type) { (value, decoder) in
+            return try decoder.unbox(value, as: Int16.self)
+        }
+    }
+    
+    public mutating func decode(_ type: Int32.Type) throws -> Int32 {
+        return try decodeIntoType(type) { (value, decoder) in
+            return try decoder.unbox(value, as: Int32.self)
+        }
+    }
+    
+    public mutating func decode(_ type: Int64.Type) throws -> Int64 {
+        return try decodeIntoType(type) { (value, decoder) in
+            return try decoder.unbox(value, as: Int64.self)
+        }
+    }
+    
+    public mutating func decode(_ type: UInt.Type) throws -> UInt {
+        return try decodeIntoType(type) { (value, decoder) in
+            return try decoder.unbox(value, as: UInt.self)
+        }
+    }
+    
+    public mutating func decode(_ type: UInt8.Type) throws -> UInt8 {
+        return try decodeIntoType(type) { (value, decoder) in
+            return try decoder.unbox(value, as: UInt8.self)
+        }
+    }
+    
+    public mutating func decode(_ type: UInt16.Type) throws -> UInt16 {
+        return try decodeIntoType(type) { (value, decoder) in
+            return try decoder.unbox(value, as: UInt16.self)
+        }
+    }
+    
+    public mutating func decode(_ type: UInt32.Type) throws -> UInt32 {
+        return try decodeIntoType(type) { (value, decoder) in
+            return try decoder.unbox(value, as: UInt32.self)
+        }
+    }
+    
+    public mutating func decode(_ type: UInt64.Type) throws -> UInt64 {
+        return try decodeIntoType(type) { (value, decoder) in
+            return try decoder.unbox(value, as: UInt64.self)
+        }
+    }
+    
+    public mutating func decode(_ type: Float.Type) throws -> Float {
+        return try decodeIntoType(type) { (value, decoder) in
+            return try decoder.unbox(value, as: Float.self)
+        }
+    }
+    
+    public mutating func decode(_ type: Double.Type) throws -> Double {
+        return try decodeIntoType(type) { (value, decoder) in
+            return try decoder.unbox(value, as: Double.self)
+        }
+    }
+    
+    public mutating func decode(_ type: String.Type) throws -> String {
+        return try decodeIntoType(type) { (value, decoder) in
+            return try decoder.unbox(value, as: String.self)
+        }
+    }
+    
+    public mutating func decode<T: Decodable>(_ type: T.Type) throws -> T {
+        return try decodeIntoType(type) { (value, decoder) in
+            return try decoder.unbox(value, as: type)
+        }
+    }
+    
+    public mutating func nestedContainer<NestedKey>(keyedBy type: NestedKey.Type) throws -> KeyedDecodingContainer<NestedKey> {
+        self.decoder.codingPath.append(ShapeCodingKey(index: self.currentIndex))
+        defer { self.decoder.codingPath.removeLast() }
+        
+        guard !self.isAtEnd else {
+            let debugDescription = "Cannot get nested keyed container -- unkeyed container is at end."
+            throw DecodingError.valueNotFound(KeyedDecodingContainer<NestedKey>.self,
+                                              DecodingError.Context(codingPath: self.codingPath,
+                                                                    debugDescription: debugDescription))
+        }
+        
+        let value = self.container[self.currentIndex]
+        guard case .dictionary(let dictionary) = value else {
+            throw DecodingError.typeMismatch(at: self.codingPath, expectation: [String: Any].self, reality: value)
+        }
+        
+        self.currentIndex += 1
+        let container = try ShapeKeyedDecodingContainer<NestedKey>(referencing: self.decoder,
+                                                                   wrapping: dictionary, isRoot: false)
+        return KeyedDecodingContainer(container)
+    }
+    
+    public mutating func nestedUnkeyedContainer() throws -> UnkeyedDecodingContainer {
+        self.decoder.codingPath.append(ShapeCodingKey(index: self.currentIndex))
+        defer { self.decoder.codingPath.removeLast() }
+        
+        guard !self.isAtEnd else {
+            let debugDescription = "Cannot get nested keyed container -- unkeyed container is at end."
+            throw DecodingError.valueNotFound(UnkeyedDecodingContainer.self,
+                                              DecodingError.Context(codingPath: self.codingPath,
+                                                                    debugDescription: debugDescription))
+        }
+        
+        let value = self.container[self.currentIndex]
+        guard case .dictionary(let dictionary) = value else {
+            throw DecodingError.typeMismatch(at: self.codingPath, expectation: [String: Any].self, reality: value)
+        }
+        
+        self.currentIndex += 1
+        return try ShapeUnkeyedDecodingContainer(referencing: self.decoder, wrapping: dictionary, isRoot: false)
+    }
+    
+    public mutating func superDecoder() throws -> Decoder {
+        self.decoder.codingPath.append(ShapeCodingKey(index: self.currentIndex))
+        defer { self.decoder.codingPath.removeLast() }
+        
+        guard !self.isAtEnd else {
+            throw DecodingError.valueNotFound(Decoder.self,
+                                              DecodingError.Context(codingPath: self.codingPath,
+                                                                    debugDescription: "Cannot get superDecoder() -- unkeyed container is at end."))
+        }
+        
+        let value = self.container[self.currentIndex]
+        self.currentIndex += 1
+        return ShapeDecoder(decoderValue: value, isRoot: false, at: self.decoder.codingPath,
+                           userInfo: self.decoder.userInfo,
+                           delegate: self.decoder.delegate)
+    }
+}


### PR DESCRIPTION
*Issue #, if available:* #6 and #1 

*Description of changes:* Add a Shape Decoder in the ShapeCoding package that provides a generic decoder that can be shared across different Codable decoders for query strings, headers and path tokens.

*Testing performed:* Along with other changes that I will submit for future PRs, I have verified encoders and decoders for query strings, http headers and http paths using these classes. These will have further unit tests.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
