### PR TITLE
Allow retries on read timeouts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,16 +21,6 @@ matrix:
       sudo: required
       services: docker
       env: DOCKER_IMAGE_TAG=swift:5.1-xenial USE_SWIFT_LINT=yes
-    - os: linux
-      dist: xenial
-      sudo: required
-      services: docker
-      env: DOCKER_IMAGE_TAG=swift:5.0.1-bionic USE_SWIFT_LINT=yes
-    - os: linux
-      dist: xenial
-      sudo: required
-      services: docker
-      env: DOCKER_IMAGE_TAG=swift:5.0.1-xenial USE_SWIFT_LINT=yes
 
 before_install:
   - docker pull $DOCKER_IMAGE_TAG

--- a/README.md
+++ b/README.md
@@ -3,9 +3,6 @@
 <img src="https://travis-ci.com/amzn/smoke-http.svg?branch=master" alt="Build - Master Branch">
 </a>
 <a href="http://swift.org">
-<img src="https://img.shields.io/badge/swift-5.0-orange.svg?style=flat" alt="Swift 5.0 Tested">
-</a>
-<a href="http://swift.org">
 <img src="https://img.shields.io/badge/swift-5.1-orange.svg?style=flat" alt="Swift 5.1 Tested">
 </a>
 <a href="http://swift.org">

--- a/Sources/SmokeHTTPClient/HTTPOperationsClient.swift
+++ b/Sources/SmokeHTTPClient/HTTPOperationsClient.swift
@@ -148,7 +148,7 @@ public struct HTTPOperationsClient {
             invocationContext: invocationContext)
                 
         let outwardsRequestContext = invocationContext.reporting.traceContext.handleOutwardsRequestStart(
-            method: httpMethod, uri: endpointPath,
+            method: httpMethod, uri: endpoint,
             logger: logger,
             internalRequestId: invocationContext.reporting.internalRequestId,
             headers: &requestHeaders, bodyData: sendBody)

--- a/Sources/SmokeHTTPClient/HTTPOperationsClient.swift
+++ b/Sources/SmokeHTTPClient/HTTPOperationsClient.swift
@@ -260,6 +260,9 @@ public struct HTTPOperationsClient {
             case ChannelError.connectTimeout:
                 cause = HTTPError.connectionError("Connection timed out")
                 wrappingError = HTTPClientError(responseCode: 500, cause: cause)
+            case let clientError as AsyncHTTPClient.HTTPClientError where clientError == AsyncHTTPClient.HTTPClientError.readTimeout:
+                cause = HTTPError.connectionError("Read timed out")
+                wrappingError = HTTPClientError(responseCode: 500, cause: cause)
             default:
                 cause = HTTPError.badResponse("Request failed")
                 wrappingError = HTTPClientError(responseCode: 400, cause: cause)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
1. Allow retries on read timeouts.
2. Remove Swift 5.0 CI as that compiler version is now not supported according to the [support policy](https://github.com/amzn/smoke-aws/blob/main/docs/Support_Policy.md).
3. Pass full endpoint to traceContext.handleOutwardsRequestStart.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
