### PR TITLE
Add a key transform strategy for encoding and decoding shapes.

### DIFF
--- a/Sources/HTTPHeadersCoding/HTTPHeadersDecoder.swift
+++ b/Sources/HTTPHeadersCoding/HTTPHeadersDecoder.swift
@@ -26,6 +26,7 @@ public struct HTTPHeadersDecoder {
     private let userInfo: [CodingUserInfoKey: Any]
     
     public typealias KeyDecodingStrategy = ShapeKeyDecodingStrategy
+    public typealias KeyDecodeTransformStrategy = ShapeKeyDecodeTransformStrategy
     
     /// The strategy to use for decoding maps.
     public enum MapDecodingStrategy {
@@ -57,13 +58,16 @@ public struct HTTPHeadersDecoder {
      - Parameters:
         - keyDecodingStrategy: the `KeyDecodingStrategy` to use for decoding.
         - mapDecodingStrategy: the `MapDecodingStrategy` to use for decoding.
+        - keyDecodeTransformStrategy: the `KeyDecodeTransformStrategy` to use for decoding.
      */
     public init(userInfo: [CodingUserInfoKey: Any] = [:],
                 keyDecodingStrategy: KeyDecodingStrategy = .useAsShapeSeparator("-"),
-                mapDecodingStrategy: MapDecodingStrategy = .singleHeader) {
+                mapDecodingStrategy: MapDecodingStrategy = .singleHeader,
+                keyDecodeTransformStrategy: KeyDecodeTransformStrategy = .none) {
         self.options = StandardDecodingOptions(
             shapeKeyDecodingStrategy: keyDecodingStrategy,
-            shapeMapDecodingStrategy: mapDecodingStrategy.shapeMapDecodingStrategy)
+            shapeMapDecodingStrategy: mapDecodingStrategy.shapeMapDecodingStrategy,
+            shapeKeyDecodeTransformStrategy: keyDecodeTransformStrategy)
         self.userInfo = userInfo
     }
     

--- a/Sources/HTTPHeadersCoding/HTTPHeadersEncoder.swift
+++ b/Sources/HTTPHeadersCoding/HTTPHeadersEncoder.swift
@@ -72,11 +72,11 @@ public class HTTPHeadersEncoder {
      */
     public init(keyEncodingStrategy: KeyEncodingStrategy = .useAsShapeSeparator("-"),
                 mapEncodingStrategy: MapEncodingStrategy = .singleHeader,
-                KeyEncodeTransformStrategy: KeyEncodeTransformStrategy = .none) {
+                keyEncodeTransformStrategy: KeyEncodeTransformStrategy = .none) {
         self.options = StandardEncodingOptions(
             shapeKeyEncodingStrategy: keyEncodingStrategy,
             shapeMapEncodingStrategy: mapEncodingStrategy.shapeMapEncodingStrategy,
-            shapeKeyEncodeTransformStrategy: KeyEncodeTransformStrategy)
+            shapeKeyEncodeTransformStrategy: keyEncodeTransformStrategy)
     }
 
     /**

--- a/Sources/HTTPHeadersCoding/HTTPHeadersEncoder.swift
+++ b/Sources/HTTPHeadersCoding/HTTPHeadersEncoder.swift
@@ -31,6 +31,7 @@ import ShapeCoding
 /// ie. HeadersInput(theType: TheType(foo: "Value1", bar: "Value2")) --> ["theArrayfoo": "Value1", "theArraybar": "Value2"]
 public class HTTPHeadersEncoder {
     public typealias KeyEncodingStrategy = ShapeKeyEncodingStrategy
+    public typealias KeyEncodeTransformStrategy = ShapeKeyEncodeTransformStrategy
 
     internal let options: StandardEncodingOptions
     
@@ -66,11 +67,16 @@ public class HTTPHeadersEncoder {
                                By default uses `.useAsShapeSeparator("-")`.
         - mapEncodingStrategy: the `MapEncodingStrategy` to use for encoding.
                                By default uses `.singleHeader`.
+        - KeyEncodeTransformStrategy: the `KeyEncodeTransformStrategy` to use for transforming keys.
+                               By default uses `.none`.
      */
     public init(keyEncodingStrategy: KeyEncodingStrategy = .useAsShapeSeparator("-"),
-                mapEncodingStrategy: MapEncodingStrategy = .singleHeader) {
-        self.options = StandardEncodingOptions(shapeKeyEncodingStrategy: keyEncodingStrategy,
-                                               shapeMapEncodingStrategy: mapEncodingStrategy.shapeMapEncodingStrategy)
+                mapEncodingStrategy: MapEncodingStrategy = .singleHeader,
+                KeyEncodeTransformStrategy: KeyEncodeTransformStrategy = .none) {
+        self.options = StandardEncodingOptions(
+            shapeKeyEncodingStrategy: keyEncodingStrategy,
+            shapeMapEncodingStrategy: mapEncodingStrategy.shapeMapEncodingStrategy,
+            shapeKeyEncodeTransformStrategy: KeyEncodeTransformStrategy)
     }
 
     /**

--- a/Sources/HTTPPathCoding/Array+getShapeForTemplate.swift
+++ b/Sources/HTTPPathCoding/Array+getShapeForTemplate.swift
@@ -19,10 +19,12 @@ import Foundation
 import ShapeCoding
 
 public extension Array where Element == String {
-    public func getShapeForTemplate(templateSegments: [HTTPPathSegment],
-                                    decoderOptions: StandardDecodingOptions = StandardDecodingOptions(
-                                                                                shapeKeyDecodingStrategy: .useAsShapeSeparator("."),
-                                                                                shapeMapDecodingStrategy: .singleShapeEntry)) throws -> Shape {
+    public func getShapeForTemplate(
+            templateSegments: [HTTPPathSegment],
+            decoderOptions: StandardDecodingOptions = StandardDecodingOptions(
+                shapeKeyDecodingStrategy: .useAsShapeSeparator("."),
+                shapeMapDecodingStrategy: .singleShapeEntry,
+                shapeKeyDecodeTransformStrategy: .none)) throws -> Shape {
         // reverse the arrays so we can use popLast to iterate in the forwards direction
         var remainingPathSegments = Array(self.reversed())
         var remainingTemplateSegments = [HTTPPathSegment](templateSegments.reversed())

--- a/Sources/HTTPPathCoding/HTTPPathDecoder.swift
+++ b/Sources/HTTPPathCoding/HTTPPathDecoder.swift
@@ -30,17 +30,22 @@ public struct HTTPPathDecoder {
     private let userInfo: [CodingUserInfoKey: Any]
     
     public typealias KeyDecodingStrategy = ShapeKeyDecodingStrategy
+    public typealias KeyDecodeTransformStrategy = ShapeKeyDecodeTransformStrategy
     
     /**
      Initializer.
      
      - Parameters:
         - keyDecodingStrategy: the `KeyDecodingStrategy` to use for decoding.
+        - keyDecodeTransformStrategy: the `KeyDecodeTransformStrategy` to use for decoding.
      */
     public init(userInfo: [CodingUserInfoKey: Any] = [:],
-                keyDecodingStrategy: KeyDecodingStrategy = .useAsShapeSeparator(".")) {
-        self.options = StandardDecodingOptions(shapeKeyDecodingStrategy: keyDecodingStrategy,
-                                               shapeMapDecodingStrategy: .singleShapeEntry)
+                keyDecodingStrategy: KeyDecodingStrategy = .useAsShapeSeparator("."),
+                keyDecodeTransformStrategy: KeyDecodeTransformStrategy = .none) {
+        self.options = StandardDecodingOptions(
+            shapeKeyDecodingStrategy: keyDecodingStrategy,
+            shapeMapDecodingStrategy: .singleShapeEntry,
+            shapeKeyDecodeTransformStrategy: keyDecodeTransformStrategy)
         self.userInfo = userInfo
     }
     

--- a/Sources/HTTPPathCoding/HTTPPathEncoder.swift
+++ b/Sources/HTTPPathCoding/HTTPPathEncoder.swift
@@ -43,11 +43,11 @@ public class HTTPPathEncoder {
                                By default uses `.none`.
      */
     public init(keyEncodingStrategy: KeyEncodingStrategy = .useAsShapeSeparator("."),
-                KeyEncodeTransformStrategy: KeyEncodeTransformStrategy = .none) {
+                keyEncodeTransformStrategy: KeyEncodeTransformStrategy = .none) {
         self.options = StandardEncodingOptions(
             shapeKeyEncodingStrategy: keyEncodingStrategy,
             shapeMapEncodingStrategy: .singleShapeEntry,
-            shapeKeyEncodeTransformStrategy: KeyEncodeTransformStrategy)
+            shapeKeyEncodeTransformStrategy: keyEncodeTransformStrategy)
     }
 
     /**

--- a/Sources/HTTPPathCoding/HTTPPathEncoder.swift
+++ b/Sources/HTTPPathCoding/HTTPPathEncoder.swift
@@ -31,6 +31,7 @@ public class HTTPPathEncoder {
     internal let options: StandardEncodingOptions
     
     public typealias KeyEncodingStrategy = ShapeKeyEncodingStrategy
+    public typealias KeyEncodeTransformStrategy = ShapeKeyEncodeTransformStrategy
 
     /**
      Initializer.
@@ -38,10 +39,15 @@ public class HTTPPathEncoder {
      - Parameters:
         - keyEncodingStrategy: the `KeyEncodingStrategy` to use for encoding.
                                By default uses `.useAsShapeSeparator(".")`.
+        - KeyEncodeTransformStrategy: the `KeyEncodeTransformStrategy` to use for transforming keys.
+                               By default uses `.none`.
      */
-    public init(keyEncodingStrategy: KeyEncodingStrategy = .useAsShapeSeparator(".")) {
-        self.options = StandardEncodingOptions(shapeKeyEncodingStrategy: keyEncodingStrategy,
-                                               shapeMapEncodingStrategy: .singleShapeEntry)
+    public init(keyEncodingStrategy: KeyEncodingStrategy = .useAsShapeSeparator("."),
+                KeyEncodeTransformStrategy: KeyEncodeTransformStrategy = .none) {
+        self.options = StandardEncodingOptions(
+            shapeKeyEncodingStrategy: keyEncodingStrategy,
+            shapeMapEncodingStrategy: .singleShapeEntry,
+            shapeKeyEncodeTransformStrategy: KeyEncodeTransformStrategy)
     }
 
     /**

--- a/Sources/QueryCoding/QueryDecoder.swift
+++ b/Sources/QueryCoding/QueryDecoder.swift
@@ -26,6 +26,7 @@ public struct QueryDecoder {
     private let userInfo: [CodingUserInfoKey: Any]
     
     public typealias KeyDecodingStrategy = ShapeKeyDecodingStrategy
+    public typealias KeyDecodeTransformStrategy = ShapeKeyDecodeTransformStrategy
     
     /// The strategy to use for decoding maps.
     public enum MapDecodingStrategy {
@@ -61,13 +62,16 @@ public struct QueryDecoder {
      - Parameters:
         - keyDecodingStrategy: the `KeyDecodingStrategy` to use for decoding.
         - mapDecodingStrategy: the `MapDecodingStrategy` to use for decoding.
+        - keyDecodeTransformStrategy: the `KeyDecodeTransformStrategy` to use for decoding.
      */
     public init(userInfo: [CodingUserInfoKey: Any] = [:],
                 keyDecodingStrategy: KeyDecodingStrategy = .useAsShapeSeparator("."),
-                mapDecodingStrategy: MapDecodingStrategy = .singleQueryEntry) {
+                mapDecodingStrategy: MapDecodingStrategy = .singleQueryEntry,
+                keyDecodeTransformStrategy: KeyDecodeTransformStrategy = .none) {
         self.options = StandardDecodingOptions(
             shapeKeyDecodingStrategy: keyDecodingStrategy,
-            shapeMapDecodingStrategy: mapDecodingStrategy.shapeMapDecodingStrategy)
+            shapeMapDecodingStrategy: mapDecodingStrategy.shapeMapDecodingStrategy,
+            shapeKeyDecodeTransformStrategy: keyDecodeTransformStrategy)
         self.userInfo = userInfo
     }
     

--- a/Sources/QueryCoding/QueryEncoder.swift
+++ b/Sources/QueryCoding/QueryEncoder.swift
@@ -29,6 +29,7 @@ import ShapeCoding
 /// Dictionary entries are indicated based on the provided `MapEncodingStrategy`
 public class QueryEncoder {
     public typealias KeyEncodingStrategy = ShapeKeyEncodingStrategy
+    public typealias KeyEncodeTransformStrategy = ShapeKeyEncodeTransformStrategy
 
     internal let options: StandardEncodingOptions
     
@@ -64,11 +65,16 @@ public class QueryEncoder {
                                By default uses `.useAsShapeSeparator(".")`.
         - mapEncodingStrategy: the `MapEncodingStrategy` to use for encoding.
                                By default uses `.singleQueryEntry`.
+        - KeyEncodeTransformStrategy: the `KeyEncodeTransformStrategy` to use for transforming keys.
+                               By default uses `.none`.
      */
     public init(keyEncodingStrategy: KeyEncodingStrategy = .useAsShapeSeparator("."),
-                mapEncodingStrategy: MapEncodingStrategy = .singleQueryEntry) {
-        self.options = StandardEncodingOptions(shapeKeyEncodingStrategy: keyEncodingStrategy,
-                                               shapeMapEncodingStrategy: mapEncodingStrategy.shapeMapEncodingStrategy)
+                mapEncodingStrategy: MapEncodingStrategy = .singleQueryEntry,
+                KeyEncodeTransformStrategy: KeyEncodeTransformStrategy = .none) {
+        self.options = StandardEncodingOptions(
+            shapeKeyEncodingStrategy: keyEncodingStrategy,
+            shapeMapEncodingStrategy: mapEncodingStrategy.shapeMapEncodingStrategy,
+            shapeKeyEncodeTransformStrategy: KeyEncodeTransformStrategy)
     }
 
     /**

--- a/Sources/QueryCoding/QueryEncoder.swift
+++ b/Sources/QueryCoding/QueryEncoder.swift
@@ -70,11 +70,11 @@ public class QueryEncoder {
      */
     public init(keyEncodingStrategy: KeyEncodingStrategy = .useAsShapeSeparator("."),
                 mapEncodingStrategy: MapEncodingStrategy = .singleQueryEntry,
-                KeyEncodeTransformStrategy: KeyEncodeTransformStrategy = .none) {
+                keyEncodeTransformStrategy: KeyEncodeTransformStrategy = .none) {
         self.options = StandardEncodingOptions(
             shapeKeyEncodingStrategy: keyEncodingStrategy,
             shapeMapEncodingStrategy: mapEncodingStrategy.shapeMapEncodingStrategy,
-            shapeKeyEncodeTransformStrategy: KeyEncodeTransformStrategy)
+            shapeKeyEncodeTransformStrategy: keyEncodeTransformStrategy)
     }
 
     /**

--- a/Sources/ShapeCoding/StandardDecodingOptions.swift
+++ b/Sources/ShapeCoding/StandardDecodingOptions.swift
@@ -63,15 +63,30 @@ public enum ShapeMapDecodingStrategy {
     case separateShapeEntriesWith(keyTag: String, valueTag: String)
 }
 
+/// The strategy to use for transforming shape keys.
+public enum ShapeKeyDecodeTransformStrategy {
+    /// The shape keys will not be transformed.
+    case none
+    
+    /// The first character of shape keys will be uncapitialized.
+    case uncapitalizeFirstCharacter
+    
+    /// The shape key will be transformed using the provided function.
+    case custom((String) -> String)
+}
+
 /// The standard decoding options to use in conjunction with
 /// StandardShapeDecoderDelegate.
 public struct StandardDecodingOptions {
     public let shapeKeyDecodingStrategy: ShapeKeyDecodingStrategy
     public let shapeMapDecodingStrategy: ShapeMapDecodingStrategy
+    public let shapeKeyDecodeTransformStrategy: ShapeKeyDecodeTransformStrategy
     
     public init(shapeKeyDecodingStrategy: ShapeKeyDecodingStrategy,
-                shapeMapDecodingStrategy: ShapeMapDecodingStrategy) {
+                shapeMapDecodingStrategy: ShapeMapDecodingStrategy,
+                shapeKeyDecodeTransformStrategy: ShapeKeyDecodeTransformStrategy) {
         self.shapeKeyDecodingStrategy = shapeKeyDecodingStrategy
         self.shapeMapDecodingStrategy = shapeMapDecodingStrategy
+        self.shapeKeyDecodeTransformStrategy = shapeKeyDecodeTransformStrategy
     }
 }

--- a/Sources/ShapeCoding/StandardEncodingOptions.swift
+++ b/Sources/ShapeCoding/StandardEncodingOptions.swift
@@ -58,15 +58,30 @@ public enum ShapeMapEncodingStrategy {
     case separateShapeEntriesWith(keyTag: String, valueTag: String)
 }
 
+/// The strategy to use for transforming shape keys.
+public enum ShapeKeyEncodeTransformStrategy {
+    /// The shape keys will not be transformed.
+    case none
+    
+    /// The first character of shape keys will be capitialized.
+    case capitalizeFirstCharacter
+    
+    /// The shape key will be transformed using the provided function.
+    case custom((String) -> String)
+}
+
 /// The standard encoding options to use in conjunction with
 /// StandardShapeSingleValueEncodingContainerDelegate.
 public struct StandardEncodingOptions {
     public let shapeKeyEncodingStrategy: ShapeKeyEncodingStrategy
     public let shapeMapEncodingStrategy: ShapeMapEncodingStrategy
+    public let shapeKeyEncodeTransformStrategy: ShapeKeyEncodeTransformStrategy
     
     public init(shapeKeyEncodingStrategy: ShapeKeyEncodingStrategy,
-                shapeMapEncodingStrategy: ShapeMapEncodingStrategy) {
+                shapeMapEncodingStrategy: ShapeMapEncodingStrategy,
+                shapeKeyEncodeTransformStrategy: ShapeKeyEncodeTransformStrategy) {
         self.shapeKeyEncodingStrategy = shapeKeyEncodingStrategy
         self.shapeMapEncodingStrategy = shapeMapEncodingStrategy
+        self.shapeKeyEncodeTransformStrategy = shapeKeyEncodeTransformStrategy
     }
 }

--- a/Sources/ShapeCoding/StandardShapeSingleValueEncodingContainerDelegate.swift
+++ b/Sources/ShapeCoding/StandardShapeSingleValueEncodingContainerDelegate.swift
@@ -60,9 +60,24 @@ ShapeSingleValueEncodingContainerDelegate {
             let sortedValues = values.sorted { (left, right) in left.key < right.key }
 
             try sortedValues.enumerated().forEach { entry in
-                let innerKey = entry.element.key
+                let innerKey: String
                 let index = entry.offset
                 let keyToUse: String
+                
+                let untransformedKey = entry.element.key
+                switch options.shapeKeyEncodeTransformStrategy {
+                case .none:
+                    innerKey = untransformedKey
+                case .capitalizeFirstCharacter:
+                    if untransformedKey.count > 0 {
+                        innerKey = untransformedKey.prefix(1).capitalized
+                            + untransformedKey.dropFirst()
+                    } else {
+                        innerKey = ""
+                    }
+                case .custom(let transform):
+                    innerKey = transform(untransformedKey)
+                }
 
                 // if this isn't the root and using the separateShapeEntriesWith strategy
                 if !isRoot, case let .separateShapeEntriesWith(keyTag: keyTag, valueTag: valueTag) = options.shapeMapEncodingStrategy {

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -23,6 +23,7 @@ import XCTest
 
 XCTMain([
     testCase(StandardShapeParserTests.allTests),
+    testCase(ShapeSingleValueEncodingContainerTests.allTests),
     testCase(SmokeHTTPClientTests.allTests),
     testCase(QueryEncoderTests.allTests),
     testCase(HTTPHeadersEncoderTests.allTests),

--- a/Tests/ShapeCodingTests/ShapeSingleValueEncodingContainerTests.swift
+++ b/Tests/ShapeCodingTests/ShapeSingleValueEncodingContainerTests.swift
@@ -1,0 +1,400 @@
+// Copyright 2018-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+// ShapeSingleValueEncodingContainerTests.swift
+// ShapeCodingTests
+//
+
+import XCTest
+@testable import ShapeCoding
+
+struct TestTypeA: Codable, Equatable {
+    let firstly: String?
+    let secondly: String?
+    let thirdly: String?
+}
+
+struct TestTypeB: Codable, Equatable {
+    let action: String
+    let ids: [String]
+}
+
+struct TestTypeC: Codable, Equatable {
+    let action: String
+    let map: [String: String]
+}
+
+struct TestTypeD1: Codable, Equatable {
+    let action: String
+    let ids: [TestTypeA]
+}
+
+struct TestTypeD2: Codable, Equatable {
+    let action: String
+    let id: TestTypeA
+}
+
+fileprivate let useDotEncoderOptions = StandardEncodingOptions(
+    shapeKeyEncodingStrategy: .useAsShapeSeparator("."),
+    shapeMapEncodingStrategy: .singleShapeEntry,
+    shapeKeyEncodeTransformStrategy: .none)
+fileprivate let capitalizeEncoderOptions = StandardEncodingOptions(
+    shapeKeyEncodingStrategy: .useAsShapeSeparator("."),
+    shapeMapEncodingStrategy: .singleShapeEntry,
+    shapeKeyEncodeTransformStrategy: .capitalizeFirstCharacter)
+fileprivate let customTransformEncoderOptions = StandardEncodingOptions(
+    shapeKeyEncodingStrategy: .useAsShapeSeparator("."),
+    shapeMapEncodingStrategy: .singleShapeEntry,
+    shapeKeyEncodeTransformStrategy: .custom({ key in String(key.reversed()) }))
+
+class ShapeSingleValueEncodingContainerTests: XCTestCase {
+
+    func encode<ValueType: Encodable>(
+            value: ValueType,
+            options: StandardEncodingOptions) throws -> [String: String] {
+        let delegate = StandardShapeSingleValueEncodingContainerDelegate(options: options)
+        let container = ShapeSingleValueEncodingContainer(
+            userInfo: [:],
+            codingPath: [],
+            delegate: delegate,
+            allowedCharacterSet: .alphanumerics,
+            defaultValue: nil)
+        try value.encode(to: container)
+
+        var elements: [(String, String?)] = []
+        try container.getSerializedElements(nil, isRoot: true, elements: &elements)
+        
+        var encodedElements: [String: String] = [:]
+        elements.forEach { element in
+            if let value = element.1 {
+                encodedElements[element.0] = value
+            }
+        }
+        
+        return encodedElements
+    }
+    
+    func testEncodeBasicType() throws {
+        let input = TestTypeA(firstly: "value1",
+                              secondly: "value2",
+                              thirdly: "value3")
+        
+        let encodedValues = try encode(value: input,
+                                       options: useDotEncoderOptions)
+        
+        let expected = [
+            "firstly": "value1",
+            "secondly": "value2",
+            "thirdly": "value3"]
+        
+        XCTAssertEqual(expected, encodedValues)
+    }
+    
+    func testEncodeBasicTypeWithCapitialization() throws {
+        let input = TestTypeA(firstly: "value1",
+                              secondly: "value2",
+                              thirdly: "value3")
+        
+        let encodedValues = try encode(value: input,
+                                       options: capitalizeEncoderOptions)
+        
+        let expected = [
+            "Firstly": "value1",
+            "Secondly": "value2",
+            "Thirdly": "value3"]
+        
+        XCTAssertEqual(expected, encodedValues)
+    }
+    
+    func testEncodeBasicTypeWithCustomTransform() throws {
+        let input = TestTypeA(firstly: "value1",
+                              secondly: "value2",
+                              thirdly: "value3")
+        
+        let encodedValues = try encode(value: input,
+                                       options: customTransformEncoderOptions)
+        
+        let expected = [
+            "yltsrif": "value1",
+            "yldnoces": "value2",
+            "yldriht": "value3"]
+        
+        XCTAssertEqual(expected, encodedValues)
+    }
+    
+    func testEncodeBasicTypeWithEncoding() throws {
+        let input = TestTypeA(firstly: "value1=",
+                              secondly: "value2=",
+                              thirdly: "value3=")
+        
+        let encodedValues = try encode(value: input,
+                                       options: useDotEncoderOptions)
+        
+        let expected = [
+            "firstly": "value1%3D",
+            "secondly": "value2%3D",
+            "thirdly": "value3%3D"]
+        
+        XCTAssertEqual(expected, encodedValues)
+    }
+    
+    func testEncodeNoValues() throws {
+        let input = TestTypeA(firstly: nil,
+                              secondly: nil,
+                              thirdly: nil)
+        
+        let encodedValues = try encode(value: input,
+                                       options: useDotEncoderOptions)
+        
+        let expected: [String: String] = [:]
+        
+        XCTAssertEqual(expected, encodedValues)
+    }
+    
+    func testEncodeTypeWithList() throws {
+        let input = TestTypeB(action: "myAction", ids: ["value1", "value2"])
+        
+        let encodedValues = try encode(value: input,
+                                       options: useDotEncoderOptions)
+        
+        let expected = [
+            "action": "myAction",
+            "ids.1": "value1",
+            "ids.2": "value2"]
+        
+        XCTAssertEqual(expected, encodedValues)
+    }
+    
+    func testEncodeTypeWithListWithCapitialization() throws {
+        let input = TestTypeB(action: "myAction", ids: ["value1", "value2"])
+        
+        let encodedValues = try encode(value: input,
+                                       options: capitalizeEncoderOptions)
+        
+        let expected = [
+            "Action": "myAction",
+            "Ids.1": "value1",
+            "Ids.2": "value2"]
+        
+        XCTAssertEqual(expected, encodedValues)
+    }
+    
+    func testEncodeTypeWithListWithCustomTransform() throws {
+        let input = TestTypeB(action: "myAction", ids: ["value1", "value2"])
+        
+        let encodedValues = try encode(value: input,
+                                       options: customTransformEncoderOptions)
+        
+        let expected = [
+            "noitca": "myAction",
+            "sdi.1": "value1",
+            "sdi.2": "value2"]
+        
+        XCTAssertEqual(expected, encodedValues)
+    }
+    
+    func testEncodeTypeWithMap() throws {
+        let input = TestTypeC(action: "myAction",
+                              map: ["id1": "value1",
+                                    "id2": "value2"])
+        
+        let encodedValues = try encode(value: input,
+                                       options: useDotEncoderOptions)
+        
+        let expected = [
+            "action": "myAction",
+            "map.id1": "value1",
+            "map.id2": "value2"]
+        
+        XCTAssertEqual(expected, encodedValues)
+    }
+    
+    func testEncodeTypeWithMapWithCapitialization() throws {
+        let input = TestTypeC(action: "myAction",
+                              map: ["id1": "value1",
+                                    "id2": "value2"])
+        
+        let encodedValues = try encode(value: input,
+                                       options: capitalizeEncoderOptions)
+        
+        let expected = [
+            "Action": "myAction",
+            "Map.Id1": "value1",
+            "Map.Id2": "value2"]
+        
+        XCTAssertEqual(expected, encodedValues)
+    }
+    
+    func testEncodeTypeWithMapWithCustomTransform() throws {
+        let input = TestTypeC(action: "myAction",
+                              map: ["id1": "value1",
+                                    "id2": "value2"])
+        
+        let encodedValues = try encode(value: input,
+                                       options: customTransformEncoderOptions)
+        
+        let expected = [
+            "noitca": "myAction",
+            "pam.1di": "value1",
+            "pam.2di": "value2"]
+        
+        XCTAssertEqual(expected, encodedValues)
+    }
+    
+    func testEncodeTypeWithListOfType() throws {
+        let value1 = TestTypeA(firstly: "value1",
+                              secondly: "value2",
+                              thirdly: "value3")
+        let value2 = TestTypeA(firstly: "value4",
+                              secondly: "value5",
+                              thirdly: "value6")
+        let input = TestTypeD1(action: "myAction", ids: [value1, value2])
+        
+        let encodedValues = try encode(value: input,
+                                       options: useDotEncoderOptions)
+        
+        let expected = [
+            "action": "myAction",
+            "ids.1.firstly": "value1",
+            "ids.1.secondly": "value2",
+            "ids.1.thirdly": "value3",
+            "ids.2.firstly": "value4",
+            "ids.2.secondly": "value5",
+            "ids.2.thirdly": "value6"]
+        
+        XCTAssertEqual(expected, encodedValues)
+    }
+    
+    func testEncodeTypeWithListOfTypeWithCapitialization() throws {
+        let value1 = TestTypeA(firstly: "value1",
+                              secondly: "value2",
+                              thirdly: "value3")
+        let value2 = TestTypeA(firstly: "value4",
+                              secondly: "value5",
+                              thirdly: "value6")
+        let input = TestTypeD1(action: "myAction", ids: [value1, value2])
+        
+        let encodedValues = try encode(value: input,
+                                       options: capitalizeEncoderOptions)
+        
+        let expected = [
+            "Action": "myAction",
+            "Ids.1.Firstly": "value1",
+            "Ids.1.Secondly": "value2",
+            "Ids.1.Thirdly": "value3",
+            "Ids.2.Firstly": "value4",
+            "Ids.2.Secondly": "value5",
+            "Ids.2.Thirdly": "value6"]
+        
+        XCTAssertEqual(expected, encodedValues)
+    }
+    
+    func testEncodeTypeWithListOfTypeWithCustomTransform() throws {
+        let value1 = TestTypeA(firstly: "value1",
+                              secondly: "value2",
+                              thirdly: "value3")
+        let value2 = TestTypeA(firstly: "value4",
+                              secondly: "value5",
+                              thirdly: "value6")
+        let input = TestTypeD1(action: "myAction", ids: [value1, value2])
+        
+        let encodedValues = try encode(value: input,
+                                       options: customTransformEncoderOptions)
+        
+        let expected = [
+            "noitca": "myAction",
+            "sdi.1.yltsrif": "value1",
+            "sdi.1.yldnoces": "value2",
+            "sdi.1.yldriht": "value3",
+            "sdi.2.yltsrif": "value4",
+            "sdi.2.yldnoces": "value5",
+            "sdi.2.yldriht": "value6"]
+        
+        XCTAssertEqual(expected, encodedValues)
+    }
+    
+    func testEncodeTypeWithNestedType() throws {
+        let value1 = TestTypeA(firstly: "value1",
+                              secondly: "value2",
+                              thirdly: "value3")
+        let input = TestTypeD2(action: "myAction", id: value1)
+        
+        let encodedValues = try encode(value: input,
+                                       options: useDotEncoderOptions)
+        
+        let expected = [
+            "action": "myAction",
+            "id.firstly": "value1",
+            "id.secondly": "value2",
+            "id.thirdly": "value3"]
+        
+        XCTAssertEqual(expected, encodedValues)
+    }
+    
+    func testEncodeTypeWithNestedTypeWithCapitialization() throws {
+        let value1 = TestTypeA(firstly: "value1",
+                              secondly: "value2",
+                              thirdly: "value3")
+        let input = TestTypeD2(action: "myAction", id: value1)
+        
+        let encodedValues = try encode(value: input,
+                                       options: capitalizeEncoderOptions)
+        
+        let expected = [
+            "Action": "myAction",
+            "Id.Firstly": "value1",
+            "Id.Secondly": "value2",
+            "Id.Thirdly": "value3"]
+        
+        XCTAssertEqual(expected, encodedValues)
+    }
+    
+    func testEncodeTypeWithNestedTypeWithCustomTransform() throws {
+        let value1 = TestTypeA(firstly: "value1",
+                              secondly: "value2",
+                              thirdly: "value3")
+        let input = TestTypeD2(action: "myAction", id: value1)
+        
+        let encodedValues = try encode(value: input,
+                                       options: customTransformEncoderOptions)
+        
+        let expected = [
+            "noitca": "myAction",
+            "di.yltsrif": "value1",
+            "di.yldnoces": "value2",
+            "di.yldriht": "value3"]
+        
+        XCTAssertEqual(expected, encodedValues)
+    }
+
+    static var allTests = [
+        ("testEncodeBasicType", testEncodeBasicType),
+        ("testEncodeBasicTypeWithCapitialization", testEncodeBasicTypeWithCapitialization),
+        ("testEncodeBasicTypeWithCustomTransform", testEncodeBasicTypeWithCustomTransform),
+        ("testEncodeBasicTypeWithEncoding", testEncodeBasicTypeWithEncoding),
+        ("testEncodeNoValues", testEncodeNoValues),
+        ("testEncodeTypeWithList", testEncodeTypeWithList),
+        ("testEncodeTypeWithListWithCapitialization", testEncodeTypeWithListWithCapitialization),
+        ("testEncodeTypeWithListWithCustomTransform", testEncodeTypeWithListWithCustomTransform),
+        ("testEncodeTypeWithMap", testEncodeTypeWithMap),
+        ("testEncodeTypeWithMapWithCapitialization", testEncodeTypeWithMapWithCapitialization),
+        ("testEncodeTypeWithMapWithCustomTransform", testEncodeTypeWithMapWithCustomTransform),
+        ("testEncodeTypeWithListOfType", testEncodeTypeWithListOfType),
+        ("testEncodeTypeWithListOfTypeWithCapitialization", testEncodeTypeWithListOfTypeWithCapitialization),
+        ("testEncodeTypeWithListOfTypeWithCustomTransform", testEncodeTypeWithListOfTypeWithCustomTransform),
+        ("testEncodeTypeWithNestedType", testEncodeTypeWithNestedType),
+        ("testEncodeTypeWithNestedTypeWithCapitialization", testEncodeTypeWithNestedTypeWithCapitialization),
+        ("testEncodeTypeWithNestedTypeWithCustomTransform", testEncodeTypeWithNestedTypeWithCustomTransform),
+    ]
+}
+

--- a/Tests/ShapeCodingTests/StandardShapeParserTests.swift
+++ b/Tests/ShapeCodingTests/StandardShapeParserTests.swift
@@ -20,19 +20,44 @@ import XCTest
 
 fileprivate let useDotDecoderOptions = StandardDecodingOptions(
     shapeKeyDecodingStrategy: .useAsShapeSeparator("."),
-    shapeMapDecodingStrategy: .singleShapeEntry)
+    shapeMapDecodingStrategy: .singleShapeEntry,
+    shapeKeyDecodeTransformStrategy: .none)
+fileprivate let uncapitalizeDecoderOptions = StandardDecodingOptions(
+    shapeKeyDecodingStrategy: .useAsShapeSeparator("."),
+    shapeMapDecodingStrategy: .singleShapeEntry,
+    shapeKeyDecodeTransformStrategy: .uncapitalizeFirstCharacter)
+fileprivate let customTransformDecoderOptions = StandardDecodingOptions(
+    shapeKeyDecodingStrategy: .useAsShapeSeparator("."),
+    shapeMapDecodingStrategy: .singleShapeEntry,
+    shapeKeyDecodeTransformStrategy: .custom({ key in String(key.reversed()) }))
 fileprivate let flatStructureDecoderOptions = StandardDecodingOptions(
     shapeKeyDecodingStrategy: .flatStructure,
-    shapeMapDecodingStrategy: .singleShapeEntry)
+    shapeMapDecodingStrategy: .singleShapeEntry,
+    shapeKeyDecodeTransformStrategy: .none)
 
 class StandardShapeParserTests: XCTestCase {
 
-    func testEncodeBasicType() throws {
-        let input: [(String, String?)] = [("firstly", "value1"),
-                                          ("secondly", "value2"),
-                                          ("thirdly", "value3")]
+    func testDecodeBasicType() throws {
+        let input: [(String, String?)] = [("Firstly", "value1"),
+                                          ("Secondly", "value2"),
+                                          ("Thirdly", "value3")]
         let shape = try StandardShapeParser.parse(with: input,
-                                                       decoderOptions: useDotDecoderOptions)
+                                                  decoderOptions: useDotDecoderOptions)
+        
+        let expected = Shape.dictionary([
+            "Firstly": .string("value1"),
+            "Secondly": .string("value2"),
+            "Thirdly": .string("value3")])
+        
+        XCTAssertEqual(expected, shape)
+    }
+    
+    func testDecodeBasicTypeWithUncapitalization() throws {
+        let input: [(String, String?)] = [("Firstly", "value1"),
+                                          ("Secondly", "value2"),
+                                          ("Thirdly", "value3")]
+        let shape = try StandardShapeParser.parse(with: input,
+                                                  decoderOptions: uncapitalizeDecoderOptions)
         
         let expected = Shape.dictionary([
             "firstly": .string("value1"),
@@ -41,43 +66,73 @@ class StandardShapeParserTests: XCTestCase {
         
         XCTAssertEqual(expected, shape)
     }
-
-    func testEncodeBasicTypeWithEncoding() throws {
-        let input: [(String, String?)] = [("firstly", "value1%3D"),
-                                          ("secondly", "value2%3D"),
-                                          ("thirdly", "value3%3D")]
+    
+    func testDecodeBasicTypeWithCustomTransform() throws {
+        let input: [(String, String?)] = [("Firstly", "value1"),
+                                          ("Secondly", "value2"),
+                                          ("Thirdly", "value3")]
         let shape = try StandardShapeParser.parse(with: input,
-                                                          decoderOptions: useDotDecoderOptions)
+                                                  decoderOptions: customTransformDecoderOptions)
         
         let expected = Shape.dictionary([
-            "firstly": .string("value1="),
-            "secondly": .string("value2="),
-            "thirdly": .string("value3=")])
+            "yltsriF": .string("value1"),
+            "yldnoceS": .string("value2"),
+            "yldrihT": .string("value3")])
         
         XCTAssertEqual(expected, shape)
     }
 
-    func testEncodeNoValues() throws {
-        let input: [(String, String?)] = [("firstly", nil),
-                                          ("secondly", nil),
-                                          ("thirdly", nil)]
+    func testDecodeBasicTypeWithEncoding() throws {
+        let input: [(String, String?)] = [("Firstly", "value1%3D"),
+                                          ("Secondly", "value2%3D"),
+                                          ("Thirdly", "value3%3D")]
         let shape = try StandardShapeParser.parse(with: input,
-                                                      decoderOptions: useDotDecoderOptions)
+                                                  decoderOptions: useDotDecoderOptions)
+        
+        let expected = Shape.dictionary([
+            "Firstly": .string("value1="),
+            "Secondly": .string("value2="),
+            "Thirdly": .string("value3=")])
+        
+        XCTAssertEqual(expected, shape)
+    }
+
+    func testDecodeNoValues() throws {
+        let input: [(String, String?)] = [("Firstly", nil),
+                                          ("Secondly", nil),
+                                          ("Thirdly", nil)]
+        let shape = try StandardShapeParser.parse(with: input,
+                                                  decoderOptions: useDotDecoderOptions)
     
         let expected = Shape.dictionary([
-            "firstly": .null,
-            "secondly": .null,
-            "thirdly": .null])
+            "Firstly": .null,
+            "Secondly": .null,
+            "Thirdly": .null])
     
         XCTAssertEqual(expected, shape)
     }
 
-    func testEncodeTypeWithMap() throws {
-        let input: [(String, String?)] = [("action", "myAction"),
-                                          ("map.id1", "value1"),
-                                          ("map.id2", "value2")]
+    func testDecodeTypeWithMap() throws {
+        let input: [(String, String?)] = [("Action", "myAction"),
+                                          ("Map.Id1", "value1"),
+                                          ("Map.Id2", "value2")]
         let shape = try StandardShapeParser.parse(with: input,
-                                                      decoderOptions: useDotDecoderOptions)
+                                                  decoderOptions: useDotDecoderOptions)
+        
+        let expected = Shape.dictionary([
+            "Action": .string("myAction"),
+            "Map": .dictionary(["Id1": .string("value1"),
+                                "Id2": .string("value2")])])
+        
+        XCTAssertEqual(expected, shape)
+    }
+    
+    func testDecodeTypeWithMapWithUncapitalization() throws {
+        let input: [(String, String?)] = [("Action", "myAction"),
+                                          ("Map.Id1", "value1"),
+                                          ("Map.Id2", "value2")]
+        let shape = try StandardShapeParser.parse(with: input,
+                                                  decoderOptions: uncapitalizeDecoderOptions)
         
         let expected = Shape.dictionary([
             "action": .string("myAction"),
@@ -87,41 +142,94 @@ class StandardShapeParserTests: XCTestCase {
         XCTAssertEqual(expected, shape)
     }
     
-    func testEncodeTypeWithMapLikeFlatStructure() throws {
-        let input: [(String, String?)] = [("action", "myAction"),
-                                          ("map.id1", "value1"),
-                                          ("map.id2", "value2")]
+    func testDecodeTypeWithMapWithCustomTransform() throws {
+        let input: [(String, String?)] = [("Action", "myAction"),
+                                          ("Map.Id1", "value1"),
+                                          ("Map.Id2", "value2")]
         let shape = try StandardShapeParser.parse(with: input,
-                                                      decoderOptions: flatStructureDecoderOptions)
+                                                  decoderOptions: customTransformDecoderOptions)
         
         let expected = Shape.dictionary([
-            "action": .string("myAction"),
-            "map.id1": .string("value1"),
-            "map.id2": .string("value2")])
+            "noitcA": .string("myAction"),
+            "paM": .dictionary(["1dI": .string("value1"),
+                                "2dI": .string("value2")])])
+        
+        XCTAssertEqual(expected, shape)
+    }
+    
+    func testDecodeTypeWithMapLikeFlatStructure() throws {
+        let input: [(String, String?)] = [("Action", "myAction"),
+                                          ("Map.Id1", "value1"),
+                                          ("Map.Id2", "value2")]
+        let shape = try StandardShapeParser.parse(with: input,
+                                                  decoderOptions: flatStructureDecoderOptions)
+        
+        let expected = Shape.dictionary([
+            "Action": .string("myAction"),
+            "Map.Id1": .string("value1"),
+            "Map.Id2": .string("value2")])
         
         XCTAssertEqual(expected, shape)
     }
 
-    func testEncodeTypeWithMapWithMapDecodingStrategy() throws {
-        let input: [(String, String?)] = [("action", "myAction"),
-                                          ("map.1.Name", "id1"),
-                                          ("map.1.Value", "value1"),
-                                          ("map.2.Name", "id2"),
-                                          ("map.2.Value", "value2")]
+    func testDecodeTypeWithMapWithMapDecodingStrategy() throws {
+        let input: [(String, String?)] = [("Action", "myAction"),
+                                          ("Map.1.Name", "id1"),
+                                          ("Map.1.Value", "value1"),
+                                          ("Map.2.Name", "id2"),
+                                          ("Map.2.Value", "value2")]
         let shape = try StandardShapeParser.parse(with: input,
-                                                      decoderOptions: useDotDecoderOptions)
+                                                  decoderOptions: useDotDecoderOptions)
         
         let expected = Shape.dictionary([
-            "action": .string("myAction"),
-            "map": .dictionary(["1": .dictionary(["Name": .string("id1"),
+            "Action": .string("myAction"),
+            "Map": .dictionary(["1": .dictionary(["Name": .string("id1"),
                                                   "Value": .string("value1")]),
                                 "2": .dictionary(["Name": .string("id2"),
                                                   "Value": .string("value2")])])])
         
         XCTAssertEqual(expected, shape)
     }
+    
+    func testDecodeTypeWithMapWithMapDecodingStrategyWithUncapitialization() throws {
+        let input: [(String, String?)] = [("Action", "myAction"),
+                                          ("Map.1.Name", "id1"),
+                                          ("Map.1.Value", "value1"),
+                                          ("Map.2.Name", "id2"),
+                                          ("Map.2.Value", "value2")]
+        let shape = try StandardShapeParser.parse(with: input,
+                                                  decoderOptions: uncapitalizeDecoderOptions)
+        
+        let expected = Shape.dictionary([
+            "action": .string("myAction"),
+            "map": .dictionary(["1": .dictionary(["name": .string("id1"),
+                                                  "value": .string("value1")]),
+                                "2": .dictionary(["name": .string("id2"),
+                                                  "value": .string("value2")])])])
+        
+        XCTAssertEqual(expected, shape)
+    }
+    
+    func testDecodeTypeWithMapWithMapDecodingStrategyWithCustomTransform() throws {
+        let input: [(String, String?)] = [("Action", "myAction"),
+                                          ("Map.1.Name", "id1"),
+                                          ("Map.1.Value", "value1"),
+                                          ("Map.2.Name", "id2"),
+                                          ("Map.2.Value", "value2")]
+        let shape = try StandardShapeParser.parse(with: input,
+                                                  decoderOptions: customTransformDecoderOptions)
+        
+        let expected = Shape.dictionary([
+            "noitcA": .string("myAction"),
+            "paM": .dictionary(["1": .dictionary(["emaN": .string("id1"),
+                                                  "eulaV": .string("value1")]),
+                                "2": .dictionary(["emaN": .string("id2"),
+                                                  "eulaV": .string("value2")])])])
+        
+        XCTAssertEqual(expected, shape)
+    }
 
-    func testEncodeTypeWithMapWithEncoding() throws {
+    func testDecodeTypeWithMapWithEncoding() throws {
         let input: [(String, String?)] = [("action", "myAction"),
                                           ("map.id1", "value1%3D"),
                                           ("map.id2", "value2%3D")]
@@ -137,12 +245,19 @@ class StandardShapeParserTests: XCTestCase {
     }
 
     static var allTests = [
-        ("testEncodeBasicType", testEncodeBasicType),
-        ("testEncodeBasicTypeWithEncoding", testEncodeBasicTypeWithEncoding),
-        ("testEncodeNoValues", testEncodeNoValues),
-        ("testEncodeTypeWithMap", testEncodeTypeWithMap),
-        ("testEncodeTypeWithMapLikeFlatStructure", testEncodeTypeWithMapLikeFlatStructure),
-        ("testEncodeTypeWithMapWithMapDecodingStrategy", testEncodeTypeWithMapWithMapDecodingStrategy),
-        ("testEncodeTypeWithMapWithEncoding", testEncodeTypeWithMapWithEncoding),
+        ("testDecodeBasicType", testDecodeBasicType),
+        ("testDecodeBasicTypeWithUncapitalization", testDecodeBasicTypeWithUncapitalization),
+        ("testDecodeBasicTypeWithCustomTransform", testDecodeBasicTypeWithCustomTransform),
+        ("testDecodeBasicTypeWithEncoding", testDecodeBasicTypeWithEncoding),
+        ("testDecodeNoValues", testDecodeNoValues),
+        ("testDecodeTypeWithMap", testDecodeTypeWithMap),
+        ("testDecodeTypeWithMapWithUncapitalization", testDecodeTypeWithMapWithUncapitalization),
+        ("testDecodeTypeWithMapWithCustomTransform", testDecodeTypeWithMapWithCustomTransform),
+        ("testDecodeTypeWithMapLikeFlatStructure", testDecodeTypeWithMapLikeFlatStructure),
+        ("testDecodeTypeWithMapWithMapDecodingStrategy", testDecodeTypeWithMapWithMapDecodingStrategy),
+        ("testDecodeTypeWithMapWithMapDecodingStrategyWithUncapitialization",
+         testDecodeTypeWithMapWithMapDecodingStrategyWithUncapitialization),
+        ("testDecodeTypeWithMapWithMapDecodingStrategyWithCustomTransform", testDecodeTypeWithMapWithMapDecodingStrategyWithCustomTransform),
+        ("testDecodeTypeWithMapWithEncoding", testDecodeTypeWithMapWithEncoding),
     ]
 }


### PR DESCRIPTION
*Issue #, if available:* https://github.com/amzn/smoke-aws/issues/10

*Description of changes:* Add a key transform strategy for encoding and decoding shapes with a passthrough option, an option to capitalise and de-capitalise the first character and a custom transform. This is enable use cases where there is a known mapping from the Codable instance to the serialised form that cannot be fully expressed as CodingKeys (the mapping is different in different circumstances.

*Testing performed:* Added unit tests for encoding and decoding with all three strategy options. Also verified that this enables a fix (with additional changes to SmokeAWS) for https://github.com/amzn/smoke-aws/issues/10 (where encoding for EC2 requires capitalisation of keys but decoding doesn't).


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
