### PR TITLE
Add public constructor for HTTPRequestParameters.

### DIFF
--- a/Sources/SmokeHTTPClient/HTTPClientInvocationDelegate.swift
+++ b/Sources/SmokeHTTPClient/HTTPClientInvocationDelegate.swift
@@ -33,6 +33,31 @@ public struct HTTPRequestParameters {
     public let bodyData: Data
     /// Any additional headers to add
     public let additionalHeaders: [(String, String)]
+    
+    /**
+     Initializer.
+     
+     - Parameters:
+        - contentType: The endpoint url to request a response from.
+        - endpointUrl: The endpoint url to request a response from.
+        - endpointPath: The path to request a response from.
+        - httpMethod: The http method to use for the request.
+        - bodyData: The request body data to use.
+        - additionalHeaders: Any additional headers to add
+     */
+    public init(contentType: String,
+                endpointUrl: URL,
+                endpointPath: String,
+                httpMethod: HTTPMethod,
+                bodyData: Data,
+                additionalHeaders: [(String, String)]) {
+        self.contentType = contentType
+        self.endpointUrl = endpointUrl
+        self.endpointPath = endpointPath
+        self.httpMethod = httpMethod
+        self.bodyData = bodyData
+        self.additionalHeaders = additionalHeaders
+    }
 }
 
 public protocol HTTPClientInvocationDelegate {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Add public constructor for HTTPRequestParameters. Previously the struct is public, is used in a public protocol but cannot be instantiated outside of the package.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
