### PR TITLE
Downstream service call tracing

### DIFF
--- a/Sources/SmokeHTTPClient/HTTPClient+executeAsyncRetriableWithoutOutput.swift
+++ b/Sources/SmokeHTTPClient/HTTPClient+executeAsyncRetriableWithoutOutput.swift
@@ -27,7 +27,8 @@ public extension HTTPClient {
     /**
      Helper type that manages the state of a retriable async request.
      */
-    private class ExecuteAsyncWithoutOutputRetriable<InputType, InvocationStrategyType>
+    private class ExecuteAsyncWithoutOutputRetriable<InputType, InvocationStrategyType,
+        InvocationReportingType: HTTPClientInvocationReporting, HandlerDelegateType: HTTPClientChannelInboundHandlerDelegate>
             where InputType: HTTPRequestInputProtocol, InvocationStrategyType: AsyncResponseInvocationStrategy,
             InvocationStrategyType.OutputType == HTTPClientError? {
         let endpointOverride: URL?
@@ -36,8 +37,9 @@ public extension HTTPClient {
         let input: InputType
         let outerCompletion: (HTTPClientError?) -> ()
         let asyncResponseInvocationStrategy: InvocationStrategyType
-        let invocationContext: HTTPClientInvocationContext
-        let innerInvocationContext: HTTPClientInvocationContext
+        let invocationContext: HTTPClientInvocationContext<InvocationReportingType, HandlerDelegateType>
+        let innerInvocationContext:
+            HTTPClientInvocationContext<HTTPClientInnerRetryInvocationReporting<InvocationReportingType.TraceContextType>, HandlerDelegateType>
         let httpClient: HTTPClient
         let retryConfiguration: HTTPClientRetryConfiguration
         let retryOnError: (HTTPClientError) -> Bool
@@ -49,7 +51,7 @@ public extension HTTPClient {
         init(endpointOverride: URL?, endpointPath: String, httpMethod: HTTPMethod,
              input: InputType, outerCompletion: @escaping (HTTPClientError?) -> (),
              asyncResponseInvocationStrategy: InvocationStrategyType,
-             invocationContext: HTTPClientInvocationContext,
+             invocationContext: HTTPClientInvocationContext<InvocationReportingType, HandlerDelegateType>,
              httpClient: HTTPClient,
              retryConfiguration: HTTPClientRetryConfiguration,
              retryOnError: @escaping (HTTPClientError) -> Bool) {
@@ -71,7 +73,9 @@ public extension HTTPClient {
                 self.latencyMetricDetails = nil
             }
             // When using retry wrappers, the `HTTPClient` itself shouldn't record any metrics.
-            let innerReporting = HTTPClientInnerRetryInvocationReporting(logger: invocationContext.reporting.logger)
+            let innerReporting = HTTPClientInnerRetryInvocationReporting(internalRequestId: invocationContext.reporting.internalRequestId,
+                                                                         traceContext: invocationContext.reporting.traceContext,
+                                                                         logger: invocationContext.reporting.logger)
             self.innerInvocationContext = HTTPClientInvocationContext(reporting: innerReporting, handlerDelegate: invocationContext.handlerDelegate)
         }
         
@@ -167,13 +171,14 @@ public extension HTTPClient {
         - retryConfiguration: the retry configuration for this request.
         - retryOnError: function that should return if the provided error is retryable.
      */
-    func executeAsyncRetriableWithoutOutput<InputType>(
+    func executeAsyncRetriableWithoutOutput<InputType,
+        InvocationReportingType: HTTPClientInvocationReporting, HandlerDelegateType: HTTPClientChannelInboundHandlerDelegate>(
         endpointOverride: URL? = nil,
         endpointPath: String,
         httpMethod: HTTPMethod,
         input: InputType,
         completion: @escaping (HTTPClientError?) -> (),
-        invocationContext: HTTPClientInvocationContext,
+        invocationContext: HTTPClientInvocationContext<InvocationReportingType, HandlerDelegateType>,
         retryConfiguration: HTTPClientRetryConfiguration,
         retryOnError: @escaping (HTTPClientError) -> Bool) throws
         where InputType: HTTPRequestInputProtocol {
@@ -202,14 +207,15 @@ public extension HTTPClient {
         - retryConfiguration: the retry configuration for this request.
         - retryOnError: function that should return if the provided error is retryable.
      */
-    func executeAsyncRetriableWithoutOutput<InputType, InvocationStrategyType>(
+    func executeAsyncRetriableWithoutOutput<InputType, InvocationStrategyType,
+        InvocationReportingType: HTTPClientInvocationReporting, HandlerDelegateType: HTTPClientChannelInboundHandlerDelegate>(
         endpointOverride: URL? = nil,
         endpointPath: String,
         httpMethod: HTTPMethod,
         input: InputType,
         completion: @escaping (HTTPClientError?) -> (),
         asyncResponseInvocationStrategy: InvocationStrategyType,
-        invocationContext: HTTPClientInvocationContext,
+        invocationContext: HTTPClientInvocationContext<InvocationReportingType, HandlerDelegateType>,
         retryConfiguration: HTTPClientRetryConfiguration,
         retryOnError: @escaping (HTTPClientError) -> Bool) throws
         where InputType: HTTPRequestInputProtocol, InvocationStrategyType: AsyncResponseInvocationStrategy,

--- a/Sources/SmokeHTTPClient/HTTPClient+executeAsyncWithOutput.swift
+++ b/Sources/SmokeHTTPClient/HTTPClient+executeAsyncWithOutput.swift
@@ -36,13 +36,14 @@ public extension HTTPClient {
         - completion: Completion handler called with the response body or any error.
         - invocationContext: context to use for this invocation.
      */
-    func executeAsyncWithOutput<InputType, OutputType>(
+    func executeAsyncWithOutput<InputType, OutputType,
+        InvocationReportingType: HTTPClientInvocationReporting, HandlerDelegateType: HTTPClientChannelInboundHandlerDelegate>(
             endpointOverride: URL? = nil,
             endpointPath: String,
             httpMethod: HTTPMethod,
             input: InputType,
             completion: @escaping (Result<OutputType, HTTPClientError>) -> (),
-            invocationContext: HTTPClientInvocationContext) throws -> EventLoopFuture<Channel>
+            invocationContext: HTTPClientInvocationContext<InvocationReportingType, HandlerDelegateType>) throws -> EventLoopFuture<Channel>
         where InputType: HTTPRequestInputProtocol, OutputType: HTTPResponseOutputProtocol {
             return try executeAsyncWithOutput(
                 endpointOverride: endpointOverride,
@@ -65,14 +66,15 @@ public extension HTTPClient {
          - asyncResponseInvocationStrategy: The invocation strategy for the response from this request.
          - invocationContext: context to use for this invocation.
      */
-    func executeAsyncWithOutput<InputType, OutputType, InvocationStrategyType>(
+    func executeAsyncWithOutput<InputType, OutputType, InvocationStrategyType,
+        InvocationReportingType: HTTPClientInvocationReporting, HandlerDelegateType: HTTPClientChannelInboundHandlerDelegate>(
             endpointOverride: URL? = nil,
             endpointPath: String,
             httpMethod: HTTPMethod,
             input: InputType,
             completion: @escaping (Result<OutputType, HTTPClientError>) -> (),
             asyncResponseInvocationStrategy: InvocationStrategyType,
-            invocationContext: HTTPClientInvocationContext) throws -> EventLoopFuture<Channel>
+            invocationContext: HTTPClientInvocationContext<InvocationReportingType, HandlerDelegateType>) throws -> EventLoopFuture<Channel>
             where InputType: HTTPRequestInputProtocol, InvocationStrategyType: AsyncResponseInvocationStrategy,
         InvocationStrategyType.OutputType == Result<OutputType, HTTPClientError>,
         OutputType: HTTPResponseOutputProtocol {

--- a/Sources/SmokeHTTPClient/HTTPClient+executeAsyncWithoutOutput.swift
+++ b/Sources/SmokeHTTPClient/HTTPClient+executeAsyncWithoutOutput.swift
@@ -36,13 +36,13 @@ public extension HTTPClient {
         - completion: Completion handler called with an error if one occurs or nil otherwise.
         - invocationContext: context to use for this invocation.
      */
-    func executeAsyncWithoutOutput<InputType>(
+    func executeAsyncWithoutOutput<InputType, InvocationReportingType: HTTPClientInvocationReporting, HandlerDelegateType: HTTPClientChannelInboundHandlerDelegate>(
         endpointOverride: URL? = nil,
         endpointPath: String,
         httpMethod: HTTPMethod,
         input: InputType,
         completion: @escaping (HTTPClientError?) -> (),
-        invocationContext: HTTPClientInvocationContext) throws -> EventLoopFuture<Channel>
+        invocationContext: HTTPClientInvocationContext<InvocationReportingType, HandlerDelegateType>) throws -> EventLoopFuture<Channel>
         where InputType: HTTPRequestInputProtocol {
             return try executeAsyncWithoutOutput(
                 endpointOverride: endpointOverride,
@@ -65,14 +65,15 @@ public extension HTTPClient {
         - asyncResponseInvocationStrategy: The invocation strategy for the response from this request.
         - invocationContext: context to use for this invocation.
      */
-    func executeAsyncWithoutOutput<InputType, InvocationStrategyType>(
+    func executeAsyncWithoutOutput<InputType, InvocationStrategyType,
+            InvocationReportingType: HTTPClientInvocationReporting, HandlerDelegateType: HTTPClientChannelInboundHandlerDelegate>(
         endpointOverride: URL? = nil,
         endpointPath: String,
         httpMethod: HTTPMethod,
         input: InputType,
         completion: @escaping (HTTPClientError?) -> (),
         asyncResponseInvocationStrategy: InvocationStrategyType,
-        invocationContext: HTTPClientInvocationContext) throws -> EventLoopFuture<Channel>
+        invocationContext: HTTPClientInvocationContext<InvocationReportingType, HandlerDelegateType>) throws -> EventLoopFuture<Channel>
         where InputType: HTTPRequestInputProtocol, InvocationStrategyType: AsyncResponseInvocationStrategy,
         InvocationStrategyType.OutputType == HTTPClientError? {
             

--- a/Sources/SmokeHTTPClient/HTTPClient+executeSyncRetriableWithOutput.swift
+++ b/Sources/SmokeHTTPClient/HTTPClient+executeSyncRetriableWithOutput.swift
@@ -27,15 +27,17 @@ public extension HTTPClient {
     /**
      Helper type that manages the state of a retriable sync request.
      */
-    private class ExecuteSyncWithOutputRetriable<InputType, OutputType>
+    private class ExecuteSyncWithOutputRetriable<InputType, OutputType,
+            InvocationReportingType: HTTPClientInvocationReporting, HandlerDelegateType: HTTPClientChannelInboundHandlerDelegate>
             where InputType: HTTPRequestInputProtocol,
             OutputType: HTTPResponseOutputProtocol {
         let endpointOverride: URL?
         let endpointPath: String
         let httpMethod: HTTPMethod
         let input: InputType
-        let invocationContext: HTTPClientInvocationContext
-        let innerInvocationContext: HTTPClientInvocationContext
+        let invocationContext: HTTPClientInvocationContext<InvocationReportingType, HandlerDelegateType>
+        let innerInvocationContext:
+            HTTPClientInvocationContext<HTTPClientInnerRetryInvocationReporting<InvocationReportingType.TraceContextType>, HandlerDelegateType>
         let httpClient: HTTPClient
         let retryConfiguration: HTTPClientRetryConfiguration
         let retryOnError: (HTTPClientError) -> Bool
@@ -47,7 +49,7 @@ public extension HTTPClient {
         
         init(endpointOverride: URL?, endpointPath: String, httpMethod: HTTPMethod,
              input: InputType,
-             invocationContext: HTTPClientInvocationContext,
+             invocationContext: HTTPClientInvocationContext<InvocationReportingType, HandlerDelegateType>,
              httpClient: HTTPClient,
              retryConfiguration: HTTPClientRetryConfiguration,
              retryOnError: @escaping (Swift.Error) -> Bool) {
@@ -67,7 +69,9 @@ public extension HTTPClient {
                 self.latencyMetricDetails = nil
             }
             // When using retry wrappers, the `HTTPClient` itself shouldn't record any metrics.
-            let innerReporting = HTTPClientInnerRetryInvocationReporting(logger: invocationContext.reporting.logger)
+            let innerReporting = HTTPClientInnerRetryInvocationReporting(internalRequestId: invocationContext.reporting.internalRequestId,
+                                                                         traceContext: invocationContext.reporting.traceContext,
+                                                                         logger: invocationContext.reporting.logger)
             self.innerInvocationContext = HTTPClientInvocationContext(reporting: innerReporting, handlerDelegate: invocationContext.handlerDelegate)
         }
         
@@ -156,18 +160,19 @@ public extension HTTPClient {
         - retryConfiguration: the retry configuration for this request.
         - retryOnError: function that should return if the provided error is retryable.
      */
-    func executeSyncRetriableWithOutput<InputType, OutputType>(
+    func executeSyncRetriableWithOutput<InputType, OutputType,
+            InvocationReportingType: HTTPClientInvocationReporting, HandlerDelegateType: HTTPClientChannelInboundHandlerDelegate>(
         endpointOverride: URL? = nil,
         endpointPath: String,
         httpMethod: HTTPMethod,
         input: InputType,
-        invocationContext: HTTPClientInvocationContext,
+        invocationContext: HTTPClientInvocationContext<InvocationReportingType, HandlerDelegateType>,
         retryConfiguration: HTTPClientRetryConfiguration,
         retryOnError: @escaping (Swift.Error) -> Bool) throws -> OutputType
         where InputType: HTTPRequestInputProtocol,
         OutputType: HTTPResponseOutputProtocol {
 
-            let retriable = ExecuteSyncWithOutputRetriable<InputType, OutputType>(
+            let retriable = ExecuteSyncWithOutputRetriable<InputType, OutputType, InvocationReportingType, HandlerDelegateType>(
                 endpointOverride: endpointOverride, endpointPath: endpointPath,
                 httpMethod: httpMethod, input: input,
                 invocationContext: invocationContext, httpClient: self,

--- a/Sources/SmokeHTTPClient/HTTPClient+executeSyncWithOutput.swift
+++ b/Sources/SmokeHTTPClient/HTTPClient+executeSyncWithOutput.swift
@@ -34,12 +34,12 @@ public extension HTTPClient {
          - Returns: the response body.
          - Throws: If an error occurred during the request.
      */
-    func executeSyncWithOutput<InputType, OutputType>(
+    func executeSyncWithOutput<InputType, OutputType, InvocationReportingType: HTTPClientInvocationReporting, HandlerDelegateType: HTTPClientChannelInboundHandlerDelegate>(
         endpointOverride: URL? = nil,
         endpointPath: String,
         httpMethod: HTTPMethod,
         input: InputType,
-        invocationContext: HTTPClientInvocationContext) throws -> OutputType
+        invocationContext: HTTPClientInvocationContext<InvocationReportingType, HandlerDelegateType>) throws -> OutputType
         where InputType: HTTPRequestInputProtocol,
         OutputType: HTTPResponseOutputProtocol {
             

--- a/Sources/SmokeHTTPClient/HTTPClient+executeSyncWithoutOutput.swift
+++ b/Sources/SmokeHTTPClient/HTTPClient+executeSyncWithoutOutput.swift
@@ -34,12 +34,12 @@ public extension HTTPClient {
          - invocationContext: context to use for this invocation.
          - Throws: If an error occurred during the request.
      */
-    func executeSyncWithoutOutput<InputType>(
+    func executeSyncWithoutOutput<InputType, InvocationReportingType: HTTPClientInvocationReporting, HandlerDelegateType: HTTPClientChannelInboundHandlerDelegate>(
         endpointOverride: URL? = nil,
         endpointPath: String,
         httpMethod: HTTPMethod,
         input: InputType,
-        invocationContext: HTTPClientInvocationContext) throws
+        invocationContext: HTTPClientInvocationContext<InvocationReportingType, HandlerDelegateType>) throws
         where InputType: HTTPRequestInputProtocol {
             var responseError: HTTPClientError?
             let completedSemaphore = DispatchSemaphore(value: 0)

--- a/Sources/SmokeHTTPClient/HTTPClient.swift
+++ b/Sources/SmokeHTTPClient/HTTPClient.swift
@@ -163,13 +163,13 @@ public class HTTPClient {
         }
     }
 
-    func executeAsync<InputType>(
+    func executeAsync<InputType, InvocationReportingType: HTTPClientInvocationReporting, HandlerDelegateType: HTTPClientChannelInboundHandlerDelegate>(
             endpointOverride: URL? = nil,
             endpointPath: String,
             httpMethod: HTTPMethod,
             input: InputType,
             completion: @escaping (Result<HTTPResponseComponents, HTTPClientError>) -> (),
-            invocationContext: HTTPClientInvocationContext) throws -> EventLoopFuture<Channel>
+            invocationContext: HTTPClientInvocationContext<InvocationReportingType, HandlerDelegateType>) throws -> EventLoopFuture<Channel>
             where InputType: HTTPRequestInputProtocol {
 
         let endpointHostName = endpointOverride?.host ?? self.endpointHostName

--- a/Sources/SmokeHTTPClient/HTTPClientChannelInboundHandler.swift
+++ b/Sources/SmokeHTTPClient/HTTPClientChannelInboundHandler.swift
@@ -35,7 +35,8 @@ internal struct HttpHeaderNames {
  Implementation of the ChannelInboundHandler protocol that handles sending
  data to the server and receiving a response.
  */
-public final class HTTPClientChannelInboundHandler: ChannelInboundHandler {
+public final class HTTPClientChannelInboundHandler<InvocationReportingType: HTTPClientInvocationReporting,
+        HandlerDelegateType: HTTPClientChannelInboundHandlerDelegate>: ChannelInboundHandler {
     public typealias InboundIn = HTTPClientResponsePart
     public typealias OutboundOut = HTTPClientRequestPart
 
@@ -55,14 +56,15 @@ public final class HTTPClientChannelInboundHandler: ChannelInboundHandler {
     public var responseHead: HTTPResponseHead?
     /// The body data previously received.
     public var partialBody: Data?
+    public var outwardsRequestContext: InvocationReportingType.TraceContextType.OutwardsRequestContext?
 
     /// A completion handler to pass any recieved response to.
     private let completion: (Result<HTTPResponseComponents, HTTPClientError>) -> ()
     /// A function that provides an Error based on the payload provided.
-    private let errorProvider: (HTTPResponseHead, HTTPResponseComponents, HTTPClientInvocationReporting) throws -> HTTPClientError
+    private let errorProvider: (HTTPResponseHead, HTTPResponseComponents, InvocationReportingType) throws -> HTTPClientError
     /// Delegate that provides client-specific logic
-    private let delegate: HTTPClientChannelInboundHandlerDelegate
-    private let invocationReporting: HTTPClientInvocationReporting
+    private let delegate: HandlerDelegateType
+    private let invocationReporting: InvocationReportingType
 
     /**
      Initializer.
@@ -83,10 +85,10 @@ public final class HTTPClientChannelInboundHandler: ChannelInboundHandler {
          httpMethod: HTTPMethod,
          bodyData: Data,
          additionalHeaders: [(String, String)],
-         errorProvider: @escaping (HTTPResponseHead, HTTPResponseComponents, HTTPClientInvocationReporting) throws -> HTTPClientError,
+         errorProvider: @escaping (HTTPResponseHead, HTTPResponseComponents, InvocationReportingType) throws -> HTTPClientError,
          completion: @escaping (Result<HTTPResponseComponents, HTTPClientError>) -> (),
-         channelInboundHandlerDelegate: HTTPClientChannelInboundHandlerDelegate,
-         invocationReporting: HTTPClientInvocationReporting) {
+         channelInboundHandlerDelegate: HandlerDelegateType,
+         invocationReporting: InvocationReportingType) {
         self.contentType = contentType
         self.endpointUrl = endpointUrl
         self.endpointPath = endpointPath
@@ -164,6 +166,11 @@ public final class HTTPClientChannelInboundHandler: ChannelInboundHandler {
             let error = HTTPClientError(responseCode: 400, cause: cause)
 
             logger.error("Response head was not received")
+            
+            invocationReporting.traceContext.handleOutwardsRequestFailure(outwardsRequestContext: self.outwardsRequestContext,
+                                                                          logger: self.invocationReporting.logger,
+                                                                          internalRequestId: self.invocationReporting.internalRequestId,
+                                                                          responseHead: nil,bodyData: bodyData, error: error)
 
             // complete with this error
             completion(.failure(error))
@@ -192,6 +199,11 @@ public final class HTTPClientChannelInboundHandler: ChannelInboundHandler {
 
         // if the response status is ok
         if isSuccess {
+            invocationReporting.traceContext.handleOutwardsRequestSuccess(outwardsRequestContext: self.outwardsRequestContext,
+                                                                          logger: self.invocationReporting.logger,
+                                                                          internalRequestId: self.invocationReporting.internalRequestId,
+                                                                          responseHead: responseHead, bodyData: bodyData)
+            
             // complete with the response data (potentially empty)
             completion(.success(responseComponents))
             return
@@ -201,6 +213,11 @@ public final class HTTPClientChannelInboundHandler: ChannelInboundHandler {
         if let error = delegate.handleErrorResponses(responseHead: responseHead,
                                                      responseBodyData: bodyData,
                                                      invocationReporting: invocationReporting) {
+            invocationReporting.traceContext.handleOutwardsRequestFailure(outwardsRequestContext: self.outwardsRequestContext,
+                                                                          logger: self.invocationReporting.logger,
+                                                                          internalRequestId: self.invocationReporting.internalRequestId,
+                                                                          responseHead: responseHead, bodyData: bodyData, error: error)
+            
             completion(.failure(error))
             return
         }
@@ -215,6 +232,11 @@ public final class HTTPClientChannelInboundHandler: ChannelInboundHandler {
             // if the provider throws an error, use this error
             responseError = HTTPClientError(responseCode: 400, cause: error)
         }
+        
+        invocationReporting.traceContext.handleOutwardsRequestFailure(outwardsRequestContext: self.outwardsRequestContext,
+                                                                      logger: self.invocationReporting.logger,
+                                                                      internalRequestId: self.invocationReporting.internalRequestId,
+                                                                      responseHead: responseHead, bodyData: bodyData, error: responseError)
 
         // complete with the error
         completion(.failure(responseError))
@@ -250,8 +272,15 @@ public final class HTTPClientChannelInboundHandler: ChannelInboundHandler {
         headers.append(("Accept", "*/*"))
 
         // Create the request head
-        var httpRequestHead = HTTPRequestHead(version: HTTPVersion(major: 1, minor: 1),
+        let httpVersion = HTTPVersion(major: 1, minor: 1)
+        var httpRequestHead = HTTPRequestHead(version: httpVersion,
                                               method: httpMethod, uri: endpointPath)
+        
+        self.outwardsRequestContext = invocationReporting.traceContext.handleOutwardsRequestStart(method: httpMethod, uri: endpointPath, version: httpVersion,
+                                                                                                  logger: self.invocationReporting.logger,
+                                                                                                  internalRequestId: self.invocationReporting.internalRequestId,
+                                                                                                  headers: &headers, bodyData: bodyData)
+        
         httpRequestHead.headers = HTTPHeaders(headers)
 
         // copy the body data to a ByteBuffer

--- a/Sources/SmokeHTTPClient/HTTPClientChannelInboundHandler.swift
+++ b/Sources/SmokeHTTPClient/HTTPClientChannelInboundHandler.swift
@@ -35,8 +35,7 @@ internal struct HttpHeaderNames {
  Implementation of the ChannelInboundHandler protocol that handles sending
  data to the server and receiving a response.
  */
-public final class HTTPClientChannelInboundHandler<InvocationReportingType: HTTPClientInvocationReporting,
-        HandlerDelegateType: HTTPClientChannelInboundHandlerDelegate>: ChannelInboundHandler {
+public final class HTTPClientChannelInboundHandler<InvocationReportingType: HTTPClientInvocationReporting>: ChannelInboundHandler {
     public typealias InboundIn = HTTPClientResponsePart
     public typealias OutboundOut = HTTPClientRequestPart
 
@@ -63,7 +62,9 @@ public final class HTTPClientChannelInboundHandler<InvocationReportingType: HTTP
     /// A function that provides an Error based on the payload provided.
     private let errorProvider: (HTTPResponseHead, HTTPResponseComponents, InvocationReportingType) throws -> HTTPClientError
     /// Delegate that provides client-specific logic
-    private let delegate: HandlerDelegateType
+    /// TODO: It is possible for this type to be generic with the HTTPClientChannelInboundHandlerDelegate once compatibility
+    /// with Swift 5.0 is dropped (requires the ability to refer to Self as a generic parameter)
+    private let delegate: HTTPClientChannelInboundHandlerDelegate
     private let invocationReporting: InvocationReportingType
 
     /**
@@ -87,7 +88,7 @@ public final class HTTPClientChannelInboundHandler<InvocationReportingType: HTTP
          additionalHeaders: [(String, String)],
          errorProvider: @escaping (HTTPResponseHead, HTTPResponseComponents, InvocationReportingType) throws -> HTTPClientError,
          completion: @escaping (Result<HTTPResponseComponents, HTTPClientError>) -> (),
-         channelInboundHandlerDelegate: HandlerDelegateType,
+         channelInboundHandlerDelegate: HTTPClientChannelInboundHandlerDelegate,
          invocationReporting: InvocationReportingType) {
         self.contentType = contentType
         self.endpointUrl = endpointUrl

--- a/Sources/SmokeHTTPClient/HTTPClientChannelInboundHandlerDelegate.swift
+++ b/Sources/SmokeHTTPClient/HTTPClientChannelInboundHandlerDelegate.swift
@@ -22,22 +22,27 @@ import Logging
 public protocol HTTPClientChannelInboundHandlerDelegate {
     var specifyContentHeadersForZeroLengthBody: Bool { get }
 
-    func addClientSpecificHeaders(handler: HTTPClientChannelInboundHandler, invocationReporting: HTTPClientInvocationReporting) -> [(String, String)]
+    func addClientSpecificHeaders<InvocationReportingType: HTTPClientInvocationReporting>(
+        handler: HTTPClientChannelInboundHandler<InvocationReportingType, Self>,
+        invocationReporting: InvocationReportingType) -> [(String, String)]
 
-    func handleErrorResponses(responseHead: HTTPResponseHead, responseBodyData: Data?,
-                              invocationReporting: HTTPClientInvocationReporting) -> HTTPClientError?
+    func handleErrorResponses<InvocationReportingType: HTTPClientInvocationReporting>(
+        responseHead: HTTPResponseHead, responseBodyData: Data?,
+        invocationReporting: InvocationReportingType) -> HTTPClientError?
 }
 
 public struct DefaultHTTPClientChannelInboundHandlerDelegate: HTTPClientChannelInboundHandlerDelegate {
     public let specifyContentHeadersForZeroLengthBody: Bool = true
 
-    public func addClientSpecificHeaders(handler: HTTPClientChannelInboundHandler,
-                                         invocationReporting: HTTPClientInvocationReporting) -> [(String, String)] {
+    public func addClientSpecificHeaders<InvocationReportingType: HTTPClientInvocationReporting>(
+            handler: HTTPClientChannelInboundHandler<InvocationReportingType, Self>,
+            invocationReporting: InvocationReportingType) -> [(String, String)] {
         return []
     }
 
-    public func handleErrorResponses(responseHead: HTTPResponseHead, responseBodyData: Data?,
-                                     invocationReporting: HTTPClientInvocationReporting) -> HTTPClientError? {
+    public func handleErrorResponses<InvocationReportingType: HTTPClientInvocationReporting>(
+            responseHead: HTTPResponseHead, responseBodyData: Data?,
+            invocationReporting: InvocationReportingType) -> HTTPClientError? {
         return nil
     }
 }

--- a/Sources/SmokeHTTPClient/HTTPClientChannelInboundHandlerDelegate.swift
+++ b/Sources/SmokeHTTPClient/HTTPClientChannelInboundHandlerDelegate.swift
@@ -23,7 +23,7 @@ public protocol HTTPClientChannelInboundHandlerDelegate {
     var specifyContentHeadersForZeroLengthBody: Bool { get }
 
     func addClientSpecificHeaders<InvocationReportingType: HTTPClientInvocationReporting>(
-        handler: HTTPClientChannelInboundHandler<InvocationReportingType, Self>,
+        handler: HTTPClientChannelInboundHandler<InvocationReportingType>,
         invocationReporting: InvocationReportingType) -> [(String, String)]
 
     func handleErrorResponses<InvocationReportingType: HTTPClientInvocationReporting>(
@@ -35,7 +35,7 @@ public struct DefaultHTTPClientChannelInboundHandlerDelegate: HTTPClientChannelI
     public let specifyContentHeadersForZeroLengthBody: Bool = true
 
     public func addClientSpecificHeaders<InvocationReportingType: HTTPClientInvocationReporting>(
-            handler: HTTPClientChannelInboundHandler<InvocationReportingType, Self>,
+            handler: HTTPClientChannelInboundHandler<InvocationReportingType>,
             invocationReporting: InvocationReportingType) -> [(String, String)] {
         return []
     }

--- a/Sources/SmokeHTTPClient/HTTPClientDelegate.swift
+++ b/Sources/SmokeHTTPClient/HTTPClientDelegate.swift
@@ -26,9 +26,10 @@ import Logging
 public protocol HTTPClientDelegate {
 
     /// Gets the error corresponding to a client response body on the response head and body data.
-    func getResponseError(responseHead: HTTPResponseHead,
-                          responseComponents: HTTPResponseComponents,
-                          invocationReporting: HTTPClientInvocationReporting) throws -> HTTPClientError
+    func getResponseError<InvocationReportingType: HTTPClientInvocationReporting>(
+        responseHead: HTTPResponseHead,
+        responseComponents: HTTPResponseComponents,
+        invocationReporting: InvocationReportingType) throws -> HTTPClientError
 
     /**
      Gets the encoded input body and path with a query string for a client request.
@@ -37,16 +38,17 @@ public protocol HTTPClientDelegate {
         - input: The input used to define the request.
         - httpPath: The http path for the request.
      */
-    func encodeInputAndQueryString<InputType>(
+    func encodeInputAndQueryString<InputType, InvocationReportingType: HTTPClientInvocationReporting>(
         input: InputType,
         httpPath: String,
-        invocationReporting: HTTPClientInvocationReporting) throws -> HTTPRequestComponents
+        invocationReporting: InvocationReportingType) throws -> HTTPRequestComponents
     where InputType: HTTPRequestInputProtocol
 
     /// Gets the decoded output base on the response body.
-    func decodeOutput<OutputType>(output: Data?,
-                                  headers: [(String, String)],
-                                  invocationReporting: HTTPClientInvocationReporting) throws -> OutputType
+    func decodeOutput<OutputType, InvocationReportingType: HTTPClientInvocationReporting>(
+        output: Data?,
+        headers: [(String, String)],
+        invocationReporting: InvocationReportingType) throws -> OutputType
     where OutputType: HTTPResponseOutputProtocol
 
     /// Gets the TLS configuration required for HTTPClient's use-case.

--- a/Sources/SmokeHTTPClient/HTTPClientInnerRetryInvocationReporting.swift
+++ b/Sources/SmokeHTTPClient/HTTPClientInnerRetryInvocationReporting.swift
@@ -22,7 +22,9 @@ import Metrics
 /**
  When using retry wrappers, the `HTTPClient` itself shouldn't record any metrics.
  */
-internal struct HTTPClientInnerRetryInvocationReporting: HTTPClientInvocationReporting {
+internal struct HTTPClientInnerRetryInvocationReporting<TraceContextType: InvocationTraceContext>: HTTPClientInvocationReporting {
+    let internalRequestId: String
+    let traceContext: TraceContextType
     let logger: Logging.Logger
     let successCounter: Metrics.Counter? = nil
     let failure5XXCounter: Metrics.Counter? = nil

--- a/Sources/SmokeHTTPClient/HTTPClientInvocationContext.swift
+++ b/Sources/SmokeHTTPClient/HTTPClientInvocationContext.swift
@@ -22,12 +22,12 @@ import Metrics
 /**
  A context related to the invocation of the HTTPClient.
  */
-public struct HTTPClientInvocationContext {
-    public let reporting: HTTPClientInvocationReporting
-    public let handlerDelegate: HTTPClientChannelInboundHandlerDelegate
+public struct HTTPClientInvocationContext<InvocationReportingType: HTTPClientInvocationReporting, HandlerDelegateType: HTTPClientChannelInboundHandlerDelegate> {
+    public let reporting: InvocationReportingType
+    public let handlerDelegate: HandlerDelegateType
     
-    public init(reporting: HTTPClientInvocationReporting,
-                handlerDelegate: HTTPClientChannelInboundHandlerDelegate) {
+    public init(reporting: InvocationReportingType,
+                handlerDelegate: HandlerDelegateType) {
         self.reporting = reporting
         self.handlerDelegate = handlerDelegate
     }

--- a/Sources/SmokeHTTPClient/HTTPClientInvocationReporting.swift
+++ b/Sources/SmokeHTTPClient/HTTPClientInvocationReporting.swift
@@ -23,9 +23,16 @@ import Metrics
  A context related to reporting on the invocation of the HTTPClient.
  */
 public protocol HTTPClientInvocationReporting {
+    associatedtype TraceContextType: InvocationTraceContext
     
     /// The `Logging.Logger` to use for logging for this invocation.
     var logger: Logging.Logger { get }
+    
+    /// The internal Request Id associated with this invocation.
+    var internalRequestId: String { get }
+    
+    /// The trace context associated with this invocation.
+    var traceContext: TraceContextType { get }
     
     /// The `Metrics.Counter` to record the success of this invocation.
     var successCounter: Metrics.Counter? { get }

--- a/Sources/SmokeHTTPClient/InvocationTraceContext.swift
+++ b/Sources/SmokeHTTPClient/InvocationTraceContext.swift
@@ -1,0 +1,37 @@
+// Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+//  OperationTraceContext.swift
+//  SmokeHTTPClient
+//
+
+import Foundation
+import NIOHTTP1
+import Logging
+
+public protocol InvocationTraceContext {
+    associatedtype OutwardsRequestContext
+    
+    func handleOutwardsRequestStart(
+        method: HTTPMethod, uri: String,
+        version: HTTPVersion, logger: Logging.Logger, internalRequestId: String,
+        headers: inout [(String, String)], bodyData: Data) -> OutwardsRequestContext
+    
+    func handleOutwardsRequestSuccess(
+        outwardsRequestContext: OutwardsRequestContext?, logger: Logging.Logger, internalRequestId: String, responseHead: HTTPResponseHead?,
+                                      bodyData: Data?)
+    
+    func handleOutwardsRequestFailure(
+        outwardsRequestContext: OutwardsRequestContext?, logger: Logging.Logger, internalRequestId: String, responseHead: HTTPResponseHead?,
+                                      bodyData: Data?, error: Swift.Error)
+}

--- a/Sources/SmokeHTTPClient/InvocationTraceContext.swift
+++ b/Sources/SmokeHTTPClient/InvocationTraceContext.swift
@@ -11,7 +11,7 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 //
-//  OperationTraceContext.swift
+//  InvocationTraceContext.swift
 //  SmokeHTTPClient
 //
 

--- a/Sources/SmokeHTTPClient/StandardHTTPClientInvocationReporting.swift
+++ b/Sources/SmokeHTTPClient/StandardHTTPClientInvocationReporting.swift
@@ -19,7 +19,9 @@ import Foundation
 import Logging
 import Metrics
 
-public struct StandardHTTPClientInvocationReporting: HTTPClientInvocationReporting {
+public struct StandardHTTPClientInvocationReporting<TraceContextType: InvocationTraceContext>: HTTPClientInvocationReporting {
+    public let internalRequestId: String
+    public let traceContext: TraceContextType
     public let logger: Logging.Logger
     public let successCounter: Metrics.Counter?
     public let failure5XXCounter: Metrics.Counter?
@@ -27,13 +29,17 @@ public struct StandardHTTPClientInvocationReporting: HTTPClientInvocationReporti
     public let retryCountRecorder: Metrics.Recorder?
     public let latencyTimer: Metrics.Timer?
     
-    public init(logger: Logging.Logger = Logger(label: "com.amazon.SmokeHTTP.SmokeHTTPClient.StandardHTTPClientInvocationReporting"),
+    public init(internalRequestId: String,
+                traceContext: TraceContextType,
+                logger: Logging.Logger = Logger(label: "com.amazon.SmokeHTTP.SmokeHTTPClient.StandardHTTPClientInvocationReporting"),
                 successCounter: Metrics.Counter? = nil,
                 failure5XXCounter: Metrics.Counter? = nil,
                 failure4XXCounter: Metrics.Counter? = nil,
                 retryCountRecorder: Metrics.Recorder? = nil,
                 latencyTimer: Metrics.Timer? = nil) {
         self.logger = logger
+        self.internalRequestId = internalRequestId
+        self.traceContext = traceContext
         self.successCounter = successCounter
         self.failure5XXCounter = failure5XXCounter
         self.failure4XXCounter = failure4XXCounter


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Pass through a tracing context type, with the ability for that type to record the start and end of a downstream service call, modify the headers sent on the call and use the headers from the response.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
