### PR TITLE
Request retry with exponential backoff

### DIFF
--- a/Sources/SmokeHTTPClient/HTTPClient+executeAsyncRetriableWithOutput.swift
+++ b/Sources/SmokeHTTPClient/HTTPClient+executeAsyncRetriableWithOutput.swift
@@ -1,0 +1,141 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+//  HTTPClient+executeAsyncRetriableWithOutput.swift
+//  SmokeHTTPClient
+//
+
+import Foundation
+import NIO
+import NIOHTTP1
+import NIOOpenSSL
+import NIOTLS
+import LoggerAPI
+
+public extension HTTPClient {
+    /**
+     Helper type that manages the state of a retriable async request.
+     */
+    private class ExecuteAsyncWithOutputRetriable<InputType, OutputType, InvocationStrategyType>
+            where InputType: HTTPRequestInputProtocol, InvocationStrategyType: AsyncResponseInvocationStrategy,
+            InvocationStrategyType.OutputType == HTTPResult<OutputType>,
+            OutputType: HTTPResponseOutputProtocol {
+        let endpointOverride: URL?
+        let endpointPath: String
+        let httpMethod: HTTPMethod
+        let input: InputType
+        let outerCompletion: (HTTPResult<OutputType>) -> ()
+        let asyncResponseInvocationStrategy: InvocationStrategyType
+        let handlerDelegate: HTTPClientChannelInboundHandlerDelegate
+        let httpClient: HTTPClient
+        let retryConfiguration: HTTPClientRetryConfiguration
+        let queue = DispatchQueue.global()
+        
+        var retriesRemaining: Int
+        
+        init(endpointOverride: URL?, endpointPath: String, httpMethod: HTTPMethod,
+             input: InputType, outerCompletion: @escaping (HTTPResult<OutputType>) -> (),
+             asyncResponseInvocationStrategy: InvocationStrategyType,
+             handlerDelegate: HTTPClientChannelInboundHandlerDelegate,
+             httpClient: HTTPClient,
+             retryConfiguration: HTTPClientRetryConfiguration) {
+            self.endpointOverride = endpointOverride
+            self.endpointPath = endpointPath
+            self.httpMethod = httpMethod
+            self.input = input
+            self.outerCompletion = outerCompletion
+            self.asyncResponseInvocationStrategy = asyncResponseInvocationStrategy
+            self.handlerDelegate = handlerDelegate
+            self.httpClient = httpClient
+            self.retryConfiguration = retryConfiguration
+            self.retriesRemaining = retryConfiguration.numRetries
+        }
+        
+        func executeAsyncWithOutput() throws {
+            // submit the asynchronous request
+            _ = try httpClient.executeAsyncWithOutput(endpointOverride: endpointOverride,
+                                                      endpointPath: endpointPath, httpMethod: httpMethod,
+                                                      input: input, completion: completion,
+                                                      asyncResponseInvocationStrategy: asyncResponseInvocationStrategy,
+                                                      handlerDelegate: handlerDelegate)
+        }
+        
+        func completion(innerResult: HTTPResult<OutputType>) {
+            let result: HTTPResult<OutputType>
+
+            switch innerResult {
+            case .error(let error):
+                // if there are retries remaining
+                if retriesRemaining > 0 {
+                    // determine the required interval
+                    let retryInterval = Int(retryConfiguration.getRetryInterval(retriesRemaining: retriesRemaining))
+                    
+                    retriesRemaining -= 1
+                    
+                    let deadline = DispatchTime.now() + .milliseconds(retryInterval)
+                    queue.asyncAfter(deadline: deadline) {
+                        do {
+                            // execute again
+                            try self.executeAsyncWithOutput()
+                            return
+                        } catch {
+                            // its attempting to retry causes an error; complete with the provided error
+                            self.outerCompletion(.error(error))
+                        }
+                    }
+                }
+                // its an error; complete with the provided error
+                result = .error(error)
+            case .response:
+                result = innerResult
+            }
+
+            outerCompletion(result)
+        }
+    }
+    
+    /**
+     Submits a request that will return a response body to this client asynchronously.
+
+     - Parameters:
+        - endpointPath: The endpoint path for this request.
+        - httpMethod: The http method to use for this request.
+        - input: the input body data to send with this request.
+        - completion: Completion handler called with the response body or any error.
+        - asyncResponseInvocationStrategy: The invocation strategy for the response from this request.
+        - handlerDelegate: the delegate used to customize the request's channel handler.
+        - retryConfiguration: the retry configuration for this request.
+     */
+    public func executeAsyncRetriableWithOutput<InputType, OutputType, InvocationStrategyType>(
+            endpointOverride: URL? = nil,
+            endpointPath: String,
+            httpMethod: HTTPMethod,
+            input: InputType,
+            completion: @escaping (HTTPResult<OutputType>) -> (),
+            asyncResponseInvocationStrategy: InvocationStrategyType,
+            handlerDelegate: HTTPClientChannelInboundHandlerDelegate,
+            retryConfiguration: HTTPClientRetryConfiguration) throws
+            where InputType: HTTPRequestInputProtocol, InvocationStrategyType: AsyncResponseInvocationStrategy,
+        InvocationStrategyType.OutputType == HTTPResult<OutputType>,
+        OutputType: HTTPResponseOutputProtocol {
+
+            let retriable = ExecuteAsyncWithOutputRetriable(
+                endpointOverride: endpointOverride, endpointPath: endpointPath,
+                httpMethod: httpMethod, input: input, outerCompletion: completion,
+                asyncResponseInvocationStrategy: asyncResponseInvocationStrategy,
+                handlerDelegate: handlerDelegate, httpClient: self,
+                retryConfiguration: retryConfiguration)
+            
+            try retriable.executeAsyncWithOutput()
+    }
+}

