### PR TITLE
HTTPResponseOutputProtocol for responses

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,9 +1,16 @@
 disabled_rules:
   - trailing_whitespace
   - void_return
+  - class_delegate_protocol
+  - weak_delegate
+  - type_name
+  - generic_type_name
 included:
   - Sources
 line_length: 150
 function_body_length:
   warning: 50
   error: 75
+function_parameter_count:
+  warning: 8
+  error: 10

--- a/Sources/SmokeHTTPClient/HTTPClient+executeAsyncWithOutput.swift
+++ b/Sources/SmokeHTTPClient/HTTPClient+executeAsyncWithOutput.swift
@@ -1,0 +1,126 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+//  HTTPClient+executeAsyncWithOutput.swift
+//  SmokeHTTPClient
+//
+
+import Foundation
+import NIO
+import NIOHTTP1
+import NIOOpenSSL
+import NIOTLS
+import LoggerAPI
+
+public extension HTTPClient {
+    /**
+     Submits a request that will return a response body to this client asynchronously.
+     The completion handler's execution will be scheduled on DispatchQueue.global()
+     rather than executing on a thread from SwiftNIO.
+
+     - Parameters:
+     - endpointPath: The endpoint path for this request.
+     - httpMethod: The http method to use for this request.
+     - input: the input body data to send with this request.
+     - completion: Completion handler called with the response body or any error.
+     - handlerDelegate: the delegate used to customize the request's channel handler.
+     */
+    public func executeAsyncWithOutput<InputType, OutputType>(
+            endpointOverride: URL? = nil,
+            endpointPath: String,
+            httpMethod: HTTPMethod,
+            input: InputType,
+            completion: @escaping (HTTPResult<OutputType>) -> (),
+            handlerDelegate: HTTPClientChannelInboundHandlerDelegate) throws -> Channel
+        where InputType: HTTPRequestInputProtocol, OutputType: HTTPResponseOutputProtocol {
+            return try executeAsyncWithOutput(
+                endpointOverride: endpointOverride,
+                endpointPath: endpointPath,
+                httpMethod: httpMethod,
+                input: input,
+                completion: completion,
+                asyncResponseInvocationStrategy: GlobalDispatchQueueAsyncResponseInvocationStrategy<HTTPResult<OutputType>>(),
+                handlerDelegate: handlerDelegate)
+    }
+
+    /**
+     Submits a request that will return a response body to this client asynchronously.
+
+     - Parameters:
+     - endpointPath: The endpoint path for this request.
+     - httpMethod: The http method to use for this request.
+     - input: the input body data to send with this request.
+     - completion: Completion handler called with the response body or any error.
+     - asyncResponseInvocationStrategy: The invocation strategy for the response from this request.
+     - handlerDelegate: the delegate used to customize the request's channel handler.
+     */
+    public func executeAsyncWithOutput<InputType, OutputType, InvocationStrategyType>(
+            endpointOverride: URL? = nil,
+            endpointPath: String,
+            httpMethod: HTTPMethod,
+            input: InputType,
+            completion: @escaping (HTTPResult<OutputType>) -> (),
+            asyncResponseInvocationStrategy: InvocationStrategyType,
+            handlerDelegate: HTTPClientChannelInboundHandlerDelegate) throws -> Channel
+            where InputType: HTTPRequestInputProtocol, InvocationStrategyType: AsyncResponseInvocationStrategy,
+        InvocationStrategyType.OutputType == HTTPResult<OutputType>,
+        OutputType: HTTPResponseOutputProtocol {
+
+        var hasComplete = false
+        let requestDelegate = clientDelegate
+        // create a wrapping completion handler to pass to the ChannelInboundHandler
+        // that will decode the returned body into the desired decodable type.
+        let wrappingCompletion: (HTTPResult<HTTPResponseComponents>) -> () = { (rawResult) in
+            let result: HTTPResult<OutputType>
+
+            switch rawResult {
+            case .error(let error):
+                // its an error; complete with the provided error
+                result = .error(error)
+            case .response(let response):
+                do {
+                    // decode the provided body into the desired type
+                    let output: OutputType = try requestDelegate.decodeOutput(
+                        output: response.body,
+                        headers: response.headers)
+
+                    // complete with the decoded type
+                    result = .response(output)
+                } catch {
+                    // if there was a decoding error, complete with that error
+                    result = .error(error)
+                }
+            }
+
+            asyncResponseInvocationStrategy.invokeResponse(response: result, completion: completion)
+            hasComplete = true
+        }
+
+        // submit the asynchronous request
+        let channel = try executeAsync(endpointOverride: endpointOverride,
+                                       endpointPath: endpointPath,
+                                       httpMethod: httpMethod,
+                                       input: input,
+                                       completion: wrappingCompletion,
+                                       handlerDelegate: handlerDelegate)
+
+        channel.closeFuture.whenComplete {
+            // if this channel is being closed and no response has been recorded
+            if !hasComplete {
+                completion(.error(HTTPClient.unexpectedClosureType))
+            }
+        }
+
+        return channel
+    }
+}

