### PR TITLE
Add a RawShape enumeration 

### DIFF
--- a/Sources/ShapeCoding/RawShape.swift
+++ b/Sources/ShapeCoding/RawShape.swift
@@ -1,0 +1,79 @@
+// Copyright 2018-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+//  RawShape.swift
+//  ShapeCoding
+//
+
+import Foundation
+
+/**
+ An enumeration of possible types of a shape that retains the original decoded structure.
+ Compared to the `Shape` enumeration, there a difference in how arrays are stored - `Shape`
+ stores arrays as a dictionary of values keyed by a 1-based index. `RawShape` separates
+ the definition of dictionaries and arrays, each in their original form.
+ */
+public enum RawShape: Equatable, Codable {
+    case dictionary([String: RawShape])
+    case array([RawShape])
+    case string(String)
+    
+    public init(from decoder: Decoder) throws {
+        do {
+            let theDictionary = try [String: RawShape](from: decoder)
+            
+            self = .dictionary(theDictionary)
+        } catch {
+            do {
+                let theArray = try [RawShape](from: decoder)
+                
+                self = .array(theArray)
+            } catch {
+                let theString = try String(from: decoder)
+                
+                self = .string(theString)
+            }
+        }
+    }
+    
+    public func encode(to encoder: Encoder) throws {
+        switch self {
+        case .string(let string):
+            try string.encode(to: encoder)
+        case .array(let array):
+            try array.encode(to: encoder)
+        case .dictionary(let map):
+            try map.encode(to: encoder)
+        }
+    }
+    
+    /// Converts an instance of this enumeration to its corresponding `Shape`.
+    public var asShape: Shape {
+        switch self {
+        case .string(let string):
+            return .string(string)
+        case .dictionary(let dictionary):
+            let transformedDictionary = dictionary.mapValues{ $0.asShape }
+            
+            return .dictionary(transformedDictionary)
+        case .array(let array):
+            var transformedDictionary: [String: Shape] = [:]
+            // map each value in the array to the dictionary keyed by its 1-based index
+            array.enumerated().forEach { (entry) in
+                transformedDictionary["\(entry.offset + 1)"] = entry.element.asShape
+            }
+            
+            return .dictionary(transformedDictionary)
+        }
+    }
+}

--- a/Sources/ShapeCoding/ShapeElement.swift
+++ b/Sources/ShapeCoding/ShapeElement.swift
@@ -37,6 +37,13 @@ public protocol ShapeElement {
          - elements: the array to append elements from this element to.
      */
     func getSerializedElements(_ key: String?, isRoot: Bool, elements: inout [(String, String?)]) throws
+    
+    /**
+     Function to return the `RawShape` instance that represents this `ShapeElement`.
+ 
+     - Returns: the corresponding `RawShape` instance.
+     */
+    func asRawShape() throws -> RawShape
 }
 
 /// Conform String to the `ShapeElement` protocol such that it returns itself as
@@ -47,6 +54,10 @@ extension String: ShapeElement {
         } else {
             throw ShapeEncoderError.typeNotShapeCompatible("String cannot be used as a shape element without a key")
         }
+    }
+    
+    public func asRawShape() throws -> RawShape {
+        return .string(self)
     }
 }
 

--- a/Sources/ShapeCoding/ShapeSingleValueEncodingContainer.swift
+++ b/Sources/ShapeCoding/ShapeSingleValueEncodingContainer.swift
@@ -184,6 +184,10 @@ extension ShapeSingleValueEncodingContainer: ShapeElement {
             isRoot: isRoot,
             elements: &elements)
     }
+    
+    public func asRawShape() throws -> RawShape {
+        return try delegate.rawShapeForEncodingContainer(containerValue: containerValue)
+    }
 }
 
 extension ShapeSingleValueEncodingContainer: Swift.Encoder {

--- a/Sources/ShapeCoding/ShapeSingleValueEncodingContainerDelegate.swift
+++ b/Sources/ShapeCoding/ShapeSingleValueEncodingContainerDelegate.swift
@@ -36,4 +36,13 @@ public protocol ShapeSingleValueEncodingContainerDelegate {
         key: String?,
         isRoot: Bool,
         elements: inout [(String, String?)]) throws
+    
+    /**
+     Function to return the `RawShape` instance that represents the provider `ContainerValueType`.
+ 
+     - Parameters:
+        - containerValue: the containerValue to return the `RawShape` for.
+     - Returns: the corresponding `RawShape` instance.
+     */
+    func rawShapeForEncodingContainer(containerValue: ContainerValueType?) throws -> RawShape
 }

--- a/Sources/ShapeCoding/StandardShapeSingleValueEncodingContainerDelegate.swift
+++ b/Sources/ShapeCoding/StandardShapeSingleValueEncodingContainerDelegate.swift
@@ -90,4 +90,25 @@ ShapeSingleValueEncodingContainerDelegate {
             }
         }
     }
+    
+    public func rawShapeForEncodingContainer(containerValue: ContainerValueType?) throws -> RawShape {
+        // the encoding process must have placed a value in this container
+        guard let containerValue = containerValue else {
+            fatalError("Attempted to access uninitialized container.")
+        }
+        
+        switch containerValue {
+        case .singleValue(let value):
+            // get the raw shape for container value
+            return try value.asRawShape()
+        case .unkeyedContainer(let values):
+            let transformedArray = try values.map { try $0.asRawShape() }
+            
+            return .array(transformedArray)
+        case .keyedContainer(let values):
+            let transformedDictionary = try values.mapValues { try $0.asRawShape() }
+            
+            return .dictionary(transformedDictionary)
+        }
+    }
 }


### PR DESCRIPTION
*Description of changes:* Add a RawShape enumeration with the ability to extract the original decoded form (string, nested array, nested dictionary from a `ShapeSingleValueEncodingContainer` RawShape conforms to `Codable`, allowing easier interoperability with other encoders/decoders such as JSONDecoder/JSONEncoder.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