--- a/Sources/SmokeHTTPClient/HTTPClient+executeAsyncRetriableWithOutput.swift
+++ b/Sources/SmokeHTTPClient/HTTPClient+executeAsyncRetriableWithOutput.swift
@@ -106,6 +106,39 @@ public extension HTTPClient {
     
     /**
      Submits a request that will return a response body to this client asynchronously.
+     The completion handler's execution will be scheduled on DispatchQueue.global()
+     rather than executing on a thread from SwiftNIO.
+
+     - Parameters:
+        - endpointPath: The endpoint path for this request.
+        - httpMethod: The http method to use for this request.
+        - input: the input body data to send with this request.
+        - completion: Completion handler called with the response body or any error.
+        - handlerDelegate: the delegate used to customize the request's channel handler.
+        - retryConfiguration: the retry configuration for this request.
+     */
+    public func executeAsyncRetriableWithOutput<InputType, OutputType>(
+            endpointOverride: URL? = nil,
+            endpointPath: String,
+            httpMethod: HTTPMethod,
+            input: InputType,
+            completion: @escaping (HTTPResult<OutputType>) -> (),
+            handlerDelegate: HTTPClientChannelInboundHandlerDelegate,
+            retryConfiguration: HTTPClientRetryConfiguration) throws
+        where InputType: HTTPRequestInputProtocol, OutputType: HTTPResponseOutputProtocol {
+            try executeAsyncRetriableWithOutput(
+                endpointOverride: endpointOverride,
+                endpointPath: endpointPath,
+                httpMethod: httpMethod,
+                input: input,
+                completion: completion,
+                asyncResponseInvocationStrategy: GlobalDispatchQueueAsyncResponseInvocationStrategy<HTTPResult<OutputType>>(),
+                handlerDelegate: handlerDelegate,
+                retryConfiguration: retryConfiguration)
+    }
+    
+    /**
+     Submits a request that will return a response body to this client asynchronously.
 
      - Parameters:
         - endpointPath: The endpoint path for this request.

--- a/Sources/SmokeHTTPClient/HTTPClient+executeAsyncRetriableWithoutOutput.swift
+++ b/Sources/SmokeHTTPClient/HTTPClient+executeAsyncRetriableWithoutOutput.swift
@@ -103,6 +103,39 @@ public extension HTTPClient {
     }
     
     /**
+     Submits a request that will not return a response body to this client asynchronously.
+     The completion handler's execution will be scheduled on DispatchQueue.global()
+     rather than executing on a thread from SwiftNIO.
+     
+     - Parameters:
+        - endpointPath: The endpoint path for this request.
+        - httpMethod: The http method to use for this request.
+        - input: the input body data to send with this request.
+        - completion: Completion handler called with an error if one occurs or nil otherwise.
+        - handlerDelegate: the delegate used to customize the request's channel handler.
+        - retryConfiguration: the retry configuration for this request.
+     */
+    public func executeAsyncRetriableWithoutOutput<InputType>(
+        endpointOverride: URL? = nil,
+        endpointPath: String,
+        httpMethod: HTTPMethod,
+        input: InputType,
+        completion: @escaping (Error?) -> (),
+        handlerDelegate: HTTPClientChannelInboundHandlerDelegate,
+        retryConfiguration: HTTPClientRetryConfiguration) throws
+        where InputType: HTTPRequestInputProtocol {
+            try executeAsyncRetriableWithoutOutput(
+                endpointOverride: endpointOverride,
+                endpointPath: endpointPath,
+                httpMethod: httpMethod,
+                input: input,
+                completion: completion,
+                asyncResponseInvocationStrategy: GlobalDispatchQueueAsyncResponseInvocationStrategy<Error?>(),
+                handlerDelegate: handlerDelegate,
+                retryConfiguration: retryConfiguration)
+    }
+    
+    /**
      Submits a request that will return a response body to this client asynchronously.
 
      - Parameters:

--- a/Sources/SmokeHTTPClient/HTTPClient+executeAsyncRetriableWithoutOutput.swift
+++ b/Sources/SmokeHTTPClient/HTTPClient+executeAsyncRetriableWithoutOutput.swift
@@ -1,0 +1,138 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+//  HTTPClient+executeAsyncRetriableWithoutOutput.swift
+//  SmokeHTTPClient
+//
+
+import Foundation
+import NIO
+import NIOHTTP1
+import NIOOpenSSL
+import NIOTLS
+import LoggerAPI
+
+public extension HTTPClient {
+    /**
+     Helper type that manages the state of a retriable async request.
+     */
+    private class ExecuteAsyncWithoutOutputRetriable<InputType, InvocationStrategyType>
+            where InputType: HTTPRequestInputProtocol, InvocationStrategyType: AsyncResponseInvocationStrategy,
+            InvocationStrategyType.OutputType == Error? {
+        let endpointOverride: URL?
+        let endpointPath: String
+        let httpMethod: HTTPMethod
+        let input: InputType
+        let outerCompletion: (Error?) -> ()
+        let asyncResponseInvocationStrategy: InvocationStrategyType
+        let handlerDelegate: HTTPClientChannelInboundHandlerDelegate
+        let httpClient: HTTPClient
+        let retryConfiguration: HTTPClientRetryConfiguration
+        let queue = DispatchQueue.global()
+        
+        var retriesRemaining: Int
+        
+        init(endpointOverride: URL?, endpointPath: String, httpMethod: HTTPMethod,
+             input: InputType, outerCompletion: @escaping (Error?) -> (),
+             asyncResponseInvocationStrategy: InvocationStrategyType,
+             handlerDelegate: HTTPClientChannelInboundHandlerDelegate,
+             httpClient: HTTPClient,
+             retryConfiguration: HTTPClientRetryConfiguration) {
+            self.endpointOverride = endpointOverride
+            self.endpointPath = endpointPath
+            self.httpMethod = httpMethod
+            self.input = input
+            self.outerCompletion = outerCompletion
+            self.asyncResponseInvocationStrategy = asyncResponseInvocationStrategy
+            self.handlerDelegate = handlerDelegate
+            self.httpClient = httpClient
+            self.retryConfiguration = retryConfiguration
+            self.retriesRemaining = retryConfiguration.numRetries
+        }
+        
+        func executeAsyncWithoutOutput() throws {
+            // submit the asynchronous request
+            _ = try httpClient.executeAsyncWithoutOutput(endpointOverride: endpointOverride,
+                                                         endpointPath: endpointPath, httpMethod: httpMethod,
+                                                         input: input, completion: completion,
+                                                         asyncResponseInvocationStrategy: asyncResponseInvocationStrategy,
+                                                         handlerDelegate: handlerDelegate)
+        }
+        
+        func completion(innerError: Error?) {
+            let error: Error?
+
+            if let innerError = innerError {
+                // if there are retries remaining
+                if retriesRemaining > 0 {
+                    // determine the required interval
+                    let retryInterval = Int(retryConfiguration.getRetryInterval(retriesRemaining: retriesRemaining))
+                    
+                    retriesRemaining -= 1
+                    
+                    let deadline = DispatchTime.now() + .milliseconds(retryInterval)
+                    queue.asyncAfter(deadline: deadline) {
+                        do {
+                            // execute again
+                            try self.executeAsyncWithoutOutput()
+                            return
+                        } catch {
+                            // its attempting to retry causes an error; complete with the provided error
+                            self.outerCompletion(innerError)
+                        }
+                    }
+                }
+                // its an error; complete with the provided error
+                error = innerError
+            } else {
+                error = innerError
+            }
+
+            outerCompletion(error)
+        }
+    }
+    
+    /**
+     Submits a request that will return a response body to this client asynchronously.
+
+     - Parameters:
+        - endpointPath: The endpoint path for this request.
+        - httpMethod: The http method to use for this request.
+        - input: the input body data to send with this request.
+        - completion: Completion handler called with the response body or any error.
+        - asyncResponseInvocationStrategy: The invocation strategy for the response from this request.
+        - handlerDelegate: the delegate used to customize the request's channel handler.
+        - retryConfiguration: the retry configuration for this request.
+     */
+    public func executeAsyncRetriableWithoutOutput<InputType, InvocationStrategyType>(
+        endpointOverride: URL? = nil,
+        endpointPath: String,
+        httpMethod: HTTPMethod,
+        input: InputType,
+        completion: @escaping (Error?) -> (),
+        asyncResponseInvocationStrategy: InvocationStrategyType,
+        handlerDelegate: HTTPClientChannelInboundHandlerDelegate,
+        retryConfiguration: HTTPClientRetryConfiguration) throws
+        where InputType: HTTPRequestInputProtocol, InvocationStrategyType: AsyncResponseInvocationStrategy,
+        InvocationStrategyType.OutputType == Error? {
+
+            let retriable = ExecuteAsyncWithoutOutputRetriable(
+                endpointOverride: endpointOverride, endpointPath: endpointPath,
+                httpMethod: httpMethod, input: input, outerCompletion: completion,
+                asyncResponseInvocationStrategy: asyncResponseInvocationStrategy,
+                handlerDelegate: handlerDelegate, httpClient: self,
+                retryConfiguration: retryConfiguration)
+            
+            try retriable.executeAsyncWithoutOutput()
+    }
+}