--- a/Sources/SmokeHTTPClient/HTTPClient+executeAsyncWithoutOutput.swift
+++ b/Sources/SmokeHTTPClient/HTTPClient+executeAsyncWithoutOutput.swift
@@ -1,0 +1,113 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+//  HTTPClient+executeAsyncWithoutOutput.swift
+//  SmokeHTTPClient
+//
+
+import Foundation
+import NIO
+import NIOHTTP1
+import NIOOpenSSL
+import NIOTLS
+import LoggerAPI
+
+public extension HTTPClient {
+    /**
+     Submits a request that will not return a response body to this client asynchronously.
+     The completion handler's execution will be scheduled on DispatchQueue.global()
+     rather than executing on a thread from SwiftNIO.
+     
+     - Parameters:
+     - endpointPath: The endpoint path for this request.
+     - httpMethod: The http method to use for this request.
+     - input: the input body data to send with this request.
+     - completion: Completion handler called with an error if one occurs or nil otherwise.
+     - handlerDelegate: the delegate used to customize the request's channel handler.
+     */
+    public func executeAsyncWithoutOutput<InputType>(
+        endpointOverride: URL? = nil,
+        endpointPath: String,
+        httpMethod: HTTPMethod,
+        input: InputType,
+        completion: @escaping (Error?) -> (),
+        handlerDelegate: HTTPClientChannelInboundHandlerDelegate) throws -> Channel
+        where InputType: HTTPRequestInputProtocol {
+            return try executeAsyncWithoutOutput(
+                endpointOverride: endpointOverride,
+                endpointPath: endpointPath,
+                httpMethod: httpMethod,
+                input: input,
+                completion: completion,
+                asyncResponseInvocationStrategy: GlobalDispatchQueueAsyncResponseInvocationStrategy<Error?>(),
+                handlerDelegate: handlerDelegate)
+    }
+    
+    /**
+     Submits a request that will not return a response body to this client asynchronously.
+     
+     - Parameters:
+     - endpointPath: The endpoint path for this request.
+     - httpMethod: The http method to use for this request.
+     - input: the input body data to send with this request.
+     - completion: Completion handler called with an error if one occurs or nil otherwise.
+     - asyncResponseInvocationStrategy: The invocation strategy for the response from this request.
+     - handlerDelegate: the delegate used to customize the request's channel handler.
+     */
+    public func executeAsyncWithoutOutput<InputType, InvocationStrategyType>(
+        endpointOverride: URL? = nil,
+        endpointPath: String,
+        httpMethod: HTTPMethod,
+        input: InputType,
+        completion: @escaping (Error?) -> (),
+        asyncResponseInvocationStrategy: InvocationStrategyType,
+        handlerDelegate: HTTPClientChannelInboundHandlerDelegate) throws -> Channel
+        where InputType: HTTPRequestInputProtocol, InvocationStrategyType: AsyncResponseInvocationStrategy,
+        InvocationStrategyType.OutputType == Error? {
+            
+            var hasComplete = false
+            // create a wrapping completion handler to pass to the ChannelInboundHandler
+            let wrappingCompletion: (HTTPResult<HTTPResponseComponents>) -> () = { (rawResult) in
+                let result: Error?
+                
+                switch rawResult {
+                case .error(let error):
+                    // its an error, complete with this error
+                    result = error
+                case .response:
+                    // its a successful completion, complete with an empty error.
+                    result = nil
+                }
+                
+                asyncResponseInvocationStrategy.invokeResponse(response: result, completion: completion)
+                hasComplete = true
+            }
+            
+            // submit the asynchronous request
+            let channel = try executeAsync(endpointOverride: endpointOverride,
+                                           endpointPath: endpointPath,
+                                           httpMethod: httpMethod,
+                                           input: input,
+                                           completion: wrappingCompletion,
+                                           handlerDelegate: handlerDelegate)
+            
+            channel.closeFuture.whenComplete {
+                // if this channel is being closed and no response has been recorded
+                if !hasComplete {
+                    completion(HTTPClient.unexpectedClosureType)
+                }
+            }
+            
+            return channel
+    }
+}

