### PR TITLE
On retry requests if a retryable error is returned

### DIFF
--- a/Sources/SmokeHTTPClient/HTTPClient+executeSyncRetriableWithoutOutput.swift
+++ b/Sources/SmokeHTTPClient/HTTPClient+executeSyncRetriableWithoutOutput.swift
@@ -41,6 +41,7 @@ public extension HTTPClient {
         let handlerDelegate: HTTPClientChannelInboundHandlerDelegate
         let httpClient: HTTPClient
         let retryConfiguration: HTTPClientRetryConfiguration
+        let retryOnError: (Swift.Error) -> Bool
         
         var retriesRemaining: Int
         
@@ -48,7 +49,8 @@ public extension HTTPClient {
              input: InputType,
              handlerDelegate: HTTPClientChannelInboundHandlerDelegate,
              httpClient: HTTPClient,
-             retryConfiguration: HTTPClientRetryConfiguration) {
+             retryConfiguration: HTTPClientRetryConfiguration,
+             retryOnError: @escaping (Swift.Error) -> Bool) {
             self.endpointOverride = endpointOverride
             self.endpointPath = endpointPath
             self.httpMethod = httpMethod
@@ -57,6 +59,7 @@ public extension HTTPClient {
             self.httpClient = httpClient
             self.retryConfiguration = retryConfiguration
             self.retriesRemaining = retryConfiguration.numRetries
+            self.retryOnError = retryOnError
         }
         
         func executeSyncWithoutOutput() throws {
@@ -71,16 +74,28 @@ public extension HTTPClient {
         }
         
         func completeOnError(error: Error) throws {
-            // if there are retries remaining
-            if retriesRemaining > 0 {
+            let shouldRetryOnError = retryOnError(error)
+            
+            // if there are retries remaining and we should retry on this error
+            if retriesRemaining > 0 && shouldRetryOnError {
                 // determine the required interval
                 let retryInterval = Int(retryConfiguration.getRetryInterval(retriesRemaining: retriesRemaining))
                 
+                let currentRetriesRemaining = retriesRemaining
                 retriesRemaining -= 1
                 
+                Log.debug("Request failed with error: \(error). Remaining retries: \(currentRetriesRemaining). "
+                        + "Retrying in \(retryInterval) ms.")
                 usleep(useconds_t(retryInterval.milliFromMicroSeconds))
+                Log.debug("Reattempting request due to remaining retries: \(currentRetriesRemaining)")
                 return try executeSyncWithoutOutput()
             } else {
+                if !shouldRetryOnError {
+                    Log.debug("Request not retried due to error returned: \(error)")
+                } else {
+                    Log.debug("Request not retried due to maximum retries: \(retryConfiguration.numRetries)")
+                }
+                
                 throw error
             }
         }
@@ -95,6 +110,7 @@ public extension HTTPClient {
         - input: the input body data to send with this request.
         - handlerDelegate: the delegate used to customize the request's channel handler.
         - retryConfiguration: the retry configuration for this request.
+        - retryOnError: function that should return if the provided error is retryable.
      */
     public func executeSyncRetriableWithoutOutput<InputType>(
         endpointOverride: URL? = nil,
@@ -102,14 +118,16 @@ public extension HTTPClient {
         httpMethod: HTTPMethod,
         input: InputType,
         handlerDelegate: HTTPClientChannelInboundHandlerDelegate,
-        retryConfiguration: HTTPClientRetryConfiguration) throws
+        retryConfiguration: HTTPClientRetryConfiguration,
+        retryOnError: @escaping (Swift.Error) -> Bool) throws
         where InputType: HTTPRequestInputProtocol {
 
             let retriable = ExecuteSyncWithoutOutputRetriable<InputType>(
                 endpointOverride: endpointOverride, endpointPath: endpointPath,
                 httpMethod: httpMethod, input: input,
                 handlerDelegate: handlerDelegate, httpClient: self,
-                retryConfiguration: retryConfiguration)
+                retryConfiguration: retryConfiguration,
+                retryOnError: retryOnError)
             
             return try retriable.executeSyncWithoutOutput()
     }


### PR DESCRIPTION
Pass a function into the HTTPClient retryable functions to indicate if the error returned is retryable.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