--- a/Sources/SmokeHTTPClient/HTTPClient+executeSyncRetriableWithOutput.swift
+++ b/Sources/SmokeHTTPClient/HTTPClient+executeSyncRetriableWithOutput.swift
@@ -1,0 +1,114 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+//  HTTPClient+executeSyncRetriableWithOutput.swift
+//  SmokeHTTPClient
+//
+
+import Foundation
+import NIO
+import NIOHTTP1
+import NIOOpenSSL
+import NIOTLS
+import LoggerAPI
+
+public extension HTTPClient {
+    /**
+     Helper type that manages the state of a retriable sync request.
+     */
+    private class ExecuteSyncWithOutputRetriable<InputType, OutputType>
+            where InputType: HTTPRequestInputProtocol,
+            OutputType: HTTPResponseOutputProtocol {
+        let endpointOverride: URL?
+        let endpointPath: String
+        let httpMethod: HTTPMethod
+        let input: InputType
+        let handlerDelegate: HTTPClientChannelInboundHandlerDelegate
+        let httpClient: HTTPClient
+        let retryConfiguration: HTTPClientRetryConfiguration
+        
+        var retriesRemaining: Int
+        
+        let milliToMicroSeconds = 1000
+        
+        init(endpointOverride: URL?, endpointPath: String, httpMethod: HTTPMethod,
+             input: InputType,
+             handlerDelegate: HTTPClientChannelInboundHandlerDelegate,
+             httpClient: HTTPClient,
+             retryConfiguration: HTTPClientRetryConfiguration) {
+            self.endpointOverride = endpointOverride
+            self.endpointPath = endpointPath
+            self.httpMethod = httpMethod
+            self.input = input
+            self.handlerDelegate = handlerDelegate
+            self.httpClient = httpClient
+            self.retryConfiguration = retryConfiguration
+            self.retriesRemaining = retryConfiguration.numRetries
+        }
+        
+        func executeSyncWithOutput() throws -> OutputType {
+            do {
+                // submit the synchronous request
+                return try httpClient.executeSyncWithOutput(endpointOverride: endpointOverride,
+                                                              endpointPath: endpointPath, httpMethod: httpMethod,
+                                                              input: input, handlerDelegate: handlerDelegate)
+            } catch {
+                return try completeOnError(error: error)
+            }
+        }
+        
+        func completeOnError(error: Error) throws -> OutputType {
+            // if there are retries remaining
+            if retriesRemaining > 0 {
+                // determine the required interval
+                let retryInterval = Int(retryConfiguration.getRetryInterval(retriesRemaining: retriesRemaining))
+                
+                retriesRemaining -= 1
+                
+                usleep(useconds_t(retryInterval * milliToMicroSeconds))
+                return try executeSyncWithOutput()
+            } else {
+                throw error
+            }
+        }
+    }
+    
+    /**
+     Submits a request that will return a response body to this client synchronously.
+
+     - Parameters:
+        - endpointPath: The endpoint path for this request.
+        - httpMethod: The http method to use for this request.
+        - input: the input body data to send with this request.
+        - handlerDelegate: the delegate used to customize the request's channel handler.
+        - retryConfiguration: the retry configuration for this request.
+     */
+    public func executeSyncRetriableWithOutput<InputType, OutputType>(
+        endpointOverride: URL? = nil,
+        endpointPath: String,
+        httpMethod: HTTPMethod,
+        input: InputType,
+        handlerDelegate: HTTPClientChannelInboundHandlerDelegate,
+        retryConfiguration: HTTPClientRetryConfiguration) throws -> OutputType
+        where InputType: HTTPRequestInputProtocol,
+        OutputType: HTTPResponseOutputProtocol {
+
+            let retriable = ExecuteSyncWithOutputRetriable<InputType, OutputType>(
+                endpointOverride: endpointOverride, endpointPath: endpointPath,
+                httpMethod: httpMethod, input: input,
+                handlerDelegate: handlerDelegate, httpClient: self,
+                retryConfiguration: retryConfiguration)
+            
+            return try retriable.executeSyncWithOutput()
+    }
+}

