### PR TITLE
Swiftlint 0.36.0 supports Swift 5.1.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,12 @@ matrix:
       dist: xenial
       sudo: required
       services: docker
-      env: DOCKER_IMAGE_TAG=swift:5.1-bionic USE_SWIFT_LINT=no
+      env: DOCKER_IMAGE_TAG=swift:5.1-bionic USE_SWIFT_LINT=yes
     - os: linux
       dist: xenial
       sudo: required
       services: docker
-      env: DOCKER_IMAGE_TAG=swift:5.1-xenial USE_SWIFT_LINT=no
+      env: DOCKER_IMAGE_TAG=swift:5.1-xenial USE_SWIFT_LINT=yes
     - os: linux
       dist: xenial
       sudo: required


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Swiftlint 0.36.0 supports Swift 5.1. Enabling Swiftlint on the CI tests for this compiler version.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
