### PR TITLE
Add public constructor to MockInvocationTraceContext

### DIFF
--- a/Sources/SmokeHTTPClient/MockInvocationTraceContext.swift
+++ b/Sources/SmokeHTTPClient/MockInvocationTraceContext.swift
@@ -22,6 +22,10 @@ import NIOHTTP1
 public struct MockInvocationTraceContext: InvocationTraceContext {
     public typealias OutwardsRequestContext = String
     
+    public init() {
+        
+    }
+    
     public func handleOutwardsRequestStart(method: HTTPMethod, uri: String, version: HTTPVersion, logger: Logger, internalRequestId: String,
                                     headers: inout [(String, String)], bodyData: Data) -> String {
         return "OutwardsRequestContext"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Add public constructor to MockInvocationTraceContext


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
