### PR TITLE
Add CI Tests for Swift 5.0.1 under Ubuntu 16.04 and Ubuntu 18.04

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 build
 .DS_Store
 .build/
+.swiftpm/
 *.xcodeproj
 *~

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,11 @@ matrix:
       dist: xenial
       sudo: required
       services: docker
+      env: DOCKER_IMAGE_TAG=swift:5.0.1-bionic USE_SWIFT_LINT=yes
+    - os: linux
+      dist: xenial
+      sudo: required
+      services: docker
       env: DOCKER_IMAGE_TAG=swift:5.0.1-xenial USE_SWIFT_LINT=yes
     - os: linux
       dist: xenial

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,11 @@ matrix:
       dist: xenial
       sudo: required
       services: docker
+      env: DOCKER_IMAGE_TAG=swift:5.0.1-xenial USE_SWIFT_LINT=yes
+    - os: linux
+      dist: xenial
+      sudo: required
+      services: docker
       env: DOCKER_IMAGE_TAG=swift:4.2.1 USE_SWIFT_LINT=yes
     - os: linux
       dist: xenial

--- a/CITests/run
+++ b/CITests/run
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-swiftLintVersion=0.29.0
+swiftLintVersion=0.33.0
 
 USE_SWIFT_LINT=$1
 

--- a/CITests/run
+++ b/CITests/run
@@ -6,7 +6,7 @@ swiftLintVersion=0.33.0
 USE_SWIFT_LINT=$1
 
 apt-get update
-apt-get -y install libssl-dev
+apt-get -y install libssl-dev libz-dev
 
 workspaceRoot=($PWD)
 srcRoot=$workspaceRoot/sources

--- a/CITests/run
+++ b/CITests/run
@@ -5,6 +5,9 @@ swiftLintVersion=0.33.0
 
 USE_SWIFT_LINT=$1
 
+apt-get update
+apt-get -y install libssl-dev
+
 workspaceRoot=($PWD)
 srcRoot=$workspaceRoot/sources
 mkdir -p $srcRoot

--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@
 </a>
 <img src="https://img.shields.io/badge/os-linux-green.svg?style=flat" alt="Linux">
 <a href="http://swift.org">
-<img src="https://img.shields.io/badge/swift-5.0-orange.svg?style=flat" alt="Swift 5.0 Compatible">
-</a>
-<a href="http://swift.org">
 <img src="https://img.shields.io/badge/swift-4.1-orange.svg?style=flat" alt="Swift 4.1 Compatible">
 </a>
 <a href="http://swift.org">
 <img src="https://img.shields.io/badge/swift-4.2-orange.svg?style=flat" alt="Swift 4.1 Compatible">
+</a>
+<a href="http://swift.org">
+<img src="https://img.shields.io/badge/swift-5.0-orange.svg?style=flat" alt="Swift 5.0 Compatible">
 </a>
 <a href="https://gitter.im/SmokeServerSide">
 <img src="https://img.shields.io/badge/chat-on%20gitter-ee115e.svg?style=flat" alt="Join the Smoke Server Side community on gitter">

--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@
 </a>
 <img src="https://img.shields.io/badge/os-linux-green.svg?style=flat" alt="Linux">
 <a href="http://swift.org">
+<img src="https://img.shields.io/badge/swift-5.0-orange.svg?style=flat" alt="Swift 5.0 Compatible">
+</a>
+<a href="http://swift.org">
 <img src="https://img.shields.io/badge/swift-4.1-orange.svg?style=flat" alt="Swift 4.1 Compatible">
 </a>
 <a href="http://swift.org">


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Add CI Tests for Swift 5.0.1 under Ubuntu 16.04 and Ubuntu 18.04.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
