### PR TITLE
Expose the EventLoopGroup of the wrapped HttpClient.

### DIFF
--- a/Sources/HTTPPathCoding/HTTPPathToken.swift
+++ b/Sources/HTTPPathCoding/HTTPPathToken.swift
@@ -85,8 +85,8 @@ extension HTTPPathToken: Equatable {
         switch (lhs, rhs) {
         case let (.string(leftString), .string(rightString)):
             return leftString == rightString
-        case let (.variable(leftValues), .variable(rightValues)):
-            return leftValues == rightValues
+        case let (.variable(leftName, leftMultiSegment), .variable(rightName, rightMultiSegment)):
+            return leftName == rightName && leftMultiSegment == rightMultiSegment
         default:
             return false
         }

--- a/Sources/SmokeHTTPClient/HTTPOperationsClient.swift
+++ b/Sources/SmokeHTTPClient/HTTPOperationsClient.swift
@@ -49,6 +49,10 @@ public struct HTTPOperationsClient {
     /// The `HTTPClient` used for this instance
     private let wrappedHttpClient: HTTPClient
     
+    public var eventLoopGroup: EventLoopGroup {
+        return self.wrappedHttpClient.eventLoopGroup
+    }
+    
     /**
      Initializer.
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
1. Expose the EventLoopGroup of the wrapped HttpClient.
2. Fix compile warning.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
