### PR TITLE
Add the ability to handle a tail beyond a greedy token

### DIFF
--- a/Sources/HTTPPathCoding/HTTPPathSegment.swift
+++ b/Sources/HTTPPathCoding/HTTPPathSegment.swift
@@ -52,7 +52,9 @@ public struct HTTPPathSegment: Equatable {
         }
         
         let invalidMultiSegments = segments.dropLast().filter { segment in
-            return segment.tokens.last?.isMultiSegment ?? false
+            return segment.tokens.reduce(false) { (initial, current) in
+                return initial || current.isMultiSegment
+            }
         }
         
         guard invalidMultiSegments.isEmpty else {

--- a/Sources/HTTPPathCoding/HTTPPathToken.swift
+++ b/Sources/HTTPPathCoding/HTTPPathToken.swift
@@ -38,6 +38,7 @@ public enum HTTPPathToken {
         var inVariable = false
         var tokens: [HTTPPathToken] = []
         
+        var hasGreedyToken = false
         repeat {
             let nextSplit = inVariable ? endCharacter : startCharacter
             let components = remainingTemplate.split(separator: nextSplit, maxSplits: 1,
@@ -48,16 +49,17 @@ public enum HTTPPathToken {
             
             if !thisToken.isEmpty {
                 if inVariable {
+                    // can only have greedy tokens at the end
+                    if hasGreedyToken {
+                        throw HTTPPathErrors.hasInvalidMultiSegmentTokens
+                    }
+                    
                     let tokenName: String
                     let multiSegment: Bool
                     if let last = thisToken.last, last == "+" {
                         tokenName = String(thisToken.dropLast())
                         multiSegment = true
-                        
-                        // can only have multi-segment tokens at the end
-                        if !futureTokens.isEmpty {
-                            throw HTTPPathErrors.hasInvalidMultiSegmentTokens
-                        }
+                        hasGreedyToken = true
                     } else {
                         tokenName = String(thisToken)
                         multiSegment = false

--- a/Tests/HTTPPathCodingTests/HTTPPathSegmentTests.swift
+++ b/Tests/HTTPPathCodingTests/HTTPPathSegmentTests.swift
@@ -82,8 +82,33 @@ class HTTPPathSegmentTests: XCTestCase {
         XCTAssertEqual(expected, output)
     }
     
+    func testTokenizeAtEndWithPlusWithTrail() throws {
+        let input = "/person/{id}/address{index+}?trail"
+
+        let expected = [HTTPPathSegment(tokens: [.string("person")]),
+                        HTTPPathSegment(tokens: [.variable(name: "id", multiSegment: false)]),
+                        HTTPPathSegment(tokens: [.string("address"),
+                                         .variable(name: "index", multiSegment: true),
+                                         .string("?trail")])]
+        
+        let output = try! HTTPPathSegment.tokenize(template: input)
+        XCTAssertEqual(expected, output)
+    }
+    
     func testInvalidTokenize() throws {
         let input = "/person/{id+}/address{index}"
+        
+        do {
+            _ = try HTTPPathSegment.tokenize(template: input)
+            
+            XCTFail()
+        } catch {
+            // expected
+        }
+    }
+    
+    func testInvalidTokenizeWithTrail() throws {
+        let input = "/person/{id+}trail/address{index}"
         
         do {
             _ = try HTTPPathSegment.tokenize(template: input)
@@ -100,6 +125,8 @@ class HTTPPathSegmentTests: XCTestCase {
         ("testTokenizeAtStart", testTokenizeAtStart),
         ("testTokenizeAtEnd", testTokenizeAtEnd),
         ("testTokenizeAtEndWithPlus", testTokenizeAtEndWithPlus),
+        ("testTokenizeAtEndWithPlusWithTrail", testTokenizeAtEndWithPlusWithTrail),
         ("testInvalidTokenize", testInvalidTokenize),
+        ("testInvalidTokenizeWithTrail", testInvalidTokenizeWithTrail),
     ]
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Add the ability to handle a trail beyond a greedy token. An example of this kind of path-

```
items{firstly}/things/{secondly}/{thirdly+}?tail
```

Add additional tests for http path encoder/decoder.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