--- a/Sources/SmokeHTTPClient/HTTPClient+executeSyncWithOutput.swift
+++ b/Sources/SmokeHTTPClient/HTTPClient+executeSyncWithOutput.swift
@@ -1,0 +1,87 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+//  HTTPClient+executeSyncWithOutput.swift
+//  SmokeHTTPClient
+//
+
+import Foundation
+import NIO
+import NIOHTTP1
+import NIOOpenSSL
+import NIOTLS
+import LoggerAPI
+
+public extension HTTPClient {
+    /**
+     Submits a request that will return a response body to this client synchronously.
+     
+     - Parameters:
+     - endpointPath: The endpoint path for this request.
+     - httpMethod: The http method to use for this request.
+     - input: the input body data to send with this request.
+     - handlerDelegate: the delegate used to customize the request's channel handler.
+     - Returns: the response body.
+     - Throws: If an error occurred during the request.
+     */
+    public func executeSyncWithOutput<InputType, OutputType>(
+        endpointOverride: URL? = nil,
+        endpointPath: String,
+        httpMethod: HTTPMethod,
+        input: InputType,
+        handlerDelegate: HTTPClientChannelInboundHandlerDelegate) throws -> OutputType
+        where InputType: HTTPRequestInputProtocol,
+        OutputType: HTTPResponseOutputProtocol {
+            
+            var responseResult: HTTPResult<OutputType>?
+            let completedSemaphore = DispatchSemaphore(value: 0)
+            
+            let completion: (HTTPResult<OutputType>) -> () = { result in
+                responseResult = result
+                completedSemaphore.signal()
+            }
+            
+            let channel = try executeAsyncWithOutput(endpointOverride: endpointOverride,
+                                                     endpointPath: endpointPath,
+                                                     httpMethod: httpMethod,
+                                                     input: input,
+                                                     completion: completion,
+                                                     // the completion handler can be safely executed on a SwiftNIO thread
+                asyncResponseInvocationStrategy: SameThreadAsyncResponseInvocationStrategy<HTTPResult<OutputType>>(),
+                handlerDelegate: handlerDelegate)
+            
+            channel.closeFuture.whenComplete {
+                // if this channel is being closed and no response has been recorded
+                if responseResult == nil {
+                    responseResult = .error(HTTPClient.unexpectedClosureType)
+                    completedSemaphore.signal()
+                }
+            }
+            
+            Log.verbose("Waiting for response from \(endpointOverride?.host ?? endpointHostName) ...")
+            completedSemaphore.wait()
+            
+            guard let result = responseResult else {
+                throw HTTPError.connectionError("Http request was closed without returning a response.")
+            }
+            
+            Log.verbose("Got response from \(endpointOverride?.host ?? endpointHostName) - response received: \(result)")
+            
+            switch result {
+            case .error(let error):
+                throw error
+            case .response(let response):
+                return response
+            }
+    }
+}

--- a/Sources/SmokeHTTPClient/HTTPClient+executeSyncWithoutOutput.swift
+++ b/Sources/SmokeHTTPClient/HTTPClient+executeSyncWithoutOutput.swift
@@ -1,0 +1,78 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+//  HTTPClient+executeSyncWithoutOutput.swift
+//  SmokeHTTPClient
+//
+
+import Foundation
+import NIO
+import NIOHTTP1
+import NIOOpenSSL
+import NIOTLS
+import LoggerAPI
+
+public extension HTTPClient {
+    private struct AsyncErrorResult {
+        let error: Error?
+    }
+    
+    /**
+     Submits a request that will not return a response body to this client synchronously.
+     
+     - Parameters:
+     - endpointPath: The endpoint path for this request.
+     - httpMethod: The http method to use for this request.
+     - input: the input body data to send with this request.
+     - handlerDelegate: the delegate used to customize the request's channel handler.
+     - Throws: If an error occurred during the request.
+     */
+    public func executeSyncWithoutOutput<InputType>(
+        endpointOverride: URL? = nil,
+        endpointPath: String,
+        httpMethod: HTTPMethod,
+        input: InputType,
+        handlerDelegate: HTTPClientChannelInboundHandlerDelegate) throws
+        where InputType: HTTPRequestInputProtocol {
+            var responseError: AsyncErrorResult?
+            let completedSemaphore = DispatchSemaphore(value: 0)
+            
+            let completion: (Error?) -> () = { error in
+                responseError = AsyncErrorResult(error: error)
+                completedSemaphore.signal()
+            }
+            
+            let channel = try executeAsyncWithoutOutput(endpointOverride: endpointOverride,
+                                                        endpointPath: endpointPath,
+                                                        httpMethod: httpMethod,
+                                                        input: input,
+                                                        completion: completion,
+                                                        // the completion handler can be safely executed on a SwiftNIO thread
+                asyncResponseInvocationStrategy: SameThreadAsyncResponseInvocationStrategy<Error?>(),
+                handlerDelegate: handlerDelegate)
+            
+            channel.closeFuture.whenComplete {
+                // if this channel is being closed and no response has been recorded
+                if responseError == nil {
+                    responseError = AsyncErrorResult(error: HTTPClient.unexpectedClosureType)
+                    completedSemaphore.signal()
+                }
+            }
+            
+            completedSemaphore.wait()
+            
+            if let error = responseError?.error {
+                throw error
+            }
+    }
+}

