### PR TITLE
Add a generic Shape encoder

### DIFF
--- a/Sources/ShapeCoding/ShapeDecoder.swift
+++ b/Sources/ShapeCoding/ShapeDecoder.swift
@@ -30,8 +30,8 @@ public class ShapeDecoder: Decoder {
      Initializer.
      */
     public init(decoderValue: Shape?, isRoot: Bool, at codingPath: [CodingKey] = [],
-                  userInfo: [CodingUserInfoKey: Any],
-                  delegate: ShapeDecoderDelegate) {
+                userInfo: [CodingUserInfoKey: Any],
+                delegate: ShapeDecoderDelegate) {
         self.decoderValue = decoderValue
         self.codingPath = codingPath
         self.userInfo = userInfo

--- a/Sources/ShapeCoding/ShapeDecoderDelegate.swift
+++ b/Sources/ShapeCoding/ShapeDecoderDelegate.swift
@@ -96,6 +96,6 @@ public protocol ShapeDecoderDelegate {
                         Shape is being retrieved for.
      - Returns: Shape for the specified key or nil if there is no such Shape.
      */
-    func getNestedShape(parentContainer: [String : Shape],
+    func getNestedShape(parentContainer: [String: Shape],
                         containerKey: CodingKey) throws -> Shape?
 }

--- a/Sources/ShapeCoding/ShapeElement.swift
+++ b/Sources/ShapeCoding/ShapeElement.swift
@@ -17,16 +17,31 @@
 
 import Foundation
 
+/**
+ Errors that can be thrown when encoding a shape.
+ */
 public enum ShapeEncoderError: Error {
     case typeNotShapeCompatible(String)
 }
 
+/**
+ Protocol that elements of a shape must conform to.
+ */
 public protocol ShapeElement {
-    func getShapeElements(_ key: String?, isRoot: Bool, elements: inout [(String, String?)]) throws
+    /**
+     Function that gathers the serialized elements that are either this element or contained within this element.
+ 
+     - Parameters:
+         - key: the key for this element if any.
+         - isRoot: if this element is the root of the type being encoded.
+         - elements: the array to append elements from this element to.
+     */
+    func getSerializedElements(_ key: String?, isRoot: Bool, elements: inout [(String, String?)]) throws
 }
 
+/// Conform String to the `ShapeElement` protocol such that it returns itself as
 extension String: ShapeElement {
-    public func getShapeElements(_ key: String?, isRoot: Bool, elements: inout [(String, String?)]) throws {
+    public func getSerializedElements(_ key: String?, isRoot: Bool, elements: inout [(String, String?)]) throws {
         if let key = key {
             elements.append((key, self))
         } else {
@@ -35,8 +50,14 @@ extension String: ShapeElement {
     }
 }
 
+/**
+ Enumeration of possible values of a container.
+ */
 public enum ContainerValueType {
+    /// A single value that conforms to the `ShapeElement` protocol
     case singleValue(ShapeElement)
+    /// an unkeyed container that has a list of values that conform to the `ShapeElement` protocol
     case unkeyedContainer([ShapeElement])
+    /// a keyed container that has a dictionary of values that conform to the `ShapeElement` protocol
     case keyedContainer([String: ShapeElement])
 }

--- a/Sources/ShapeCoding/ShapeElement.swift
+++ b/Sources/ShapeCoding/ShapeElement.swift
@@ -1,0 +1,42 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+//  ShapeElement.swift
+//  ShapeCoding
+//
+
+import Foundation
+
+public enum ShapeEncoderError: Error {
+    case typeNotShapeCompatible(String)
+}
+
+public protocol ShapeElement {
+    func getShapeElements(_ key: String?, isRoot: Bool, elements: inout [(String, String?)]) throws
+}
+
+extension String: ShapeElement {
+    public func getShapeElements(_ key: String?, isRoot: Bool, elements: inout [(String, String?)]) throws {
+        if let key = key {
+            elements.append((key, self))
+        } else {
+            throw ShapeEncoderError.typeNotShapeCompatible("String cannot be used as a shape element without a key")
+        }
+    }
+}
+
+public enum ContainerValueType {
+    case singleValue(ShapeElement)
+    case unkeyedContainer([ShapeElement])
+    case keyedContainer([String: ShapeElement])
+}

--- a/Sources/ShapeCoding/ShapeKeyedEncodingContainer.swift
+++ b/Sources/ShapeCoding/ShapeKeyedEncodingContainer.swift
@@ -1,0 +1,144 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+//  ShapeKeyedEncodingContainer.swift
+//  ShapeCoding
+//
+
+import Foundation
+
+internal struct ShapeKeyedEncodingContainer<K: CodingKey> : KeyedEncodingContainerProtocol {
+    typealias Key = K
+
+    private let enclosingContainer: ShapeSingleValueEncodingContainer
+
+    init(enclosingContainer: ShapeSingleValueEncodingContainer) {
+        self.enclosingContainer = enclosingContainer
+    }
+
+    // MARK: - Swift.KeyedEncodingContainerProtocol Methods
+
+    var codingPath: [CodingKey] {
+        return enclosingContainer.codingPath
+    }
+
+    func encodeNil(forKey key: Key) throws {
+        enclosingContainer.addToKeyedContainer(key: key, value: "")
+    }
+
+    func encode(_ value: Bool, forKey key: Key) throws {
+        enclosingContainer.addToKeyedContainer(key: key, value: value ? "true" : "false")
+    }
+
+    func encode(_ value: Int, forKey key: Key) throws {
+        enclosingContainer.addToKeyedContainer(key: key, value: String(value))
+    }
+
+    func encode(_ value: Int8, forKey key: Key) throws {
+        enclosingContainer.addToKeyedContainer(key: key, value: String(value))
+    }
+
+    func encode(_ value: Int16, forKey key: Key) throws {
+        enclosingContainer.addToKeyedContainer(key: key, value: String(value))
+    }
+
+    func encode(_ value: Int32, forKey key: Key) throws {
+        enclosingContainer.addToKeyedContainer(key: key, value: String(value))
+    }
+
+    func encode(_ value: Int64, forKey key: Key) throws {
+        enclosingContainer.addToKeyedContainer(key: key, value: String(value))
+    }
+
+    func encode(_ value: UInt, forKey key: Key) throws {
+        enclosingContainer.addToKeyedContainer(key: key, value: String(value))
+    }
+
+    func encode(_ value: UInt8, forKey key: Key) throws {
+        enclosingContainer.addToKeyedContainer(key: key, value: String(value))
+    }
+
+    func encode(_ value: UInt16, forKey key: Key) throws {
+        enclosingContainer.addToKeyedContainer(key: key, value: String(value))
+    }
+
+    func encode(_ value: UInt32, forKey key: Key) throws {
+        enclosingContainer.addToKeyedContainer(key: key, value: String(value))
+    }
+
+    func encode(_ value: UInt64, forKey key: Key) throws {
+        enclosingContainer.addToKeyedContainer(key: key, value: String(value))
+    }
+
+    func encode(_ value: Float, forKey key: Key) throws {
+        enclosingContainer.addToKeyedContainer(key: key, value: String(value))
+    }
+
+    func encode(_ value: Double, forKey key: Key) throws {
+        enclosingContainer.addToKeyedContainer(key: key, value: String(value))
+    }
+
+    func encode(_ value: String, forKey key: Key) throws {
+        let encodedValue: String
+        if let allowedCharacterSet = enclosingContainer.allowedCharacterSet,
+            let percentEncoded = value.addingPercentEncoding(withAllowedCharacters: allowedCharacterSet) {
+                encodedValue = percentEncoded
+        } else {
+            encodedValue = value
+        }
+
+        enclosingContainer.addToKeyedContainer(key: key, value: encodedValue)
+    }
+
+    func encode<T>(_ value: T, forKey key: Key)   throws where T: Encodable {
+        let nestedContainer = createNestedContainer(for: key)
+
+        try nestedContainer.encode(value)
+    }
+
+    func nestedContainer<NestedKey>(keyedBy type: NestedKey.Type,
+                                    forKey key: Key) -> KeyedEncodingContainer<NestedKey> {
+        let nestedContainer = createNestedContainer(for: key, defaultValue: .keyedContainer([:]))
+
+        let nestedKeyContainer = ShapeKeyedEncodingContainer<NestedKey>(enclosingContainer: nestedContainer)
+
+        return KeyedEncodingContainer<NestedKey>(nestedKeyContainer)
+    }
+
+    func nestedUnkeyedContainer(forKey key: Key) -> UnkeyedEncodingContainer {
+        let nestedContainer = createNestedContainer(for: key, defaultValue: .unkeyedContainer([]))
+
+        let nestedKeyContainer = ShapeUnkeyedEncodingContainer(enclosingContainer: nestedContainer)
+
+        return nestedKeyContainer
+    }
+
+    func superEncoder() -> Encoder { return createNestedContainer(for: ShapeCodingKey.super) }
+    func superEncoder(forKey key: Key) -> Encoder { return createNestedContainer(for: key) }
+
+    // MARK: -
+
+    private func createNestedContainer<NestedKey: CodingKey>(for key: NestedKey,
+                                                             defaultValue: ContainerValueType? = nil)
+        -> ShapeSingleValueEncodingContainer {
+        let nestedContainer = ShapeSingleValueEncodingContainer(
+            userInfo: enclosingContainer.userInfo,
+            codingPath: enclosingContainer.codingPath + [key],
+            delegate: enclosingContainer.delegate,
+            allowedCharacterSet: enclosingContainer.allowedCharacterSet,
+            defaultValue: defaultValue)
+        enclosingContainer.addToKeyedContainer(key: key, value: nestedContainer)
+
+        return nestedContainer
+    }
+}

--- a/Sources/ShapeCoding/ShapeSingleValueEncodingContainer.swift
+++ b/Sources/ShapeCoding/ShapeSingleValueEncodingContainer.swift
@@ -1,0 +1,237 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+//  ShapeSingleValueEncodingContainer.swift
+//  ShapeCoding
+//
+
+import Foundation
+
+/**
+ Conforms to the SingleValueEncodingContainer protocol to manage encoding a
+ value into shape elements.
+ */
+public class ShapeSingleValueEncodingContainer: SingleValueEncodingContainer {
+    internal var containerValue: ContainerValueType?
+
+    public let codingPath: [CodingKey]
+    let allowedCharacterSet: CharacterSet?
+    public let userInfo: [CodingUserInfoKey: Any]
+    let delegate: ShapeSingleValueEncodingContainerDelegate
+
+    public init(userInfo: [CodingUserInfoKey: Any],
+                codingPath: [CodingKey],
+                delegate: ShapeSingleValueEncodingContainerDelegate,
+                allowedCharacterSet: CharacterSet?,
+                defaultValue: ContainerValueType?) {
+        self.containerValue = defaultValue
+        self.userInfo = userInfo
+        self.allowedCharacterSet = allowedCharacterSet
+        self.codingPath = codingPath
+        self.delegate = delegate
+    }
+
+    public func encodeNil() throws {
+        containerValue = .singleValue("")
+    }
+
+    public func encode(_ value: Bool) throws {
+        containerValue = .singleValue(value ? "true" : "false")
+    }
+
+    public func encode(_ value: Int) throws {
+        containerValue = .singleValue(String(value))
+    }
+
+    public func encode(_ value: Int8) throws {
+        containerValue = .singleValue(String(value))
+    }
+
+    public func encode(_ value: Int16) throws {
+        containerValue = .singleValue(String(value))
+    }
+
+    public func encode(_ value: Int32) throws {
+        containerValue = .singleValue(String(value))
+    }
+
+    public func encode(_ value: Int64) throws {
+        containerValue = .singleValue(String(value))
+    }
+
+    public func encode(_ value: UInt) throws {
+        containerValue = .singleValue(String(value))
+    }
+
+    public func encode(_ value: UInt8) throws {
+        containerValue = .singleValue(String(value))
+    }
+
+    public func encode(_ value: UInt16) throws {
+        containerValue = .singleValue(String(value))
+    }
+
+    public func encode(_ value: UInt32) throws {
+        containerValue = .singleValue(String(value))
+    }
+
+    public func encode(_ value: UInt64) throws {
+        containerValue = .singleValue(String(value))
+    }
+
+    public func encode(_ value: Float) throws {
+        containerValue = .singleValue(String(value))
+    }
+
+    public func encode(_ value: Double) throws {
+        containerValue = .singleValue(String(value))
+    }
+
+    public func encode(_ value: String) throws {
+        let encodedValue: String
+        if let allowedCharacterSet = allowedCharacterSet,
+            let percentEncoded = value.addingPercentEncoding(withAllowedCharacters: allowedCharacterSet) {
+                encodedValue = percentEncoded
+        } else {
+            encodedValue = value
+        }
+
+        containerValue = .singleValue(encodedValue)
+    }
+
+    public func encode<T>(_ value: T) throws where T: Encodable {
+        if let date = value as? Foundation.Date {
+            let dateAsString = date.iso8601
+            
+            let encodedValue: String
+            if let allowedCharacterSet = allowedCharacterSet,
+                let percentEncoded = dateAsString.addingPercentEncoding(withAllowedCharacters: allowedCharacterSet) {
+                    encodedValue = percentEncoded
+            } else {
+                encodedValue = dateAsString
+            }
+
+            containerValue = .singleValue(encodedValue)
+            return
+        } else if let data = value as? Foundation.Data {
+            guard let dataAsString = String(data: data, encoding: .utf8) else {
+                let description = "Unable to serialize data instance."
+                throw EncodingError.invalidValue(data, EncodingError.Context(codingPath: self.codingPath,
+                                                                             debugDescription: description))
+            }
+            
+            let encodedValue: String
+            if let allowedCharacterSet = allowedCharacterSet,
+                let percentEncoded = dataAsString.addingPercentEncoding(withAllowedCharacters: allowedCharacterSet) {
+                    encodedValue = percentEncoded
+            } else {
+                encodedValue = dataAsString
+            }
+
+            containerValue = .singleValue(encodedValue)
+            return
+        }
+
+        try value.encode(to: self)
+    }
+
+    func addToKeyedContainer<KeyType: CodingKey>(key: KeyType, value: ShapeElement) {
+        guard let currentContainerValue = containerValue else {
+            fatalError("Attempted to add a keyed item to an unitinialized container.")
+        }
+
+        guard case .keyedContainer(var values) = currentContainerValue else {
+            fatalError("Expected keyed container and there wasn't one.")
+        }
+
+        let attributeName = key.stringValue
+
+        values[attributeName] = value
+
+        containerValue = .keyedContainer(values)
+    }
+
+    func addToUnkeyedContainer(value: ShapeElement) {
+        guard let currentContainerValue = containerValue else {
+            fatalError("Attempted to ad an unkeyed item to an uninitialized container.")
+        }
+
+        guard case .unkeyedContainer(var values) = currentContainerValue else {
+            fatalError("Expected unkeyed container and there wasn't one.")
+        }
+
+        values.append(value)
+
+        containerValue = .unkeyedContainer(values)
+    }
+}
+
+extension ShapeSingleValueEncodingContainer: ShapeElement {
+    public func getShapeElements(_ key: String?, isRoot: Bool, elements: inout [(String, String?)]) throws {
+        try delegate.shapeElementsForEncodingContainer(
+            containerValue: containerValue,
+            key: key,
+            isRoot: isRoot,
+            elements: &elements)
+    }
+}
+
+extension ShapeSingleValueEncodingContainer: Swift.Encoder {
+    var unkeyedContainerCount: Int {
+        guard let containerValue = containerValue else {
+            fatalError("Attempted to access unitialized container.")
+        }
+
+        guard case .unkeyedContainer(let values) = containerValue else {
+            fatalError("Expected unkeyed container and there wasn't one.")
+        }
+
+        return values.count
+    }
+
+    public func container<Key>(keyedBy type: Key.Type) -> KeyedEncodingContainer<Key> where Key: CodingKey {
+
+        // if there container is already initialized
+        if let currentContainerValue = containerValue {
+            guard case .keyedContainer = currentContainerValue else {
+                fatalError("Trying to use an already initialized container as a keyed container.")
+            }
+        } else {
+            containerValue = .keyedContainer([:])
+        }
+
+        let container = ShapeKeyedEncodingContainer<Key>(enclosingContainer: self)
+
+        return KeyedEncodingContainer<Key>(container)
+    }
+
+    public func unkeyedContainer() -> UnkeyedEncodingContainer {
+
+        // if there container is already initialized
+        if let currentContainerValue = containerValue {
+            guard case .unkeyedContainer = currentContainerValue else {
+                fatalError("Trying to use an already initialized container as an unkeyed container.")
+            }
+        } else {
+            containerValue = .unkeyedContainer([])
+        }
+
+        let container = ShapeUnkeyedEncodingContainer(enclosingContainer: self)
+
+        return container
+    }
+
+    public func singleValueContainer() -> SingleValueEncodingContainer {
+        return self
+    }
+}

--- a/Sources/ShapeCoding/ShapeSingleValueEncodingContainer.swift
+++ b/Sources/ShapeCoding/ShapeSingleValueEncodingContainer.swift
@@ -177,8 +177,8 @@ public class ShapeSingleValueEncodingContainer: SingleValueEncodingContainer {
 }
 
 extension ShapeSingleValueEncodingContainer: ShapeElement {
-    public func getShapeElements(_ key: String?, isRoot: Bool, elements: inout [(String, String?)]) throws {
-        try delegate.shapeElementsForEncodingContainer(
+    public func getSerializedElements(_ key: String?, isRoot: Bool, elements: inout [(String, String?)]) throws {
+        try delegate.serializedElementsForEncodingContainer(
             containerValue: containerValue,
             key: key,
             isRoot: isRoot,

--- a/Sources/ShapeCoding/ShapeSingleValueEncodingContainerDelegate.swift
+++ b/Sources/ShapeCoding/ShapeSingleValueEncodingContainerDelegate.swift
@@ -23,7 +23,7 @@ import Foundation
  */
 public protocol ShapeSingleValueEncodingContainerDelegate {
     /**
-     Function that provides the shape elements for an encoding container.
+     Function that gathers the serialized elements for an encoding container.
  
      - Parameters:
          - containerValue: the value of the container if any
@@ -31,7 +31,7 @@ public protocol ShapeSingleValueEncodingContainerDelegate {
          - isRoot: if this container is the root of the type being encoded.
          - elements: the array to append elements from this container to.
      */
-    func shapeElementsForEncodingContainer(
+    func serializedElementsForEncodingContainer(
         containerValue: ContainerValueType?,
         key: String?,
         isRoot: Bool,

--- a/Sources/ShapeCoding/ShapeSingleValueEncodingContainerDelegate.swift
+++ b/Sources/ShapeCoding/ShapeSingleValueEncodingContainerDelegate.swift
@@ -1,0 +1,39 @@
+//
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+//  ShapeSingleValueEncodingContainerDelegate.swift
+//  ShapeCoding
+//
+
+import Foundation
+
+/**
+ Delegate class that provides custom logic for a ShapeSingleValueEncodingContainer.
+ */
+public protocol ShapeSingleValueEncodingContainerDelegate {
+    /**
+     Function that provides the shape elements for an encoding container.
+ 
+     - Parameters:
+         - containerValue: the value of the container if any
+         - key: the key of the container if any.
+         - isRoot: if this container is the root of the type being encoded.
+         - elements: the array to append elements from this container to.
+     */
+    func shapeElementsForEncodingContainer(
+        containerValue: ContainerValueType?,
+        key: String?,
+        isRoot: Bool,
+        elements: inout [(String, String?)]) throws
+}

--- a/Sources/ShapeCoding/ShapeUnkeyedEncodingContainer.swift
+++ b/Sources/ShapeCoding/ShapeUnkeyedEncodingContainer.swift
@@ -1,0 +1,139 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+//  ShapeUnkeyedEncodingContainer.swift
+//  ShapeCoding
+//
+
+import Foundation
+
+internal struct ShapeUnkeyedEncodingContainer: UnkeyedEncodingContainer {
+    private let enclosingContainer: ShapeSingleValueEncodingContainer
+
+    init(enclosingContainer: ShapeSingleValueEncodingContainer) {
+        self.enclosingContainer = enclosingContainer
+    }
+
+    // MARK: - Swift.UnkeyedEncodingContainer Methods
+
+    var codingPath: [CodingKey] {
+        return enclosingContainer.codingPath
+    }
+
+    var count: Int { return enclosingContainer.unkeyedContainerCount }
+
+    func encodeNil() throws {
+        enclosingContainer.addToUnkeyedContainer(value: "") }
+
+    func encode(_ value: Bool) throws {
+        enclosingContainer.addToUnkeyedContainer(value: value ? "true" : "false") }
+
+    func encode(_ value: Int) throws {
+        enclosingContainer.addToUnkeyedContainer(value: String(value))
+    }
+
+    func encode(_ value: Int8) throws {
+        enclosingContainer.addToUnkeyedContainer(value: String(value))
+    }
+
+    func encode(_ value: Int16) throws {
+        enclosingContainer.addToUnkeyedContainer(value: String(value))
+    }
+
+    func encode(_ value: Int32) throws {
+        enclosingContainer.addToUnkeyedContainer(value: String(value))
+    }
+
+    func encode(_ value: Int64) throws {
+        enclosingContainer.addToUnkeyedContainer(value: String(value))
+    }
+
+    func encode(_ value: UInt) throws {
+        enclosingContainer.addToUnkeyedContainer(value: String(value))
+    }
+
+    func encode(_ value: UInt8) throws {
+        enclosingContainer.addToUnkeyedContainer(value: String(value))
+    }
+
+    func encode(_ value: UInt16) throws {
+        enclosingContainer.addToUnkeyedContainer(value: String(value))
+    }
+
+    func encode(_ value: UInt32) throws {
+        enclosingContainer.addToUnkeyedContainer(value: String(value))
+    }
+
+    func encode(_ value: UInt64) throws {
+        enclosingContainer.addToUnkeyedContainer(value: String(value))
+    }
+
+    func encode(_ value: Float) throws {
+        enclosingContainer.addToUnkeyedContainer(value: String(value))
+    }
+
+    func encode(_ value: Double) throws {
+        enclosingContainer.addToUnkeyedContainer(value: String(value))
+    }
+
+    func encode(_ value: String) throws {
+        let encodedValue: String
+        if let allowedCharacterSet = enclosingContainer.allowedCharacterSet,
+            let percentEncoded = value.addingPercentEncoding(withAllowedCharacters: allowedCharacterSet) {
+                encodedValue = percentEncoded
+        } else {
+            encodedValue = value
+        }
+
+        enclosingContainer.addToUnkeyedContainer(value: encodedValue)
+    }
+
+    func encode<T>(_ value: T) throws where T: Encodable {
+        try createNestedContainer().encode(value)
+    }
+
+    func nestedContainer<NestedKey>(keyedBy type: NestedKey.Type) -> KeyedEncodingContainer<NestedKey> {
+        let nestedContainer = createNestedContainer(defaultValue: .keyedContainer([:]))
+
+        let nestedKeyContainer = ShapeKeyedEncodingContainer<NestedKey>(enclosingContainer: nestedContainer)
+
+        return KeyedEncodingContainer<NestedKey>(nestedKeyContainer)
+    }
+
+    func nestedUnkeyedContainer() -> UnkeyedEncodingContainer {
+        let nestedContainer = createNestedContainer(defaultValue: .unkeyedContainer([]))
+
+        let nestedKeyContainer = ShapeUnkeyedEncodingContainer(enclosingContainer: nestedContainer)
+
+        return nestedKeyContainer
+    }
+
+    func superEncoder() -> Encoder { return createNestedContainer() }
+
+    // MARK: -
+
+    private func createNestedContainer(defaultValue: ContainerValueType? = nil)
+        -> ShapeSingleValueEncodingContainer {
+        let index = enclosingContainer.unkeyedContainerCount
+
+        let nestedContainer = ShapeSingleValueEncodingContainer(
+            userInfo: enclosingContainer.userInfo,
+            codingPath: enclosingContainer.codingPath + [ShapeCodingKey(index: index)],
+            delegate: enclosingContainer.delegate,
+            allowedCharacterSet: enclosingContainer.allowedCharacterSet,
+            defaultValue: defaultValue)
+        enclosingContainer.addToUnkeyedContainer(value: nestedContainer)
+
+        return nestedContainer
+    }
+}


### PR DESCRIPTION
*Issue #, if available:* #5 and #6 

*Description of changes:* Add a Shape Encoder in the ShapeCoding package that provides a generic decoder that can be shared across different Codable decoders for query strings, headers and path tokens.

*Testing performed:* Along with other changes that I will submit for future PRs, I have verified encoders and decoders for query strings, http headers and http paths using these classes. These will have further unit tests.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
