### PR TITLE
Fixed for a fatal error in retry logic

### DIFF
--- a/Sources/SmokeHTTPClient/HTTPClientRetryConfiguration.swift
+++ b/Sources/SmokeHTTPClient/HTTPClientRetryConfiguration.swift
@@ -61,7 +61,11 @@ public struct HTTPClientRetryConfiguration {
         
         if jitter {
             #if swift(>=4.2)
-                return Int.random(in: 0 ..< boundedMsInterval)
+                if boundedMsInterval > 0 {
+                        return RetryInterval.random(in: 0 ..< boundedMsInterval)
+                } else {
+                    return 0
+                }
             #else
                 #if os(Linux)
                     return RetryInterval(random() % Int(boundedMsInterval))


### PR DESCRIPTION


*Issue #, if available:*

*Description of changes:* Fixed for a fatal error when the retry configuration as 0 as the upper bound retry duration.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
