### PR TITLE
Get a Shape related to a template from a Path

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio.git",
         "state": {
           "branch": null,
-          "revision": "a20e129c22ad00a51c902dca54a5456f90664780",
-          "version": "1.12.0"
+          "revision": "03c541a24dd0558c942b15d8464eb75d70a921c4",
+          "version": "1.12.1"
         }
       },
       {
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio-ssl.git",
         "state": {
           "branch": null,
-          "revision": "db16c3a90b101bb53b26a58867a344ad428072e0",
-          "version": "1.3.2"
+          "revision": "0f3999f3e3c359cc74480c292644c3419e44a12f",
+          "version": "1.4.0"
         }
       },
       {

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/IBM-Swift/LoggerAPI.git",
         "state": {
           "branch": null,
-          "revision": "5041f2673aa75d6e973d9b6bd3956bc5068387c8",
-          "version": "1.7.3"
+          "revision": "d0ccb4158b83f8692531892a9c894bb757593c6f",
+          "version": "1.8.0"
         }
       },
       {
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio.git",
         "state": {
           "branch": null,
-          "revision": "5d8148c8b45dfb449276557f22120694567dd1d2",
-          "version": "1.9.5"
+          "revision": "a20e129c22ad00a51c902dca54a5456f90664780",
+          "version": "1.12.0"
         }
       },
       {
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio-ssl.git",
         "state": {
           "branch": null,
-          "revision": "8380fa29a2af784b067d8ee01c956626ca29f172",
-          "version": "1.3.1"
+          "revision": "db16c3a90b101bb53b26a58867a344ad428072e0",
+          "version": "1.3.2"
         }
       },
       {

--- a/Sources/HTTPPathCoding/Array+getShapeForTemplate.swift
+++ b/Sources/HTTPPathCoding/Array+getShapeForTemplate.swift
@@ -1,0 +1,52 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+//  Array+getShapeForTemplate.swift
+//  HTTPPathCoding
+//
+
+import Foundation
+import ShapeCoding
+
+public extension Array where Element == String {
+    public func getShapeForTemplate(templateSegments: [HTTPPathSegment],
+                                    decoderOptions: StandardDecodingOptions = StandardDecodingOptions(
+                                                                                shapeKeyDecodingStrategy: .useAsShapeSeparator("."),
+                                                                                shapeMapDecodingStrategy: .singleShapeEntry)) throws -> Shape {
+        // reverse the arrays so we can use popLast to iterate in the forwards direction
+        var remainingPathSegments = Array(self.reversed())
+        var remainingTemplateSegments = [HTTPPathSegment](templateSegments.reversed())
+        var variables: [(String, String?)] = []
+        
+        // iterate through the path elements
+        while let templateSegment = remainingTemplateSegments.popLast() {
+            guard let pathSegment = remainingPathSegments.popLast() else {
+                throw HTTPPathDecoderErrors.pathDoesNotMatchTemplate("Path has fewer segments than template.")
+            }
+            
+            try templateSegment.parse(value: pathSegment,
+                                      variables: &variables,
+                                      remainingSegmentValues: &remainingPathSegments,
+                                      isLastSegment: remainingTemplateSegments.isEmpty)
+        }
+        
+        guard remainingPathSegments.isEmpty else {
+            throw HTTPPathDecoderErrors.pathDoesNotMatchTemplate("Path has more segments than template.")
+        }
+        
+        let stackValue = try StandardShapeParser.parse(with: variables,
+                                                       decoderOptions: decoderOptions)
+        
+        return stackValue
+    }
+}

--- a/Sources/HTTPPathCoding/HTTPPathToken.swift
+++ b/Sources/HTTPPathCoding/HTTPPathToken.swift
@@ -66,7 +66,7 @@ public enum HTTPPathToken {
                     }
                     tokens.append(.variable(name: tokenName, multiSegment: multiSegment))
                 } else {
-                    tokens.append(.string(String(thisToken)))
+                    tokens.append(.string(String(thisToken.lowercased())))
                 }
             } else if !tokens.isEmpty {
                 throw HTTPPathErrors.hasAdjoiningVariables

--- a/Tests/HTTPPathCodingTests/GetShapeForTemplateTests.swift
+++ b/Tests/HTTPPathCodingTests/GetShapeForTemplateTests.swift
@@ -1,0 +1,140 @@
+//
+//  GetShapeForTemplateTests.swift
+//  HTTPPathCodingTests
+//
+//  Created by Simon Pilkington on 1/8/19.
+//
+
+import Foundation
+
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+//  GetShapeForTemplateTests.swift
+//  HTTPPathCodingTests
+//
+
+import XCTest
+@testable import HTTPPathCoding
+import ShapeCoding
+
+class GetShapeForTemplateTests: XCTestCase {
+    
+    func verifySuccessfulShape(template: String, path: String) throws {
+        let templateSegments = try HTTPPathSegment.tokenize(template: template)
+        let pathSegments = HTTPPathSegment.getPathSegmentsForPath(uri: path)
+        
+        let expected: [String: Shape] = ["id": .string("cat"),
+                                         "index": .string("23")]
+        
+        let shape: Shape
+        do {
+            shape = try pathSegments.getShapeForTemplate(templateSegments: templateSegments)
+        } catch {
+            return XCTFail()
+        }
+        
+        guard case let .dictionary(values) = shape else {
+            return XCTFail()
+        }
+        
+        XCTAssertEqual(expected, values)
+    }
+    
+    func verifyUnsuccessfulShape(template: String, path: String) throws {
+        let templateSegments = try HTTPPathSegment.tokenize(template: template)
+        let pathSegments = HTTPPathSegment.getPathSegmentsForPath(uri: path)
+        
+        do {
+            _ = try pathSegments.getShapeForTemplate(templateSegments: templateSegments)
+            XCTFail()
+        } catch {
+            // expected failure
+        }
+    }
+    
+    func testBasicGetShape() throws {
+        let template = "person{id}address{index}street"
+        let path = "personcataddress23street"
+        
+        try verifySuccessfulShape(template: template, path: path)
+    }
+    
+    func testGetShapeWithSegments() throws {
+        let template = "person/{id}/address/{index}/street"
+        let path = "person/cat/address/23/street"
+        
+        try verifySuccessfulShape(template: template, path: path)
+    }
+    
+    func testCaseInsensitiveGetShape() throws {
+        let template = "person/{id}/adDRess/{index}/street"
+        let path = "Person/cat/address/23/Street"
+        
+        try verifySuccessfulShape(template: template, path: path)
+    }
+    
+    func testTooFewSegmentsGetShape() throws {
+        let template = "person/{id}/address/{index}/street"
+        let path = "person/cat/address"
+
+        try verifyUnsuccessfulShape(template: template, path: path)
+    }
+    
+    func testTooManySegmentsGetShape() throws {
+        let template = "person/{id}/address/{index}/street"
+        let path = "person/cat/address/23/street/number/13"
+
+        try verifyUnsuccessfulShape(template: template, path: path)
+    }
+    
+    func testNotMatchingGetShape() throws {
+        let template = "person/{id}/address/{index}/street"
+        let path = "person/cat/country/23/street"
+
+        try verifyUnsuccessfulShape(template: template, path: path)
+    }
+    
+    func testGreedyTokenGetShape() throws {
+        let template = "person/{id}/address/{index+}"
+        let path = "person/cat/address/23/street"
+        
+        let templateSegments = try HTTPPathSegment.tokenize(template: template)
+        let pathSegments = HTTPPathSegment.getPathSegmentsForPath(uri: path)
+        
+        let expected: [String: Shape] = ["id": .string("cat"),
+                                         "index": .string("23/street")]
+        
+        let shape: Shape
+        do {
+            shape = try pathSegments.getShapeForTemplate(templateSegments: templateSegments)
+        } catch {
+            return XCTFail()
+        }
+        
+        guard case let .dictionary(values) = shape else {
+            return XCTFail()
+        }
+        
+        XCTAssertEqual(expected, values)
+    }
+    
+    static var allTests = [
+        ("testBasicGetShape", testBasicGetShape),
+        ("testGetShapeWithSegments", testGetShapeWithSegments),
+        ("testCaseInsensitiveGetShape", testCaseInsensitiveGetShape),
+        ("testTooFewSegmentsGetShape", testTooFewSegmentsGetShape),
+        ("testTooManySegmentsGetShape", testTooManySegmentsGetShape),
+        ("testNotMatchingGetShape", testNotMatchingGetShape),
+        ]
+}

--- a/Tests/HTTPPathCodingTests/GetShapeForTemplateTests.swift
+++ b/Tests/HTTPPathCodingTests/GetShapeForTemplateTests.swift
@@ -1,12 +1,3 @@
-//
-//  GetShapeForTemplateTests.swift
-//  HTTPPathCodingTests
-//
-//  Created by Simon Pilkington on 1/8/19.
-//
-
-import Foundation
-
 // Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License").

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -29,4 +29,5 @@ XCTMain([
     testCase(HTTPPathEncoderTests.allTests),
     testCase(HTTPPathTokenTests.allTests),
     testCase(HTTPPathSegmentTests.allTests),
+    testCase(GetShapeForTemplateTests.allTests),
 ])


### PR DESCRIPTION
Move logic to get a Shape related to a template from a Path into a common function with case insensitive comparison. This logic is required for both the HTTPPathDecoder and higher level routing/handler selection. 

*Issue #, if available:*

*Description of changes:* Added unit tests to verify new functionality.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.