### PR TITLE
Add HTTPClientCoreInvocationReporting protocol

### DIFF
--- a/Sources/SmokeHTTPClient/HTTPClientCoreInvocationReporting.swift
+++ b/Sources/SmokeHTTPClient/HTTPClientCoreInvocationReporting.swift
@@ -1,0 +1,39 @@
+// Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+//  HTTPClientCoreInvocationReporting.swift
+//  SmokeHTTPClient
+//
+
+import Foundation
+import Logging
+
+/**
+ A context related to reporting on the invocation of the HTTPClient. This represents the
+ core requirements for invocation reporting.
+ 
+ The HTTPClientCoreInvocationReporting protocol can exposed by higher level clients that manage the
+ metrics requirements of the HTTPClientInvocationReporting protocol.
+ */
+public protocol HTTPClientCoreInvocationReporting {
+    associatedtype TraceContextType: InvocationTraceContext
+    
+    /// The `Logging.Logger` to use for logging for this invocation.
+    var logger: Logging.Logger { get }
+    
+    /// The internal Request Id associated with this invocation.
+    var internalRequestId: String { get }
+    
+    /// The trace context associated with this invocation.
+    var traceContext: TraceContextType { get }
+}

--- a/Sources/SmokeHTTPClient/HTTPClientInvocationReporting.swift
+++ b/Sources/SmokeHTTPClient/HTTPClientInvocationReporting.swift
@@ -20,19 +20,10 @@ import Logging
 import Metrics
 
 /**
- A context related to reporting on the invocation of the HTTPClient.
+ A context related to reporting on the invocation of the HTTPClient. This interface extends the
+ HTTPClientCoreInvocationReporting protocol by adding metrics emitted by the 
  */
-public protocol HTTPClientInvocationReporting {
-    associatedtype TraceContextType: InvocationTraceContext
-    
-    /// The `Logging.Logger` to use for logging for this invocation.
-    var logger: Logging.Logger { get }
-    
-    /// The internal Request Id associated with this invocation.
-    var internalRequestId: String { get }
-    
-    /// The trace context associated with this invocation.
-    var traceContext: TraceContextType { get }
+public protocol HTTPClientInvocationReporting: HTTPClientCoreInvocationReporting {
     
     /// The `Metrics.Counter` to record the success of this invocation.
     var successCounter: Metrics.Counter? { get }

--- a/Sources/SmokeHTTPClient/MockCoreInvocationReporting.swift
+++ b/Sources/SmokeHTTPClient/MockCoreInvocationReporting.swift
@@ -1,0 +1,39 @@
+// Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+//  MockCoreInvocationReporting.swift
+//  SmokeHTTPClient
+//
+import Foundation
+import Logging
+
+/**
+  A type conforming to the `HTTPClientCoreInvocationReporting` protocol, predominantly for testing.
+ */
+public struct MockCoreInvocationReporting: HTTPClientCoreInvocationReporting {
+    public let logger: Logger
+    public var internalRequestId: String
+    public var traceContext: MockInvocationTraceContext
+    
+    public init(
+            logger: Logger = Logger(label: "com.amazon.SmokeHTTPClient.MockCoreInvocationReporting"),
+            internalRequestId: String = "internalRequestId",
+            traceContext: MockInvocationTraceContext = .init()) {
+        self.logger = logger
+        self.internalRequestId = internalRequestId
+        self.traceContext = traceContext
+    }
+}
+ 
+ 
+    


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Add HTTPClientCoreInvocationReporting protocol and the MockCoreInvocationReporting implementation, replacing equivalents in SmokeAWS, allowing these interfaces to be used without taking a dependency on SmokeAWS.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