--- a/Sources/SmokeHTTPClient/HTTPClient+executeSyncRetriableWithoutOutput.swift
+++ b/Sources/SmokeHTTPClient/HTTPClient+executeSyncRetriableWithoutOutput.swift
@@ -1,0 +1,112 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+//  HTTPClient+executeSyncRetriableWithoutOutput.swift
+//  SmokeHTTPClient
+//
+
+import Foundation
+import NIO
+import NIOHTTP1
+import NIOOpenSSL
+import NIOTLS
+import LoggerAPI
+
+public extension HTTPClient {
+    /**
+     Helper type that manages the state of a retriable sync request.
+     */
+    private class ExecuteSyncWithoutOutputRetriable<InputType>
+            where InputType: HTTPRequestInputProtocol {
+        let endpointOverride: URL?
+        let endpointPath: String
+        let httpMethod: HTTPMethod
+        let input: InputType
+        let handlerDelegate: HTTPClientChannelInboundHandlerDelegate
+        let httpClient: HTTPClient
+        let retryConfiguration: HTTPClientRetryConfiguration
+        
+        var retriesRemaining: Int
+        
+        let milliToMicroSeconds = 1000
+        
+        init(endpointOverride: URL?, endpointPath: String, httpMethod: HTTPMethod,
+             input: InputType,
+             handlerDelegate: HTTPClientChannelInboundHandlerDelegate,
+             httpClient: HTTPClient,
+             retryConfiguration: HTTPClientRetryConfiguration) {
+            self.endpointOverride = endpointOverride
+            self.endpointPath = endpointPath
+            self.httpMethod = httpMethod
+            self.input = input
+            self.handlerDelegate = handlerDelegate
+            self.httpClient = httpClient
+            self.retryConfiguration = retryConfiguration
+            self.retriesRemaining = retryConfiguration.numRetries
+        }
+        
+        func executeSyncWithoutOutput() throws {
+            do {
+                // submit the synchronous request
+                try httpClient.executeSyncWithoutOutput(endpointOverride: endpointOverride,
+                                                              endpointPath: endpointPath, httpMethod: httpMethod,
+                                                              input: input, handlerDelegate: handlerDelegate)
+            } catch {
+                return try completeOnError(error: error)
+            }
+        }
+        
+        func completeOnError(error: Error) throws {
+            // if there are retries remaining
+            if retriesRemaining > 0 {
+                // determine the required interval
+                let retryInterval = Int(retryConfiguration.getRetryInterval(retriesRemaining: retriesRemaining))
+                
+                retriesRemaining -= 1
+                
+                usleep(useconds_t(retryInterval * milliToMicroSeconds))
+                return try executeSyncWithoutOutput()
+            } else {
+                throw error
+            }
+        }
+    }
+    
+    /**
+     Submits a request that will return a response body to this client synchronously.
+
+     - Parameters:
+        - endpointPath: The endpoint path for this request.
+        - httpMethod: The http method to use for this request.
+        - input: the input body data to send with this request.
+        - handlerDelegate: the delegate used to customize the request's channel handler.
+        - retryConfiguration: the retry configuration for this request.
+     */
+    public func executeSyncRetriableWithoutOutput<InputType>(
+        endpointOverride: URL? = nil,
+        endpointPath: String,
+        httpMethod: HTTPMethod,
+        input: InputType,
+        handlerDelegate: HTTPClientChannelInboundHandlerDelegate,
+        retryConfiguration: HTTPClientRetryConfiguration) throws
+        where InputType: HTTPRequestInputProtocol {
+
+            let retriable = ExecuteSyncWithoutOutputRetriable<InputType>(
+                endpointOverride: endpointOverride, endpointPath: endpointPath,
+                httpMethod: httpMethod, input: input,
+                handlerDelegate: handlerDelegate, httpClient: self,
+                retryConfiguration: retryConfiguration)
+            
+            return try retriable.executeSyncWithoutOutput()
+    }
+}

