### PR TITLE
Provide an outgoingRequestId as Logger metadata 

### DIFF
--- a/Sources/SmokeHTTPClient/HTTPClient+executeAsyncRetriableWithOutput.swift
+++ b/Sources/SmokeHTTPClient/HTTPClient+executeAsyncRetriableWithOutput.swift
@@ -82,11 +82,12 @@ public extension HTTPClient {
         
         func executeAsyncWithOutput() throws {
             // submit the asynchronous request
-            _ = try httpClient.executeAsyncWithOutput(endpointOverride: endpointOverride,
-                                                      endpointPath: endpointPath, httpMethod: httpMethod,
-                                                      input: input, completion: completion,
-                                                      asyncResponseInvocationStrategy: asyncResponseInvocationStrategy,
-                                                      invocationContext: innerInvocationContext)
+            _ = try httpClient.executeAsyncWithOutputWithWrappedInvocationContext(
+                endpointOverride: endpointOverride,
+                endpointPath: endpointPath, httpMethod: httpMethod,
+                input: input, completion: completion,
+                asyncResponseInvocationStrategy: asyncResponseInvocationStrategy,
+                invocationContext: innerInvocationContext)
         }
         
         func completion(innerResult: Result<OutputType, HTTPClientError>) {
@@ -223,12 +224,13 @@ public extension HTTPClient {
         where InputType: HTTPRequestInputProtocol, InvocationStrategyType: AsyncResponseInvocationStrategy,
         InvocationStrategyType.OutputType == Result<OutputType, HTTPClientError>,
         OutputType: HTTPResponseOutputProtocol {
-
+            let wrappingInvocationContext = invocationContext.withOutgoingRequestIdLoggerMetadata()
+            
             let retriable = ExecuteAsyncWithOutputRetriable(
                 endpointOverride: endpointOverride, endpointPath: endpointPath,
                 httpMethod: httpMethod, input: input, outerCompletion: completion,
                 asyncResponseInvocationStrategy: asyncResponseInvocationStrategy,
-                invocationContext: invocationContext, httpClient: self,
+                invocationContext: wrappingInvocationContext, httpClient: self,
                 retryConfiguration: retryConfiguration,
                 retryOnError: retryOnError)
             

--- a/Sources/SmokeHTTPClient/HTTPClient+executeAsyncRetriableWithoutOutput.swift
+++ b/Sources/SmokeHTTPClient/HTTPClient+executeAsyncRetriableWithoutOutput.swift
@@ -81,11 +81,12 @@ public extension HTTPClient {
         
         func executeAsyncWithoutOutput() throws {
             // submit the asynchronous request
-            _ = try httpClient.executeAsyncWithoutOutput(endpointOverride: endpointOverride,
-                                                         endpointPath: endpointPath, httpMethod: httpMethod,
-                                                         input: input, completion: completion,
-                                                         asyncResponseInvocationStrategy: asyncResponseInvocationStrategy,
-                                                         invocationContext: innerInvocationContext)
+            _ = try httpClient.executeAsyncWithoutOutputWithWrappedInvocationContext(
+                endpointOverride: endpointOverride,
+                endpointPath: endpointPath, httpMethod: httpMethod,
+                input: input, completion: completion,
+                asyncResponseInvocationStrategy: asyncResponseInvocationStrategy,
+                invocationContext: innerInvocationContext)
         }
         
         func completion(innerError: HTTPClientError?) {
@@ -220,12 +221,13 @@ public extension HTTPClient {
         retryOnError: @escaping (HTTPClientError) -> Bool) throws
         where InputType: HTTPRequestInputProtocol, InvocationStrategyType: AsyncResponseInvocationStrategy,
         InvocationStrategyType.OutputType == HTTPClientError? {
+            let wrappingInvocationContext = invocationContext.withOutgoingRequestIdLoggerMetadata()
 
             let retriable = ExecuteAsyncWithoutOutputRetriable(
                 endpointOverride: endpointOverride, endpointPath: endpointPath,
                 httpMethod: httpMethod, input: input, outerCompletion: completion,
                 asyncResponseInvocationStrategy: asyncResponseInvocationStrategy,
-                invocationContext: invocationContext, httpClient: self,
+                invocationContext: wrappingInvocationContext, httpClient: self,
                 retryConfiguration: retryConfiguration,
                 retryOnError: retryOnError)
             

--- a/Sources/SmokeHTTPClient/HTTPClient+executeAsyncWithOutput.swift
+++ b/Sources/SmokeHTTPClient/HTTPClient+executeAsyncWithOutput.swift
@@ -54,7 +54,7 @@ public extension HTTPClient {
                 asyncResponseInvocationStrategy: GlobalDispatchQueueAsyncResponseInvocationStrategy<Result<OutputType, HTTPClientError>>(),
                 invocationContext: invocationContext)
     }
-
+    
     /**
      Submits a request that will return a response body to this client asynchronously.
 
@@ -67,6 +67,41 @@ public extension HTTPClient {
          - invocationContext: context to use for this invocation.
      */
     func executeAsyncWithOutput<InputType, OutputType, InvocationStrategyType,
+        InvocationReportingType: HTTPClientInvocationReporting, HandlerDelegateType: HTTPClientChannelInboundHandlerDelegate>(
+            endpointOverride: URL? = nil,
+            endpointPath: String,
+            httpMethod: HTTPMethod,
+            input: InputType,
+            completion: @escaping (Result<OutputType, HTTPClientError>) -> (),
+            asyncResponseInvocationStrategy: InvocationStrategyType,
+            invocationContext: HTTPClientInvocationContext<InvocationReportingType, HandlerDelegateType>) throws -> EventLoopFuture<Channel>
+            where InputType: HTTPRequestInputProtocol, InvocationStrategyType: AsyncResponseInvocationStrategy,
+        InvocationStrategyType.OutputType == Result<OutputType, HTTPClientError>,
+        OutputType: HTTPResponseOutputProtocol {
+            let wrappingInvocationContext = invocationContext.withOutgoingRequestIdLoggerMetadata()
+            
+            return try executeAsyncWithOutputWithWrappedInvocationContext(
+                endpointOverride: endpointOverride,
+                endpointPath: endpointPath,
+                httpMethod: httpMethod,
+                input: input,
+                completion: completion,
+                asyncResponseInvocationStrategy: asyncResponseInvocationStrategy,
+                invocationContext: wrappingInvocationContext)
+    }
+
+    /**
+     Submits a request that will return a response body to this client asynchronously. To be called when the `InvocationContext` has already been wrapped with an outgoingRequestId aware Logger.
+
+     - Parameters:
+         - endpointPath: The endpoint path for this request.
+         - httpMethod: The http method to use for this request.
+         - input: the input body data to send with this request.
+         - completion: Completion handler called with the response body or any error.
+         - asyncResponseInvocationStrategy: The invocation strategy for the response from this request.
+         - invocationContext: context to use for this invocation.
+     */
+    internal func executeAsyncWithOutputWithWrappedInvocationContext<InputType, OutputType, InvocationStrategyType,
         InvocationReportingType: HTTPClientInvocationReporting, HandlerDelegateType: HTTPClientChannelInboundHandlerDelegate>(
             endpointOverride: URL? = nil,
             endpointPath: String,

--- a/Sources/SmokeHTTPClient/HTTPClient+executeAsyncWithoutOutput.swift
+++ b/Sources/SmokeHTTPClient/HTTPClient+executeAsyncWithoutOutput.swift
@@ -76,6 +76,40 @@ public extension HTTPClient {
         invocationContext: HTTPClientInvocationContext<InvocationReportingType, HandlerDelegateType>) throws -> EventLoopFuture<Channel>
         where InputType: HTTPRequestInputProtocol, InvocationStrategyType: AsyncResponseInvocationStrategy,
         InvocationStrategyType.OutputType == HTTPClientError? {
+            let wrappingInvocationContext = invocationContext.withOutgoingRequestIdLoggerMetadata()
+            
+            return try executeAsyncWithoutOutputWithWrappedInvocationContext(
+                endpointOverride: endpointOverride,
+                endpointPath: endpointPath,
+                httpMethod: httpMethod,
+                input: input,
+                completion: completion,
+                asyncResponseInvocationStrategy: asyncResponseInvocationStrategy,
+                invocationContext: wrappingInvocationContext)
+    }
+    
+    /**
+     Submits a request that will not return a response body to this client asynchronously. To be called when the `InvocationContext` has already been wrapped with an outgoingRequestId aware Logger.
+     
+     - Parameters:
+        - endpointPath: The endpoint path for this request.
+        - httpMethod: The http method to use for this request.
+        - input: the input body data to send with this request.
+        - completion: Completion handler called with an error if one occurs or nil otherwise.
+        - asyncResponseInvocationStrategy: The invocation strategy for the response from this request.
+        - invocationContext: context to use for this invocation.
+     */
+    internal func executeAsyncWithoutOutputWithWrappedInvocationContext<InputType, InvocationStrategyType,
+            InvocationReportingType: HTTPClientInvocationReporting, HandlerDelegateType: HTTPClientChannelInboundHandlerDelegate>(
+        endpointOverride: URL? = nil,
+        endpointPath: String,
+        httpMethod: HTTPMethod,
+        input: InputType,
+        completion: @escaping (HTTPClientError?) -> (),
+        asyncResponseInvocationStrategy: InvocationStrategyType,
+        invocationContext: HTTPClientInvocationContext<InvocationReportingType, HandlerDelegateType>) throws -> EventLoopFuture<Channel>
+        where InputType: HTTPRequestInputProtocol, InvocationStrategyType: AsyncResponseInvocationStrategy,
+        InvocationStrategyType.OutputType == HTTPClientError? {
             
             let latencyMetricDetails: (Date, Metrics.Timer)?
             if let latencyTimer = invocationContext.reporting.latencyTimer {

--- a/Sources/SmokeHTTPClient/HTTPClient+executeSyncRetriableWithoutOutput.swift
+++ b/Sources/SmokeHTTPClient/HTTPClient+executeSyncRetriableWithoutOutput.swift
@@ -91,9 +91,10 @@ public extension HTTPClient {
             
             do {
                 // submit the synchronous request
-                try httpClient.executeSyncWithoutOutput(endpointOverride: endpointOverride,
-                                                              endpointPath: endpointPath, httpMethod: httpMethod,
-                                                              input: input, invocationContext: innerInvocationContext)
+                try httpClient.executeSyncWithoutOutputWithWrappedInvocationContext(
+                    endpointOverride: endpointOverride,
+                    endpointPath: endpointPath, httpMethod: httpMethod,
+                    input: input, invocationContext: innerInvocationContext)
                 
                 // report success metric
                 invocationContext.reporting.successCounter?.increment()
@@ -171,11 +172,12 @@ public extension HTTPClient {
         retryConfiguration: HTTPClientRetryConfiguration,
         retryOnError: @escaping (Swift.Error) -> Bool) throws
         where InputType: HTTPRequestInputProtocol {
+            let wrappingInvocationContext = invocationContext.withOutgoingRequestIdLoggerMetadata()
 
-            let retriable = ExecuteSyncWithoutOutputRetriable<InputType, InvocationReportingType, HandlerDelegateType>(
+            let retriable = ExecuteSyncWithoutOutputRetriable(
                 endpointOverride: endpointOverride, endpointPath: endpointPath,
                 httpMethod: httpMethod, input: input,
-                invocationContext: invocationContext, httpClient: self,
+                invocationContext: wrappingInvocationContext, httpClient: self,
                 retryConfiguration: retryConfiguration,
                 retryOnError: retryOnError)
             

--- a/Sources/SmokeHTTPClient/HTTPClient+executeSyncWithOutput.swift
+++ b/Sources/SmokeHTTPClient/HTTPClient+executeSyncWithOutput.swift
@@ -42,6 +42,36 @@ public extension HTTPClient {
         invocationContext: HTTPClientInvocationContext<InvocationReportingType, HandlerDelegateType>) throws -> OutputType
         where InputType: HTTPRequestInputProtocol,
         OutputType: HTTPResponseOutputProtocol {
+            let wrappingInvocationContext = invocationContext.withOutgoingRequestIdLoggerMetadata()
+            
+            return try executeSyncWithOutputWithWrappedInvocationContext(
+                endpointOverride: endpointOverride,
+                endpointPath: endpointPath,
+                httpMethod: httpMethod,
+                input: input,
+                invocationContext: wrappingInvocationContext)
+    }
+    
+    /**
+     Submits a request that will return a response body to this client synchronously. To be called when the `InvocationContext` has already been wrapped with an outgoingRequestId aware Logger.
+     
+     - Parameters:
+         - endpointPath: The endpoint path for this request.
+         - httpMethod: The http method to use for this request.
+         - input: the input body data to send with this request.
+         - invocationContext: context to use for this invocation.
+         - Returns: the response body.
+         - Throws: If an error occurred during the request.
+     */
+    internal func executeSyncWithOutputWithWrappedInvocationContext<InputType, OutputType, InvocationReportingType: HTTPClientInvocationReporting,
+            HandlerDelegateType: HTTPClientChannelInboundHandlerDelegate>(
+        endpointOverride: URL? = nil,
+        endpointPath: String,
+        httpMethod: HTTPMethod,
+        input: InputType,
+        invocationContext: HTTPClientInvocationContext<InvocationReportingType, HandlerDelegateType>) throws -> OutputType
+        where InputType: HTTPRequestInputProtocol,
+        OutputType: HTTPResponseOutputProtocol {
             
             var responseResult: Result<OutputType, HTTPClientError>?
             let completedSemaphore = DispatchSemaphore(value: 0)

--- a/Sources/SmokeHTTPClient/HTTPClient+executeSyncWithoutOutput.swift
+++ b/Sources/SmokeHTTPClient/HTTPClient+executeSyncWithoutOutput.swift
@@ -41,6 +41,34 @@ public extension HTTPClient {
         input: InputType,
         invocationContext: HTTPClientInvocationContext<InvocationReportingType, HandlerDelegateType>) throws
         where InputType: HTTPRequestInputProtocol {
+            let wrappingInvocationContext = invocationContext.withOutgoingRequestIdLoggerMetadata()
+        
+            try executeSyncWithoutOutputWithWrappedInvocationContext(
+                endpointOverride: endpointOverride,
+                endpointPath: endpointPath,
+                httpMethod: httpMethod,
+                input: input,
+                invocationContext: wrappingInvocationContext)
+    }
+    
+    /**
+     Submits a request that will not return a response body to this client synchronously. To be called when the `InvocationContext` has already been wrapped with an outgoingRequestId aware Logger.
+     
+     - Parameters:
+         - endpointPath: The endpoint path for this request.
+         - httpMethod: The http method to use for this request.
+         - input: the input body data to send with this request.
+         - invocationContext: context to use for this invocation.
+         - Throws: If an error occurred during the request.
+     */
+    internal func executeSyncWithoutOutputWithWrappedInvocationContext<InputType, InvocationReportingType: HTTPClientInvocationReporting,
+            HandlerDelegateType: HTTPClientChannelInboundHandlerDelegate>(
+        endpointOverride: URL? = nil,
+        endpointPath: String,
+        httpMethod: HTTPMethod,
+        input: InputType,
+        invocationContext: HTTPClientInvocationContext<InvocationReportingType, HandlerDelegateType>) throws
+        where InputType: HTTPRequestInputProtocol {
             var responseError: HTTPClientError?
             let completedSemaphore = DispatchSemaphore(value: 0)
             


### PR DESCRIPTION

*Issue #, if available:*

*Description of changes:*
Provide an outgoingRequestId as Logger metadata to track the same invocation to a client. This will allow log entries for the same entry to be more easily associated through logging.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
