### PR TITLE
Http client state cleanup

### DIFF
--- a/Sources/SmokeHTTPClient/HTTPClient.swift
+++ b/Sources/SmokeHTTPClient/HTTPClient.swift
@@ -70,13 +70,16 @@ public class HTTPClient {
      Initializer.
 
      - Parameters:
-     - endpointHostName: The server hostname to contact for requests from this client.
-     - endpointPort: The server port to connect to.
-     - contentType: The content type of the payload being sent by this client.
-     - clientDelegate: Delegate for the HTTP client that provides client-specific logic for handling HTTP requests.
-     - channelInboundHandlerDelegate: Delegate for the HTTP channel inbound handler that provides client-specific logic
-     -                                around HTTP request/response settings.
-     - connectionTimeoutSeconds: The time in second the client should wait for a response. The default is 10 seconds.
+         - endpointHostName: The server hostname to contact for requests from this client.
+         - endpointPort: The server port to connect to.
+         - contentType: The content type of the payload being sent by this client.
+         - clientDelegate: Delegate for the HTTP client that provides client-specific logic for handling HTTP requests.
+         - channelInboundHandlerDelegate: Delegate for the HTTP channel inbound handler that provides client-specific logic
+         -                                around HTTP request/response settings.
+         - connectionTimeoutSeconds: The time in second the client should wait for a response. The default is 10 seconds.
+         - eventLoopProvider: Provides the event loop to be used by the client.
+                              If not specified, the client will create a new multi-threaded event loop
+                              with the number of threads specified by `System.coreCount`.
      */
     public init(endpointHostName: String,
                 endpointPort: Int,
@@ -152,7 +155,7 @@ public class HTTPClient {
      Waits for the client to be closed. If close() is not called,
      this will block forever.
      */
-    public func wait() throws {
+    public func wait() {
         if !isClosed() {
             closureDispatchGroup.wait()
         }

--- a/Sources/SmokeHTTPClient/HTTPClientChannelInboundHandler.swift
+++ b/Sources/SmokeHTTPClient/HTTPClientChannelInboundHandler.swift
@@ -149,7 +149,7 @@ public final class HTTPClientChannelInboundHandler: ChannelInboundHandler {
             Log.verbose("Channel closed on complete response.")
         }
 
-        Log.verbose("Handling body with \(partialBody?.count ?? 0) size.")
+        Log.verbose("Handling response body with \(partialBody?.count ?? 0) size.")
 
         // ensure the response head from received
         guard let responseHead = responseHead else {

--- a/Sources/SmokeHTTPClient/HTTPClientChannelInboundHandler.swift
+++ b/Sources/SmokeHTTPClient/HTTPClientChannelInboundHandler.swift
@@ -126,7 +126,8 @@ public final class HTTPClientChannelInboundHandler: ChannelInboundHandler {
             Log.verbose("Response end received.")
             // the head and all possible body parts have been received,
             // handle this response
-            handleCompleteResponse(context: ctx)
+            handleCompleteResponse(context: ctx, bodyData: partialBody)
+            partialBody = nil
         }
     }
     
@@ -141,7 +142,7 @@ public final class HTTPClientChannelInboundHandler: ChannelInboundHandler {
     /*
      Handles when the response has been completely received.
      */
-    func handleCompleteResponse(context ctx: ChannelHandlerContext) {
+    func handleCompleteResponse(context ctx: ChannelHandlerContext, bodyData: Data?) {
         // always close the channel context after the processing in this method
         defer {
             Log.verbose("Closing channel on complete response.")
@@ -149,7 +150,7 @@ public final class HTTPClientChannelInboundHandler: ChannelInboundHandler {
             Log.verbose("Channel closed on complete response.")
         }
 
-        Log.verbose("Handling response body with \(partialBody?.count ?? 0) size.")
+        Log.verbose("Handling response body with \(bodyData?.count ?? 0) size.")
 
         // ensure the response head from received
         guard let responseHead = responseHead else {
@@ -164,9 +165,9 @@ public final class HTTPClientChannelInboundHandler: ChannelInboundHandler {
         
         let headers = getHeadersFromResponse(header: responseHead)
         let responseComponents = HTTPResponseComponents(headers: headers,
-                                                        body: partialBody)
+                                                        body: bodyData)
 
-        if let bodyData = partialBody {
+        if let bodyData = bodyData {
             Log.verbose("Got response from endpoint: \(endpointUrl) and path: \(endpointPath) with " +
                 "headers: \(responseHead) and body: \(bodyData)")
         } else {
@@ -190,7 +191,7 @@ public final class HTTPClientChannelInboundHandler: ChannelInboundHandler {
         }
 
         // Handle client delegated errors
-        if let error = delegate.handleErrorResponses(responseHead: responseHead, responseBodyData: partialBody) {
+        if let error = delegate.handleErrorResponses(responseHead: responseHead, responseBodyData: bodyData) {
             completion(.error(error))
             return
         }

--- a/Sources/SmokeHTTPClient/HTTPClientChannelInboundHandler.swift
+++ b/Sources/SmokeHTTPClient/HTTPClientChannelInboundHandler.swift
@@ -104,9 +104,9 @@ public final class HTTPClientChannelInboundHandler: ChannelInboundHandler {
 
         switch responsePart {
         // This is the response head
-        case .head(let request):
-            responseHead = request
-            Log.verbose("Request head received.")
+        case .head(let response):
+            responseHead = response
+            Log.verbose("Response head received.")
         // This is part of the response body
         case .body(var byteBuffer):
             let byteBufferSize = byteBuffer.readableBytes
@@ -120,10 +120,10 @@ public final class HTTPClientChannelInboundHandler: ChannelInboundHandler {
                 partialBody = newData
             }
             
-            Log.verbose("Request body part of \(byteBufferSize) bytes received.")
+            Log.verbose("Response body part of \(byteBufferSize) bytes received.")
         // This is the response end
         case .end:
-            Log.verbose("Request end received.")
+            Log.verbose("Response end received.")
             // the head and all possible body parts have been received,
             // handle this response
             handleCompleteResponse(context: ctx)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* Move state mutation to private functions to reduce the possibility future changes will accidentally break state mutation and locking
* Use a `DispatchGroup` to handle closure waiters for HTTPClient, as described in https://github.com/amzn/smoke-framework/pull/18
* Fix instances of logging response as request
* Clear the HTTPClient body data as soon as possible 

*Testing performed:* Unit tests pass. Tested manually connecting to an AWS service to get back expected response.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