--- a/Sources/SmokeHTTPClient/HTTPClient+executeSyncRetriableWithoutOutput.swift
+++ b/Sources/SmokeHTTPClient/HTTPClient+executeSyncRetriableWithoutOutput.swift
@@ -22,6 +22,12 @@ import NIOOpenSSL
 import NIOTLS
 import LoggerAPI
 
+private extension Int {
+    var milliFromMicroSeconds: Int {
+        return self * 1000
+    }
+}
+
 public extension HTTPClient {
     /**
      Helper type that manages the state of a retriable sync request.
@@ -37,8 +43,6 @@ public extension HTTPClient {
         let retryConfiguration: HTTPClientRetryConfiguration
         
         var retriesRemaining: Int
-        
-        let milliToMicroSeconds = 1000
         
         init(endpointOverride: URL?, endpointPath: String, httpMethod: HTTPMethod,
              input: InputType,
@@ -74,7 +78,7 @@ public extension HTTPClient {
                 
                 retriesRemaining -= 1
                 
-                usleep(useconds_t(retryInterval * milliToMicroSeconds))
+                usleep(useconds_t(retryInterval.milliFromMicroSeconds))
                 return try executeSyncWithoutOutput()
             } else {
                 throw error

--- a/Sources/SmokeHTTPClient/HTTPClientRetryConfiguration.swift
+++ b/Sources/SmokeHTTPClient/HTTPClientRetryConfiguration.swift
@@ -63,7 +63,7 @@ public struct HTTPClientRetryConfiguration {
                 return Int.random(in: 0 ..< boundedMsInterval)
             #else
                 #if os(Linux)
-                    return random() % boundedMsInterval
+                    return random() % Int(boundedMsInterval)
                 #else
                     return arc4random_uniform(boundedMsInterval)
                 #endif

--- a/Sources/SmokeHTTPClient/HTTPClientRetryConfiguration.swift
+++ b/Sources/SmokeHTTPClient/HTTPClientRetryConfiguration.swift
@@ -63,7 +63,7 @@ public struct HTTPClientRetryConfiguration {
                 return Int.random(in: 0 ..< boundedMsInterval)
             #else
                 #if os(Linux)
-                    return random() % Int(boundedMsInterval)
+                    return RetryInterval(random() % Int(boundedMsInterval))
                 #else
                     return arc4random_uniform(boundedMsInterval)
                 #endif

--- a/Sources/SmokeHTTPClient/HTTPClientRetryConfiguration.swift
+++ b/Sources/SmokeHTTPClient/HTTPClientRetryConfiguration.swift
@@ -59,7 +59,15 @@ public struct HTTPClientRetryConfiguration {
         let boundedMsInterval = min(maxRetryInterval, msInterval)
         
         if jitter {
-            return arc4random_uniform(boundedMsInterval)
+            #if swift(>=4.2)
+                return Int.random(in: 0 ..< boundedMsInterval)
+            #else
+                #if os(Linux)
+                    return random() % boundedMsInterval
+                #else
+                    return arc4random_uniform(boundedMsInterval)
+                #endif
+            #endif
         }
         
         return boundedMsInterval

--- a/Sources/SmokeHTTPClient/HTTPClientRetryConfiguration.swift
+++ b/Sources/SmokeHTTPClient/HTTPClientRetryConfiguration.swift
@@ -1,0 +1,75 @@
+// Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+//  HTTPClientRetryConfiguration.swift
+//  SmokeHTTPClient
+//
+
+import Foundation
+
+/// Type alias for a retry interval.
+public typealias RetryInterval = UInt32
+
+/**
+ Retry configuration for the requests made by a HTTPClient.
+ */
+public struct HTTPClientRetryConfiguration {
+    // Number of retries to be attempted
+    public let numRetries: Int
+    // First interval of retry in millis
+    public let baseRetryInterval: RetryInterval
+    // Max amount of cumulative time to attempt retries in millis
+    public let maxRetryInterval: RetryInterval
+    // Exponential backoff for each retry
+    public let exponentialBackoff: Double
+    // Ramdomized backoff
+    public let jitter: Bool
+ 
+    /**
+     Initializer.
+ 
+     - Parameters:
+         - numRetries: number of retries to be attempted.
+         - baseRetryInterval: first interval of retry in millis.
+         - maxRetryInterval: max amount of cumulative time to attempt retries in millis
+         - exponentialBackoff: exponential backoff for each retry
+         - jitter: ramdomized backoff
+     */
+    public init(numRetries: Int, baseRetryInterval: RetryInterval, maxRetryInterval: RetryInterval,
+                exponentialBackoff: Double, jitter: Bool = true) {
+        self.numRetries = numRetries
+        self.baseRetryInterval = baseRetryInterval
+        self.maxRetryInterval = maxRetryInterval
+        self.exponentialBackoff = exponentialBackoff
+        self.jitter = jitter
+    }
+    
+    public func getRetryInterval(retriesRemaining: Int) -> RetryInterval {
+        let msInterval = RetryInterval(pow(exponentialBackoff, Double(numRetries - retriesRemaining)))
+        let boundedMsInterval = min(maxRetryInterval, msInterval)
+        
+        if jitter {
+            return arc4random_uniform(boundedMsInterval)
+        }
+        
+        return boundedMsInterval
+    }
+ 
+    /// Default try configuration with 5 retries starting at 500 ms interval.
+    public static var `default` = HTTPClientRetryConfiguration(numRetries: 5, baseRetryInterval: 500,
+                                                               maxRetryInterval: 10000, exponentialBackoff: 2)
+ 
+    /// Retry Configuration with no retries.
+    public static var noRetries = HTTPClientRetryConfiguration(numRetries: 0, baseRetryInterval: 0,
+                                                               maxRetryInterval: 0, exponentialBackoff: 0)
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Add functions to HTTPClient that accept a RetryConfiguration and handle automatically retrying a request on failure.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
