### PR TITLE
Allow retry on connection timeout

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/swift-server/async-http-client.git",
         "state": {
           "branch": null,
-          "revision": "e2636a4c24e646d3e480fc666da0c090818beb09",
-          "version": "1.1.0"
+          "revision": "037b70291941fe43de668066eb6fb802c5e181d2",
+          "version": "1.1.1"
         }
       },
       {
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio.git",
         "state": {
           "branch": null,
-          "revision": "16ab4d657e1ad4e77bd5f8b94af8538561643053",
-          "version": "2.14.0"
+          "revision": "c5fa0b456524cd73dc3ddbb263d4f46c20b86ca3",
+          "version": "2.17.0"
         }
       },
       {
@@ -42,8 +42,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio-extras.git",
         "state": {
           "branch": null,
-          "revision": "b4dbfacff47fb8d0f9e0a422d8d37935a9f10570",
-          "version": "1.4.0"
+          "revision": "7cd24c0efcf9700033f671b6a8eaa64a77dd0b72",
+          "version": "1.5.1"
         }
       },
       {
@@ -51,8 +51,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio-ssl.git",
         "state": {
           "branch": null,
-          "revision": "af46d9b58fafbb76f9b01177568d435a1b024f99",
-          "version": "2.6.2"
+          "revision": "10e0e17dd47b594c3d864a063f343d716e33e5c1",
+          "version": "2.7.3"
         }
       }
     ]

--- a/Sources/SmokeHTTPClient/HTTPOperationsClient.swift
+++ b/Sources/SmokeHTTPClient/HTTPOperationsClient.swift
@@ -253,8 +253,17 @@ public struct HTTPOperationsClient {
             completion(.failure(responseError))
             
         case .failure(let error):
-            let cause = HTTPError.badResponse("Request failed")
-            let wrappingError = HTTPClientError(responseCode: 400, cause: cause)
+            let cause: HTTPError
+            let wrappingError: HTTPClientError
+            
+            switch error {
+            case ChannelError.connectTimeout:
+                cause = HTTPError.connectionError("Connection timed out")
+                wrappingError = HTTPClientError(responseCode: 500, cause: cause)
+            default:
+                cause = HTTPError.badResponse("Request failed")
+                wrappingError = HTTPClientError(responseCode: 400, cause: cause)
+            }
             
             invocationContext.reporting.traceContext.handleOutwardsRequestFailure(
                 outwardsRequestContext: outwardsRequestContext,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Connection timeouts are handled as 400 client errors, which won't get retried by the client.
 This change handles connection timeouts as 500 server errors.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