--- a/Sources/SmokeHTTPClient/HTTPClient.swift
+++ b/Sources/SmokeHTTPClient/HTTPClient.swift
@@ -34,11 +34,34 @@ public class HTTPClient {
     /// The connection timeout in seconds
     public let connectionTimeoutSeconds: Int
     
-    private static let unexpectedClosureType =
+    /**
+     Enumeration specifying how the event loop is provided for a channel established by this client.
+     */
+    public enum EventLoopProvider {
+        /// The client will create a new EventLoopGroup to be used for channels created from
+        /// this client. The EventLoopGroup will be closed when this client is closed.
+        case spawnNewThreads
+        /// The client will use the provided EventLoopGroup for channels created from
+        /// this client. This EventLoopGroup will not be closed when this client is closed.
+        case use(EventLoopGroup)
+    }
+    
+    private enum State {
+        case active
+        case shuttingDown
+        case closed
+    }
+    
+    private let closedSemaphore = DispatchSemaphore(value: 0)
+    private var state: State
+    private var stateLock: NSLock
+    
+    static let unexpectedClosureType =
         HTTPError.connectionError("Http request was unexpectedly closed without returning a response.")
 
     /// The event loop used by requests/responses from this client
-    let eventLoopGroup: MultiThreadedEventLoopGroup
+    let eventLoopGroup: EventLoopGroup
+    let ownEventLoopGroup: Bool
 
     /**
      Initializer.
@@ -56,331 +79,91 @@ public class HTTPClient {
                 endpointPort: Int,
                 contentType: String,
                 clientDelegate: HTTPClientDelegate,
-                connectionTimeoutSeconds: Int = 10) {
+                connectionTimeoutSeconds: Int = 10,
+                eventLoopProvider: EventLoopProvider = .spawnNewThreads) {
         self.endpointHostName = endpointHostName
         self.endpointPort = endpointPort
         self.contentType = contentType
         self.clientDelegate = clientDelegate
         self.connectionTimeoutSeconds = connectionTimeoutSeconds
+        self.stateLock = NSLock()
+        self.state = .active
 
-        self.eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
+        switch eventLoopProvider {
+        case .spawnNewThreads:
+            self.eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
+            self.ownEventLoopGroup = true
+        case .use(let existingEventLoopGroup):
+            self.eventLoopGroup = existingEventLoopGroup
+            self.ownEventLoopGroup = false
+        }
     }
 
     /**
-     De-initializer. Shuts down the event loop group when this instance is deallocated.
+     De-initializer. Report if the client is not closed.
      */
     deinit {
-        do {
-            try eventLoopGroup.syncShutdownGracefully()
-        } catch {
-            Log.error("Unable to shut down event loop group: \(error)")
+        guard case .closed = state else {
+            return Log.error("HTTPClient was not shutdown properly prior to de-initialization.")
         }
     }
-
+    
     /**
-     Submits a request that will return a response body to this client asynchronously.
-     The completion handler's execution will be scheduled on DispatchQueue.global()
-     rather than executing on a thread from SwiftNIO.
-
-     - Parameters:
-     - endpointPath: The endpoint path for this request.
-     - httpMethod: The http method to use for this request.
-     - input: the input body data to send with this request.
-     - completion: Completion handler called with the response body or any error.
-     - handlerDelegate: the delegate used to customize the request's channel handler.
+     Gracefully shuts down the eventloop if owned by this client.
+     This function is idempotent and will handle being called multiple
+     times.
      */
-    public func executeAsyncWithOutput<InputType, OutputType>(
-            endpointOverride: URL? = nil,
-            endpointPath: String,
-            httpMethod: HTTPMethod,
-            input: InputType,
-            completion: @escaping (HTTPResult<OutputType>) -> (),
-            handlerDelegate: HTTPClientChannelInboundHandlerDelegate) throws -> Channel
-        where InputType: HTTPRequestInputProtocol, OutputType: Decodable {
-            return try executeAsyncWithOutput(
-                endpointOverride: endpointOverride,
-                endpointPath: endpointPath,
-                httpMethod: httpMethod,
-                input: input,
-                completion: completion,
-                asyncResponseInvocationStrategy: GlobalDispatchQueueAsyncResponseInvocationStrategy<HTTPResult<OutputType>>(),
-                handlerDelegate: handlerDelegate)
-    }
+    public func close() {
+        stateLock.lock()
+        defer {
+            stateLock.unlock()
+        }
+        
+        // if the client is already closed or shutting down
+        switch state {
+        case .closed, .shuttingDown:
+            return
+        case .active:
+            break
+        }
+        
+        // if this client owns the EventLoopGroup
+        if ownEventLoopGroup {
+            state = .shuttingDown
 
-    /**
-     Submits a request that will return a response body to this client asynchronously.
-
-     - Parameters:
-     - endpointPath: The endpoint path for this request.
-     - httpMethod: The http method to use for this request.
-     - input: the input body data to send with this request.
-     - completion: Completion handler called with the response body or any error.
-     - asyncResponseInvocationStrategy: The invocation strategy for the response from this request.
-     - handlerDelegate: the delegate used to customize the request's channel handler.
-     */
-    public func executeAsyncWithOutput<InputType, OutputType, InvocationStrategyType>(
-            endpointOverride: URL? = nil,
-            endpointPath: String,
-            httpMethod: HTTPMethod,
-            input: InputType,
-            completion: @escaping (HTTPResult<OutputType>) -> (),
-            asyncResponseInvocationStrategy: InvocationStrategyType,
-            handlerDelegate: HTTPClientChannelInboundHandlerDelegate) throws -> Channel
-            where InputType: HTTPRequestInputProtocol, InvocationStrategyType: AsyncResponseInvocationStrategy,
-        InvocationStrategyType.OutputType == HTTPResult<OutputType>, OutputType: Decodable {
-
-        var hasComplete = false
-        let requestDelegate = clientDelegate
-        // create a wrapping completion handler to pass to the ChannelInboundHandler
-        // that will decode the returned body into the desired decodable type.
-        let wrappingCompletion: (HTTPResult<Data?>) -> () = { (rawResult) in
-            let result: HTTPResult<OutputType>
-
-            switch rawResult {
-            case .error(let error):
-                // its an error; complete with the provided error
-                result = .error(error)
-            case .response(let response):
-                // we are expecting a response body
-                guard let response = response else {
-                    // complete with a bad response error
-                    return completion(.error(HTTPError.badResponse("Unexpected empty response.")))
+            eventLoopGroup.shutdownGracefully { _ in
+                self.stateLock.lock()
+                defer {
+                    self.stateLock.unlock()
                 }
-
-                do {
-                    // decode the provided body into the desired type
-                    let output: OutputType = try requestDelegate.decodeOutput(output: response)
-
-                    // complete with the decoded type
-                    result = .response(output)
-                } catch {
-                    // if there was a decoding error, complete with that error
-                    result = .error(error)
-                }
+                
+                self.signalClientClosure()
             }
-
-            asyncResponseInvocationStrategy.invokeResponse(response: result, completion: completion)
-            hasComplete = true
+        } else {
+            // nothing to do as the EventLoopGroup isn't owned by the client,
+            // close immediately
+            signalClientClosure()
         }
-
-        // submit the asynchronous request
-        let channel = try executeAsync(endpointOverride: endpointOverride,
-                                       endpointPath: endpointPath,
-                                       httpMethod: httpMethod,
-                                       input: input,
-                                       completion: wrappingCompletion,
-                                       handlerDelegate: handlerDelegate)
-
-        channel.closeFuture.whenComplete {
-            // if this channel is being closed and no response has been recorded
-            if !hasComplete {
-                completion(.error(HTTPClient.unexpectedClosureType))
-            }
-        }
-
-        return channel
     }
-
+    
+    private func signalClientClosure() {
+        state = .closed
+        closedSemaphore.signal()
+    }
+    
     /**
-     Submits a request that will not return a response body to this client asynchronously.
-     The completion handler's execution will be scheduled on DispatchQueue.global()
-     rather than executing on a thread from SwiftNIO.
-
-     - Parameters:
-     - endpointPath: The endpoint path for this request.
-     - httpMethod: The http method to use for this request.
-     - input: the input body data to send with this request.
-     - completion: Completion handler called with an error if one occurs or nil otherwise.
-     - handlerDelegate: the delegate used to customize the request's channel handler.
+     Waits for the client to be closed. If close() is not called,
+     this will block forever.
      */
-    public func executeAsyncWithoutOutput<InputType>(
-            endpointOverride: URL? = nil,
-            endpointPath: String,
-            httpMethod: HTTPMethod,
-            input: InputType,
-            completion: @escaping (Error?) -> (),
-            handlerDelegate: HTTPClientChannelInboundHandlerDelegate) throws -> Channel
-            where InputType: HTTPRequestInputProtocol {
-                return try executeAsyncWithoutOutput(
-                    endpointOverride: endpointOverride,
-                    endpointPath: endpointPath,
-                    httpMethod: httpMethod,
-                    input: input,
-                    completion: completion,
-                    asyncResponseInvocationStrategy: GlobalDispatchQueueAsyncResponseInvocationStrategy<Error?>(),
-                    handlerDelegate: handlerDelegate)
-    }
-
-    /**
-     Submits a request that will not return a response body to this client asynchronously.
-
-     - Parameters:
-     - endpointPath: The endpoint path for this request.
-     - httpMethod: The http method to use for this request.
-     - input: the input body data to send with this request.
-     - completion: Completion handler called with an error if one occurs or nil otherwise.
-     - asyncResponseInvocationStrategy: The invocation strategy for the response from this request.
-     - handlerDelegate: the delegate used to customize the request's channel handler.
-     */
-    public func executeAsyncWithoutOutput<InputType, InvocationStrategyType>(
-            endpointOverride: URL? = nil,
-            endpointPath: String,
-            httpMethod: HTTPMethod,
-            input: InputType,
-            completion: @escaping (Error?) -> (),
-            asyncResponseInvocationStrategy: InvocationStrategyType,
-            handlerDelegate: HTTPClientChannelInboundHandlerDelegate) throws -> Channel
-            where InputType: HTTPRequestInputProtocol, InvocationStrategyType: AsyncResponseInvocationStrategy,
-            InvocationStrategyType.OutputType == Error? {
-
-        var hasComplete = false
-        // create a wrapping completion handler to pass to the ChannelInboundHandler
-        let wrappingCompletion: (HTTPResult<Data?>) -> () = { (rawResult) in
-            let result: Error?
-
-            switch rawResult {
-            case .error(let error):
-                // its an error, complete with this error
-                result = error
-            case .response:
-                // its a successful completion, complete with an empty error.
-                result = nil
-            }
-
-            asyncResponseInvocationStrategy.invokeResponse(response: result, completion: completion)
-            hasComplete = true
+    public func wait() {
+        self.stateLock.lock()
+        if case .closed = state {
+            self.stateLock.unlock()
+            return
         }
-
-        // submit the asynchronous request
-        let channel = try executeAsync(endpointOverride: endpointOverride,
-                                       endpointPath: endpointPath,
-                                       httpMethod: httpMethod,
-                                       input: input,
-                                       completion: wrappingCompletion,
-                                       handlerDelegate: handlerDelegate)
-
-        channel.closeFuture.whenComplete {
-            // if this channel is being closed and no response has been recorded
-            if !hasComplete {
-                completion(HTTPClient.unexpectedClosureType)
-            }
-        }
-
-        return channel
-    }
-
-    /**
-     Submits a request that will return a response body to this client synchronously.
-
-     - Parameters:
-     - endpointPath: The endpoint path for this request.
-     - httpMethod: The http method to use for this request.
-     - input: the input body data to send with this request.
-     - handlerDelegate: the delegate used to customize the request's channel handler.
-     - Returns: the response body.
-     - Throws: If an error occurred during the request.
-     */
-    public func executeSyncWithOutput<InputType, OutputType>(
-            endpointOverride: URL? = nil,
-            endpointPath: String,
-            httpMethod: HTTPMethod,
-            input: InputType,
-            handlerDelegate: HTTPClientChannelInboundHandlerDelegate) throws -> OutputType
-            where InputType: HTTPRequestInputProtocol, OutputType: Codable {
-
-        var responseResult: HTTPResult<OutputType>?
-        let completedSemaphore = DispatchSemaphore(value: 0)
-
-        let completion: (HTTPResult<OutputType>) -> () = { result in
-            responseResult = result
-            completedSemaphore.signal()
-        }
-
-        let channel = try executeAsyncWithOutput(endpointOverride: endpointOverride,
-                                                 endpointPath: endpointPath,
-                                                 httpMethod: httpMethod,
-                                                 input: input,
-                                                 completion: completion,
-                                                 // the completion handler can be safely executed on a SwiftNIO thread
-                                                 asyncResponseInvocationStrategy: SameThreadAsyncResponseInvocationStrategy<HTTPResult<OutputType>>(),
-                                                 handlerDelegate: handlerDelegate)
-
-        channel.closeFuture.whenComplete {
-            // if this channel is being closed and no response has been recorded
-            if responseResult == nil {
-                responseResult = .error(HTTPClient.unexpectedClosureType)
-                completedSemaphore.signal()
-            }
-        }
-
-        Log.verbose("Waiting for response from \(endpointOverride?.host ?? endpointHostName) ...")
-        completedSemaphore.wait()
-
-        guard let result = responseResult else {
-            throw HTTPError.connectionError("Http request was closed without returning a response.")
-        }
-
-        Log.verbose("Got response from \(endpointOverride?.host ?? endpointHostName) - response received: \(result)")
-
-        switch result {
-        case .error(let error):
-            throw error
-        case .response(let response):
-            return response
-        }
-    }
-
-    private struct AsyncErrorResult {
-        let error: Error?
-    }
-
-    /**
-     Submits a request that will not return a response body to this client synchronously.
-
-     - Parameters:
-     - endpointPath: The endpoint path for this request.
-     - httpMethod: The http method to use for this request.
-     - input: the input body data to send with this request.
-     - handlerDelegate: the delegate used to customize the request's channel handler.
-     - Throws: If an error occurred during the request.
-     */
-    public func executeSyncWithoutOutput<InputType>(
-            endpointOverride: URL? = nil,
-            endpointPath: String,
-            httpMethod: HTTPMethod,
-            input: InputType,
-            handlerDelegate: HTTPClientChannelInboundHandlerDelegate) throws
-            where InputType: HTTPRequestInputProtocol {
-        var responseError: AsyncErrorResult?
-        let completedSemaphore = DispatchSemaphore(value: 0)
-
-        let completion: (Error?) -> () = { error in
-            responseError = AsyncErrorResult(error: error)
-            completedSemaphore.signal()
-        }
-
-        let channel = try executeAsyncWithoutOutput(endpointOverride: endpointOverride,
-                                                    endpointPath: endpointPath,
-                                                    httpMethod: httpMethod,
-                                                    input: input,
-                                                    completion: completion,
-                                                    // the completion handler can be safely executed on a SwiftNIO thread
-                                                    asyncResponseInvocationStrategy: SameThreadAsyncResponseInvocationStrategy<Error?>(),
-                                                    handlerDelegate: handlerDelegate)
-
-        channel.closeFuture.whenComplete {
-            // if this channel is being closed and no response has been recorded
-            if responseError == nil {
-                responseError = AsyncErrorResult(error: HTTPClient.unexpectedClosureType)
-                completedSemaphore.signal()
-            }
-        }
-
-        completedSemaphore.wait()
-
-        if let error = responseError?.error {
-            throw error
-        }
+        self.stateLock.unlock()
+        
+        closedSemaphore.wait()
     }
 
     func executeAsync<InputType>(
@@ -388,7 +171,7 @@ public class HTTPClient {
             endpointPath: String,
             httpMethod: HTTPMethod,
             input: InputType,
-            completion: @escaping (HTTPResult<Data?>) -> (),
+            completion: @escaping (HTTPResult<HTTPResponseComponents>) -> (),
             handlerDelegate: HTTPClientChannelInboundHandlerDelegate) throws -> Channel
             where InputType: HTTPRequestInputProtocol {
 

--- a/Sources/SmokeHTTPClient/HTTPClientChannelInboundHandler.swift
+++ b/Sources/SmokeHTTPClient/HTTPClientChannelInboundHandler.swift
@@ -56,9 +56,9 @@ public final class HTTPClientChannelInboundHandler: ChannelInboundHandler {
     public var bodyParts: [ByteBuffer] = []
 
     /// A completion handler to pass any recieved response to.
-    private let completion: (HTTPResult<Data?>) -> ()
+    private let completion: (HTTPResult<HTTPResponseComponents>) -> ()
     /// A function that provides an Error based on the payload provided.
-    private let errorProvider: (HTTPResponseHead, Data) throws -> Error
+    private let errorProvider: (HTTPResponseHead, HTTPResponseComponents) throws -> Error
     /// Delegate that provides client-specific logic
     private let delegate: HTTPClientChannelInboundHandlerDelegate
 
@@ -81,8 +81,8 @@ public final class HTTPClientChannelInboundHandler: ChannelInboundHandler {
          httpMethod: HTTPMethod,
          bodyData: Data,
          additionalHeaders: [(String, String)],
-         errorProvider: @escaping (HTTPResponseHead, Data) throws -> Error,
-         completion: @escaping (HTTPResult<Data?>) -> (),
+         errorProvider: @escaping (HTTPResponseHead, HTTPResponseComponents) throws -> Error,
+         completion: @escaping (HTTPResult<HTTPResponseComponents>) -> (),
          channelInboundHandlerDelegate: HTTPClientChannelInboundHandlerDelegate) {
         self.contentType = contentType
         self.endpointUrl = endpointUrl
@@ -118,6 +118,14 @@ public final class HTTPClientChannelInboundHandler: ChannelInboundHandler {
             // handle this response
             handleCompleteResponse(context: ctx)
         }
+    }
+    
+    private func getHeadersFromResponse(header: HTTPResponseHead) -> [(String, String)] {
+        let headers: [(String, String)] = header.headers.map { header in
+            return (header.name, header.value)
+        }
+        
+        return headers
     }
 
     /*
@@ -158,6 +166,10 @@ public final class HTTPClientChannelInboundHandler: ChannelInboundHandler {
             completion(.error(error))
             return
         }
+        
+        let headers = getHeadersFromResponse(header: responseHead)
+        let responseComponents = HTTPResponseComponents(headers: headers,
+                                                        body: responseBodyData)
 
         if let bodyData = responseBodyData {
             Log.verbose("Got response from endpoint: \(endpointUrl) and path: \(endpointPath) with " +
@@ -166,11 +178,19 @@ public final class HTTPClientChannelInboundHandler: ChannelInboundHandler {
             Log.verbose("Got response from endpoint: \(endpointUrl) and path: \(endpointPath) with " +
                 "headers: \(responseHead) and empty body.")
         }
+        
+        let isSuccess: Bool
+        switch responseHead.status {
+        case .ok, .created, .accepted, .nonAuthoritativeInformation, .noContent, .resetContent, .partialContent:
+            isSuccess = true
+        default:
+            isSuccess = false
+        }
 
         // if the response status is ok
-        if case .ok = responseHead.status {
+        if isSuccess {
             // complete with the response data (potentially empty)
-            completion(.response(responseBodyData))
+            completion(.response(responseComponents))
             return
         }
 
@@ -180,17 +200,10 @@ public final class HTTPClientChannelInboundHandler: ChannelInboundHandler {
             return
         }
 
-        // otherwise this is the error case
-        // If there is no body, can't know anything about the error
-        guard let bodyData = responseBodyData else {
-            completion(.error(HTTPError.unknownError("Error with status '\(responseHead.status)' with empty body")))
-            return
-        }
-
         let responseError: Error
         do {
             // attempt to get the error from the provider
-            responseError = try errorProvider(responseHead, bodyData)
+            responseError = try errorProvider(responseHead, responseComponents)
         } catch {
             // if the provider throws an error, use this error
             responseError = error
@@ -216,7 +229,6 @@ public final class HTTPClientChannelInboundHandler: ChannelInboundHandler {
     public func channelActive(ctx: ChannelHandlerContext) {
         Log.verbose("Preparing request on channel active.")
         var headers = delegate.addClientSpecificHeaders(handler: self)
-        headers.append(contentsOf: additionalHeaders)
 
         // TODO: Move headers out to HTTPClient for UrlRequest
         if bodyData.count > 0 || delegate.specifyContentHeadersForZeroLengthBody {

--- a/Sources/SmokeHTTPClient/HTTPClientDelegate.swift
+++ b/Sources/SmokeHTTPClient/HTTPClientDelegate.swift
@@ -40,7 +40,7 @@ public protocol HTTPClientDelegate {
         httpPath: String) throws -> HTTPRequestComponents
     where InputType: HTTPRequestInputProtocol
 
-    /// Gets the decoded ouput base on the response body.
+    /// Gets the decoded output base on the response body.
     func decodeOutput<OutputType>(output: Data?,
                                   headers: [(String, String)]) throws -> OutputType
     where OutputType: HTTPResponseOutputProtocol

--- a/Sources/SmokeHTTPClient/HTTPClientDelegate.swift
+++ b/Sources/SmokeHTTPClient/HTTPClientDelegate.swift
@@ -25,7 +25,8 @@ import NIOOpenSSL
 public protocol HTTPClientDelegate {
 
     /// Gets the error corresponding to a client response body on the response head and body data.
-    func getResponseError(responseHead: HTTPResponseHead, bodyData: Data) throws -> Error
+    func getResponseError(responseHead: HTTPResponseHead,
+                          responseComponents: HTTPResponseComponents) throws -> Error
 
     /**
      Gets the encoded input body and path with a query string for a client request.
@@ -40,7 +41,9 @@ public protocol HTTPClientDelegate {
     where InputType: HTTPRequestInputProtocol
 
     /// Gets the decoded ouput base on the response body.
-    func decodeOutput<OutputType: Decodable>(output: Data) throws -> OutputType
+    func decodeOutput<OutputType>(output: Data?,
+                                  headers: [(String, String)]) throws -> OutputType
+    where OutputType: HTTPResponseOutputProtocol
 
     /// Gets the TLS configuration required for HTTPClient's use-case.
     func getTLSConfiguration() -> TLSConfiguration

--- a/Sources/SmokeHTTPClient/HTTPRequestInputProtocol.swift
+++ b/Sources/SmokeHTTPClient/HTTPRequestInputProtocol.swift
@@ -11,7 +11,7 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 //
-//  HTTPRequestInput.swift
+//  HTTPRequestInputProtocol.swift
 //  SmokeHTTPClient
 //
 

--- a/Sources/SmokeHTTPClient/HTTPResponseComponents.swift
+++ b/Sources/SmokeHTTPClient/HTTPResponseComponents.swift
@@ -11,24 +11,21 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 //
-//  HTTPRequestComponents.swift
+//  HTTPResponseComponents.swift
 //  SmokeHTTPClient
 //
 
 import Foundation
 
 /// The parsed components that specify a request.
-public struct HTTPRequestComponents {
-    /// the path for the request including the query.
-    public let pathWithQuery: String
-    /// any request specific headers that needs to be added.
-    public let additionalHeaders: [(String, String)]
-    /// The body data of the request.
-    public let body: Data
+public struct HTTPResponseComponents {
+    /// any response headers.
+    public let headers: [(String, String)]
+    /// The body data of the response.
+    public let body: Data?
 
-    public init(pathWithQuery: String, additionalHeaders: [(String, String)], body: Data) {
-        self.pathWithQuery = pathWithQuery
-        self.additionalHeaders = additionalHeaders
+    public init(headers: [(String, String)], body: Data?) {
+        self.headers = headers
         self.body = body
     }
 }

--- a/Sources/SmokeHTTPClient/HTTPResponseOutputProtocol.swift
+++ b/Sources/SmokeHTTPClient/HTTPResponseOutputProtocol.swift
@@ -1,0 +1,37 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+//  HTTPResponseInputProtocol.swift
+//  SmokeHTTPClient
+//
+
+import Foundation
+
+/**
+ A protocol that represents output from a HTTP response.
+ */
+public protocol HTTPResponseOutputProtocol {
+    associatedtype BodyType: Decodable
+    associatedtype HeadersType: Decodable
+    
+    /**
+     Composes an instance from its constituent Decodable parts.
+     May return one of its constituent parts if of a compatible type.
+ 
+     - Parameters:
+        - bodyDecodableProvider: provider for the decoded body for this instance.
+        - headersDecodableProvider: provider for the decoded headers for this instance.
+     */
+    static func compose(bodyDecodableProvider: () throws -> BodyType,
+                        headersDecodableProvider: () throws -> HeadersType) throws -> Self
+}


### PR DESCRIPTION
*Issue #, if available:* #2 and #3

*Description of changes:*
* clean up HTTPClient by splitting into multiple files with extensions for the different APIs
* change the response conformance for the HTTPClient APIs from Decodable to a new protocol HTTPResponseInputProtocol that is equivalent to HTTPRequestInputProtocol but for responses. 
* expose the response headers to the HTTPClientDelegate to it can incorporate them into the response
* allow for empty body responses


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
