### PR TITLE
Add reuse socket option and cleanup response handling

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio.git",
         "state": {
           "branch": null,
-          "revision": "98434c1f1d687ff5a24d2cabfbd19b5c7d2d7a2f",
-          "version": "1.13.0"
+          "revision": "29a9f2aca71c8afb07e291336f1789337ce235dd",
+          "version": "1.13.2"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -46,7 +46,7 @@ let package = Package(
         // Targets can depend on other targets in this package, and on products in packages which this package depends on.
         .target(
             name: "SmokeHTTPClient",
-            dependencies: ["LoggerAPI", "NIO", "NIOHTTP1", "NIOOpenSSL"]),
+            dependencies: ["LoggerAPI", "NIO", "NIOHTTP1", "NIOFoundationCompat", "NIOOpenSSL"]),
         .target(
             name: "QueryCoding",
             dependencies: ["ShapeCoding"]),

--- a/Sources/ShapeCoding/DateISO8601Extensions.swift
+++ b/Sources/ShapeCoding/DateISO8601Extensions.swift
@@ -17,23 +17,23 @@
 
 import Foundation
 
-private let iso8601DateFormatter: DateFormatter = {
-     let formatter = DateFormatter()
-     formatter.calendar = Calendar(identifier: .iso8601)
-     formatter.locale = Locale(identifier: "en_US_POSIX")
-     formatter.timeZone = TimeZone(secondsFromGMT: 0)
-     formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSXXXXX"
-     return formatter
- }()
+private func iso8601DateFormatter() -> DateFormatter {
+    let formatter = DateFormatter()
+    formatter.calendar = Calendar(identifier: .iso8601)
+    formatter.locale = Locale(identifier: "en_US_POSIX")
+    formatter.timeZone = TimeZone(secondsFromGMT: 0)
+    formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSXXXXX"
+    return formatter
+}
 
- extension Date {
-     var iso8601: String {
-         return iso8601DateFormatter.string(from: self)
-     }
- }
+extension Date {
+    var iso8601: String {
+        return iso8601DateFormatter().string(from: self)
+    }
+}
 
- extension String {
-     var dateFromISO8601: Date? {
-         return iso8601DateFormatter.date(from: self)   // "Mar 22, 2017, 10:22 AM"
-     }
- }
+extension String {
+    var dateFromISO8601: Date? {
+        return iso8601DateFormatter().date(from: self)   // "Mar 22, 2017, 10:22 AM"
+    }
+}

--- a/Sources/SmokeHTTPClient/HTTPClientChannelInboundHandler.swift
+++ b/Sources/SmokeHTTPClient/HTTPClientChannelInboundHandler.swift
@@ -109,7 +109,8 @@ public final class HTTPClientChannelInboundHandler: ChannelInboundHandler {
             Log.verbose("Request head received.")
         // This is part of the response body
         case .body(var byteBuffer):
-            let newData = byteBuffer.readData(length: byteBuffer.readableBytes)
+            let byteBufferSize = byteBuffer.readableBytes
+            let newData = byteBuffer.readData(length: byteBufferSize)
             
             if var previousPartialBody = partialBody,
                 let newData = newData {
@@ -119,7 +120,7 @@ public final class HTTPClientChannelInboundHandler: ChannelInboundHandler {
                 partialBody = newData
             }
             
-            Log.verbose("Request body of \(byteBuffer.readableBytes) bytes received.")
+            Log.verbose("Request body part of \(byteBufferSize) bytes received.")
         // This is the response end
         case .end:
             Log.verbose("Request end received.")

--- a/Sources/SmokeHTTPClient/HTTPClientChannelInboundHandler.swift
+++ b/Sources/SmokeHTTPClient/HTTPClientChannelInboundHandler.swift
@@ -112,10 +112,10 @@ public final class HTTPClientChannelInboundHandler: ChannelInboundHandler {
             let byteBufferSize = byteBuffer.readableBytes
             let newData = byteBuffer.readData(length: byteBufferSize)
             
-            if var previousPartialBody = partialBody,
+            if var newPartialBody = partialBody,
                 let newData = newData {
-                    previousPartialBody += newData
-                    partialBody = previousPartialBody
+                    newPartialBody += newData
+                    partialBody = newPartialBody
             } else if let newData = newData {
                 partialBody = newData
             }

--- a/Sources/SmokeHTTPClient/HTTPClientChannelInboundHandler.swift
+++ b/Sources/SmokeHTTPClient/HTTPClientChannelInboundHandler.swift
@@ -20,6 +20,7 @@ import NIO
 import NIOHTTP1
 import NIOOpenSSL
 import NIOTLS
+import NIOFoundationCompat
 import LoggerAPI
 
 internal struct HttpHeaderNames {
@@ -52,8 +53,8 @@ public final class HTTPClientChannelInboundHandler: ChannelInboundHandler {
     public let additionalHeaders: [(String, String)]
     /// The http head of the response received
     public var responseHead: HTTPResponseHead?
-    /// The list of previous body ByteBuffers received.
-    public var bodyParts: [ByteBuffer] = []
+    /// The body data previously received.
+    public var partialBody: Data?
 
     /// A completion handler to pass any recieved response to.
     private let completion: (HTTPResult<HTTPResponseComponents>) -> ()
@@ -107,9 +108,17 @@ public final class HTTPClientChannelInboundHandler: ChannelInboundHandler {
             responseHead = request
             Log.verbose("Request head received.")
         // This is part of the response body
-        case .body(let byteBuffer):
-            // store this part of the body
-            bodyParts.append(byteBuffer)
+        case .body(var byteBuffer):
+            let newData = byteBuffer.readData(length: byteBuffer.readableBytes)
+            
+            if var previousPartialBody = partialBody,
+                let newData = newData {
+                    previousPartialBody += newData
+                    partialBody = previousPartialBody
+            } else if let newData = newData {
+                partialBody = newData
+            }
+            
             Log.verbose("Request body of \(byteBuffer.readableBytes) bytes received.")
         // This is the response end
         case .end:
@@ -139,22 +148,7 @@ public final class HTTPClientChannelInboundHandler: ChannelInboundHandler {
             Log.verbose("Channel closed on complete response.")
         }
 
-        Log.verbose("Reducing \(bodyParts.count) body parts into body.")
-
-        // concatenate any parts into a single byte array
-        let bodyBytes: [UInt8] = bodyParts.reduce([]) { (partialBytes, part) in
-            let partBytes = part.getBytes(at: 0, length: part.readableBytes)
-
-            if let partBytes = partBytes {
-                return partialBytes + partBytes
-            } else {
-                return partialBytes
-            }
-        }
-
-        Log.verbose("Reduced body with \(bodyBytes.count) size.")
-
-        let responseBodyData = !bodyBytes.isEmpty ? Data(bytes: bodyBytes) : nil
+        Log.verbose("Handling body with \(partialBody?.count ?? 0) size.")
 
         // ensure the response head from received
         guard let responseHead = responseHead else {
@@ -169,9 +163,9 @@ public final class HTTPClientChannelInboundHandler: ChannelInboundHandler {
         
         let headers = getHeadersFromResponse(header: responseHead)
         let responseComponents = HTTPResponseComponents(headers: headers,
-                                                        body: responseBodyData)
+                                                        body: partialBody)
 
-        if let bodyData = responseBodyData {
+        if let bodyData = partialBody {
             Log.verbose("Got response from endpoint: \(endpointUrl) and path: \(endpointPath) with " +
                 "headers: \(responseHead) and body: \(bodyData)")
         } else {
@@ -195,7 +189,7 @@ public final class HTTPClientChannelInboundHandler: ChannelInboundHandler {
         }
 
         // Handle client delegated errors
-        if let error = delegate.handleErrorResponses(responseHead: responseHead, responseBodyData: responseBodyData) {
+        if let error = delegate.handleErrorResponses(responseHead: responseHead, responseBodyData: partialBody) {
             completion(.error(error))
             return
         }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* 
* Add reuse socket option as shown here[1]
* Don't use a singleton date formatter as it may retain memory
* Only calculate the TLSConfiguration for a client from its delegate once
* Cleanup response handling with NIOFoundationCompat. 


[1] https://github.com/apple/swift-nio-ssl/blob/master/Sources/NIOHTTP1Client/main.swift#L87

*Description of changes:* Tested in beta environment (Linux). Confirmed functionally correct. Continuing to investigate long term memory performance 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
