### PR TITLE
Migrate to swift-log and swift-metrics.

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -2,21 +2,21 @@
   "object": {
     "pins": [
       {
-        "package": "LoggerAPI",
-        "repositoryURL": "https://github.com/IBM-Swift/LoggerAPI.git",
-        "state": {
-          "branch": null,
-          "revision": "3357dd9526cdf9436fa63bb792b669e6efdc43da",
-          "version": "1.9.0"
-        }
-      },
-      {
         "package": "swift-log",
         "repositoryURL": "https://github.com/apple/swift-log.git",
         "state": {
           "branch": null,
           "revision": "e8aabbe95db22e064ad42f1a4a9f8982664c70ed",
           "version": "1.1.1"
+        }
+      },
+      {
+        "package": "swift-metrics",
+        "repositoryURL": "https://github.com/apple/swift-metrics.git",
+        "state": {
+          "branch": null,
+          "revision": "3fefedaaef285830cc98ae80231140122076a7e0",
+          "version": "1.2.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -37,12 +37,13 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.0.0"),
         .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.0.0"),
-        .package(url: "https://github.com/IBM-Swift/LoggerAPI.git", .upToNextMajor(from: "1.0.0")),
+        .package(url: "https://github.com/apple/swift-log.git", .upToNextMajor(from: "1.0.0")),
+        .package(url: "https://github.com/apple/swift-metrics.git", .upToNextMajor(from: "1.0.0")),
     ],
     targets: [
         .target(
             name: "SmokeHTTPClient",
-            dependencies: ["LoggerAPI", "NIO", "NIOHTTP1", "NIOFoundationCompat", "NIOSSL"]),
+            dependencies: ["Logging", "Metrics", "NIO", "NIOHTTP1", "NIOFoundationCompat", "NIOSSL"]),
         .target(
             name: "QueryCoding",
             dependencies: ["ShapeCoding"]),
@@ -54,7 +55,7 @@ let package = Package(
             dependencies: ["ShapeCoding"]),
         .target(
             name: "ShapeCoding",
-            dependencies: ["LoggerAPI"]),
+            dependencies: ["Logging"]),
         .testTarget(
             name: "SmokeHTTPClientTests",
             dependencies: ["SmokeHTTPClient"]),

--- a/Sources/HTTPPathCoding/HTTPPathSegment.swift
+++ b/Sources/HTTPPathCoding/HTTPPathSegment.swift
@@ -66,9 +66,7 @@ public struct HTTPPathSegment: Equatable {
         }
         
         let invalidMultiSegments = segments.dropLast().filter { segment in
-            return segment.tokens.reduce(false) { (initial, current) in
-                return initial || current.isMultiSegment
-            }
+            return segment.tokens.map { $0.isMultiSegment }.contains(true)
         }
         
         guard invalidMultiSegments.isEmpty else {

--- a/Sources/ShapeCoding/RawShape.swift
+++ b/Sources/ShapeCoding/RawShape.swift
@@ -63,7 +63,7 @@ public enum RawShape: Equatable, Codable {
         case .string(let string):
             return .string(string)
         case .dictionary(let dictionary):
-            let transformedDictionary = dictionary.mapValues{ $0.asShape }
+            let transformedDictionary = dictionary.mapValues { $0.asShape }
             
             return .dictionary(transformedDictionary)
         case .array(let array):

--- a/Sources/ShapeCoding/ShapeKeyedEncodingContainer.swift
+++ b/Sources/ShapeCoding/ShapeKeyedEncodingContainer.swift
@@ -17,7 +17,7 @@
 
 import Foundation
 
-internal struct ShapeKeyedEncodingContainer<K: CodingKey> : KeyedEncodingContainerProtocol {
+internal struct ShapeKeyedEncodingContainer<K: CodingKey>: KeyedEncodingContainerProtocol {
     typealias Key = K
 
     private let enclosingContainer: ShapeSingleValueEncodingContainer

--- a/Sources/SmokeHTTPClient/BodyHTTPRequestInput.swift
+++ b/Sources/SmokeHTTPClient/BodyHTTPRequestInput.swift
@@ -20,7 +20,7 @@ import Foundation
 /**
  HTTP Request Input that only has a body.
  */
-public struct BodyHTTPRequestInput<BodyType: Encodable> : HTTPRequestInputProtocol {
+public struct BodyHTTPRequestInput<BodyType: Encodable>: HTTPRequestInputProtocol {
     public let queryEncodable: BodyType?
     public let pathEncodable: BodyType?
     public let bodyEncodable: BodyType?

--- a/Sources/SmokeHTTPClient/HTTPClientChannelInboundHandlerDelegate.swift
+++ b/Sources/SmokeHTTPClient/HTTPClientChannelInboundHandlerDelegate.swift
@@ -17,23 +17,27 @@
 
 import Foundation
 import NIOHTTP1
+import Logging
 
 public protocol HTTPClientChannelInboundHandlerDelegate {
     var specifyContentHeadersForZeroLengthBody: Bool { get }
 
-    func addClientSpecificHeaders(handler: HTTPClientChannelInboundHandler) -> [(String, String)]
+    func addClientSpecificHeaders(handler: HTTPClientChannelInboundHandler, invocationReporting: HTTPClientInvocationReporting) -> [(String, String)]
 
-    func handleErrorResponses(responseHead: HTTPResponseHead, responseBodyData: Data?) -> HTTPClientError?
+    func handleErrorResponses(responseHead: HTTPResponseHead, responseBodyData: Data?,
+                              invocationReporting: HTTPClientInvocationReporting) -> HTTPClientError?
 }
 
-public struct DefaultHTTPClientChannelInboundHandlerDelegate {
-    let specifyContentHeadersForZeroLengthBody: Bool = true
+public struct DefaultHTTPClientChannelInboundHandlerDelegate: HTTPClientChannelInboundHandlerDelegate {
+    public let specifyContentHeadersForZeroLengthBody: Bool = true
 
-    func addClientSpecificHeaders(handler: HTTPClientChannelInboundHandler) -> [(String, String)] {
+    public func addClientSpecificHeaders(handler: HTTPClientChannelInboundHandler,
+                                         invocationReporting: HTTPClientInvocationReporting) -> [(String, String)] {
         return []
     }
 
-    func handleErrorResponses(responseHead: HTTPResponseHead, responseBodyData: Data?) -> HTTPClientError? {
+    public func handleErrorResponses(responseHead: HTTPResponseHead, responseBodyData: Data?,
+                                     invocationReporting: HTTPClientInvocationReporting) -> HTTPClientError? {
         return nil
     }
 }

--- a/Sources/SmokeHTTPClient/HTTPClientDelegate.swift
+++ b/Sources/SmokeHTTPClient/HTTPClientDelegate.swift
@@ -18,6 +18,7 @@
 import Foundation
 import NIOHTTP1
 import NIOSSL
+import Logging
 
 /**
  Delegate protocol that handles client-specific logic.
@@ -26,7 +27,8 @@ public protocol HTTPClientDelegate {
 
     /// Gets the error corresponding to a client response body on the response head and body data.
     func getResponseError(responseHead: HTTPResponseHead,
-                          responseComponents: HTTPResponseComponents) throws -> HTTPClientError
+                          responseComponents: HTTPResponseComponents,
+                          invocationReporting: HTTPClientInvocationReporting) throws -> HTTPClientError
 
     /**
      Gets the encoded input body and path with a query string for a client request.
@@ -37,12 +39,14 @@ public protocol HTTPClientDelegate {
      */
     func encodeInputAndQueryString<InputType>(
         input: InputType,
-        httpPath: String) throws -> HTTPRequestComponents
+        httpPath: String,
+        invocationReporting: HTTPClientInvocationReporting) throws -> HTTPRequestComponents
     where InputType: HTTPRequestInputProtocol
 
     /// Gets the decoded output base on the response body.
     func decodeOutput<OutputType>(output: Data?,
-                                  headers: [(String, String)]) throws -> OutputType
+                                  headers: [(String, String)],
+                                  invocationReporting: HTTPClientInvocationReporting) throws -> OutputType
     where OutputType: HTTPResponseOutputProtocol
 
     /// Gets the TLS configuration required for HTTPClient's use-case.

--- a/Sources/SmokeHTTPClient/HTTPClientInnerRetryInvocationReporting.swift
+++ b/Sources/SmokeHTTPClient/HTTPClientInnerRetryInvocationReporting.swift
@@ -11,27 +11,22 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 //
-//  QueryHTTPRequestInput.swift
+//  HTTPClientInnerRetryInvocationReporting.swift
 //  SmokeHTTPClient
 //
 
 import Foundation
+import Logging
+import Metrics
 
 /**
- HTTP Request Input that only has a query.
+ When using retry wrappers, the `HTTPClient` itself shouldn't record any metrics.
  */
-public struct QueryHTTPRequestInput<QueryType: Encodable>: HTTPRequestInputProtocol {
-    public let queryEncodable: QueryType?
-    public let pathEncodable: QueryType?
-    public let bodyEncodable: QueryType?
-    public let additionalHeadersEncodable: QueryType?
-    public let pathPostfix: String?
-
-    public init(encodable: QueryType) {
-        self.queryEncodable = encodable
-        self.pathEncodable = nil
-        self.bodyEncodable = nil
-        self.additionalHeadersEncodable = nil
-        self.pathPostfix = nil
-    }
+internal struct HTTPClientInnerRetryInvocationReporting: HTTPClientInvocationReporting {
+    let logger: Logging.Logger
+    let successCounter: Metrics.Counter? = nil
+    let failure5XXCounter: Metrics.Counter? = nil
+    let failure4XXCounter: Metrics.Counter? = nil
+    let retryCountRecorder: Metrics.Recorder? = nil
+    let latencyTimer: Metrics.Timer? = nil
 }

--- a/Sources/SmokeHTTPClient/HTTPClientInvocationContext.swift
+++ b/Sources/SmokeHTTPClient/HTTPClientInvocationContext.swift
@@ -11,27 +11,24 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 //
-//  QueryHTTPRequestInput.swift
+//  HTTPClientInvocationContext.swift
 //  SmokeHTTPClient
 //
 
 import Foundation
+import Logging
+import Metrics
 
 /**
- HTTP Request Input that only has a query.
+ A context related to the invocation of the HTTPClient.
  */
-public struct QueryHTTPRequestInput<QueryType: Encodable>: HTTPRequestInputProtocol {
-    public let queryEncodable: QueryType?
-    public let pathEncodable: QueryType?
-    public let bodyEncodable: QueryType?
-    public let additionalHeadersEncodable: QueryType?
-    public let pathPostfix: String?
-
-    public init(encodable: QueryType) {
-        self.queryEncodable = encodable
-        self.pathEncodable = nil
-        self.bodyEncodable = nil
-        self.additionalHeadersEncodable = nil
-        self.pathPostfix = nil
+public struct HTTPClientInvocationContext {
+    public let reporting: HTTPClientInvocationReporting
+    public let handlerDelegate: HTTPClientChannelInboundHandlerDelegate
+    
+    public init(reporting: HTTPClientInvocationReporting,
+                handlerDelegate: HTTPClientChannelInboundHandlerDelegate) {
+        self.reporting = reporting
+        self.handlerDelegate = handlerDelegate
     }
 }

--- a/Sources/SmokeHTTPClient/HTTPClientInvocationReporting.swift
+++ b/Sources/SmokeHTTPClient/HTTPClientInvocationReporting.swift
@@ -1,0 +1,44 @@
+// Copyright 2018-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+//  HTTPClientInvocationReporting.swift
+//  SmokeHTTPClient
+//
+
+import Foundation
+import Logging
+import Metrics
+
+/**
+ A context related to reporting on the invocation of the HTTPClient.
+ */
+public protocol HTTPClientInvocationReporting {
+    
+    /// The `Logging.Logger` to use for logging for this invocation.
+    var logger: Logging.Logger { get }
+    
+    /// The `Metrics.Counter` to record the success of this invocation.
+    var successCounter: Metrics.Counter? { get }
+    
+    /// The `Metrics.Counter` to record the failure of this invocation.
+    var failure5XXCounter: Metrics.Counter? { get }
+    
+    /// The `Metrics.Counter` to record the failure of this invocation.
+    var failure4XXCounter: Metrics.Counter? { get }
+    
+    /// The `Metrics.Recorder` to record the number of retries that occurred as part of this invocation.
+    var retryCountRecorder: Metrics.Recorder? { get }
+    
+    /// The `Metrics.Recorder` to record the duration of this invocation.
+    var latencyTimer: Metrics.Timer? { get }
+}

--- a/Sources/SmokeHTTPClient/HTTPRequestInput.swift
+++ b/Sources/SmokeHTTPClient/HTTPRequestInput.swift
@@ -23,8 +23,7 @@ import Foundation
 public struct HTTPRequestInput<QueryType: Encodable,
                                PathType: Encodable,
                                BodyType: Encodable,
-                               AdditionalHeadersType: Encodable>
-: HTTPRequestInputProtocol {
+                               AdditionalHeadersType: Encodable>: HTTPRequestInputProtocol {
     public let queryEncodable: QueryType?
     public let pathEncodable: PathType?
     public let bodyEncodable: BodyType?

--- a/Sources/SmokeHTTPClient/HttpClientError.swift
+++ b/Sources/SmokeHTTPClient/HttpClientError.swift
@@ -1,3 +1,20 @@
+// Copyright 2018-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+//  HTTPClientError.swift
+//  SmokeHTTPClient
+//
+
 public struct HTTPClientError: Error {
     public let responseCode: Int
     public let cause: Swift.Error

--- a/Sources/SmokeHTTPClient/StandardHTTPClientInvocationReporting.swift
+++ b/Sources/SmokeHTTPClient/StandardHTTPClientInvocationReporting.swift
@@ -1,0 +1,43 @@
+// Copyright 2018-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+//  StandardHTTPClientInvocationReporting.swift
+//  SmokeHTTPClient
+//
+
+import Foundation
+import Logging
+import Metrics
+
+public struct StandardHTTPClientInvocationReporting: HTTPClientInvocationReporting {
+    public let logger: Logging.Logger
+    public let successCounter: Metrics.Counter?
+    public let failure5XXCounter: Metrics.Counter?
+    public let failure4XXCounter: Metrics.Counter?
+    public let retryCountRecorder: Metrics.Recorder?
+    public let latencyTimer: Metrics.Timer?
+    
+    public init(logger: Logging.Logger = Logger(label: "com.amazon.SmokeHTTP.SmokeHTTPClient.StandardHTTPClientInvocationReporting"),
+                successCounter: Metrics.Counter? = nil,
+                failure5XXCounter: Metrics.Counter? = nil,
+                failure4XXCounter: Metrics.Counter? = nil,
+                retryCountRecorder: Metrics.Recorder? = nil,
+                latencyTimer: Metrics.Timer? = nil) {
+        self.logger = logger
+        self.successCounter = successCounter
+        self.failure5XXCounter = failure5XXCounter
+        self.failure4XXCounter = failure4XXCounter
+        self.retryCountRecorder = retryCountRecorder
+        self.latencyTimer = latencyTimer
+    }
+}


### PR DESCRIPTION
*Issue #, if available:* #31 #32

*Description of changes:* 

Adopt SwiftMetrics and record invocation metrics for-

* successCounter: Metrics.Counter
* failure5XXCounter: Metrics.Counter
* failure4XXCounter: Metrics.Counter
* retryCountRecorder: Metrics.Recorder
* latencyTimer: Metrics.Timer

Adopt SwiftLog and pass a logger instance for each invocation.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
