### PR TITLE
Expose default TLS configuration with non-overridden function.

### DIFF
--- a/Sources/SmokeHTTPClient/HTTPClientDelegate.swift
+++ b/Sources/SmokeHTTPClient/HTTPClientDelegate.swift
@@ -58,9 +58,14 @@ public protocol HTTPClientDelegate {
 }
 
 public extension HTTPClientDelegate {
+    /// Overrides the protocol requirement by default, returning the default TLS configuration if no customization is needed
+    func getTLSConfiguration() -> TLSConfiguration? {
+        return getDefaultTLSConfiguration()
+    }
+    
     /// Default TLS configuration if no customization is needed. Simply turns certificate verification off if debugging, otherwise
     /// provides the default TLSConfiguration.
-    func getTLSConfiguration() -> TLSConfiguration? {
+    func getDefaultTLSConfiguration() -> TLSConfiguration? {
 
         // To help debugging, turn off certificate verification when locally calling.
         #if DEBUG


### PR DESCRIPTION
*Issue #, if available:* Supports adding support for non-authenticated calls: https://github.com/amzn/smoke-aws/issues/57

*Description of changes:* Expose the default TLS configuration with a function that isn't a protocol requirement. This allows conforming types of this protocol to override `getTLSConfiguration` while also using the logic for the default configuration if required.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
