### PR TITLE
Allow http requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-<a href="https://travis-ci.org/amzn/smoke-http">
+<a href="https://travis-ci.com/amzn/smoke-http">
 <img src="https://travis-ci.com/amzn/smoke-http.svg?branch=master" alt="Build - Master Branch">
 </a>
 <img src="https://img.shields.io/badge/os-linux-green.svg?style=flat" alt="Linux">

--- a/Sources/SmokeHTTPClient/HTTPClientDelegate.swift
+++ b/Sources/SmokeHTTPClient/HTTPClientDelegate.swift
@@ -46,7 +46,9 @@ public protocol HTTPClientDelegate {
     where OutputType: HTTPResponseOutputProtocol
 
     /// Gets the TLS configuration required for HTTPClient's use-case.
-    func getTLSConfiguration() -> TLSConfiguration
+    /// If this function returns nil, the HTTPClient will send requests as
+    /// unencrypted http.
+    func getTLSConfiguration() -> TLSConfiguration?
 }
 
 public extension HTTPClientDelegate {


### PR DESCRIPTION
Allow http requests by returning an optional TLSConfiguration in the HTTPClientDelegate.

*Issue #, if available:*

*Description of changes:* Allow the HTTPClient to be used in situations where SSL transport is not required. Implemented this by making the TLSConfiguration returned by the HTTPClientDelegate optional and using the correct url scheme and adding the SSLHandler to the channel pipeline based on this.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
