### PR TITLE
Add CI tests for CentOS 8, Ubuntu 20.04 and Amazon Linux 2.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,42 +5,43 @@ matrix:
       dist: xenial
       sudo: required
       services: docker
-      env: DOCKER_IMAGE_TAG=swift:5.2.5-bionic USE_SWIFT_LINT=no USE_APT_GET=yes
+      env: DOCKER_IMAGE_TAG=swift:5.2.5-bionic ONLY_RUN_SWIFT_LINT=no USE_APT_GET=yes
     - os: linux
       dist: xenial
       sudo: required
       services: docker
-      env: DOCKER_IMAGE_TAG=swift:5.2.5-xenial USE_SWIFT_LINT=no USE_APT_GET=yes
+      env: DOCKER_IMAGE_TAG=swift:5.2.5-xenial ONLY_RUN_SWIFT_LINT=no USE_APT_GET=yes
     - os: linux
       dist: xenial
       sudo: required
       services: docker
-      env: DOCKER_IMAGE_TAG=swift:5.2.5-focal USE_SWIFT_LINT=no USE_APT_GET=yes
+      env: DOCKER_IMAGE_TAG=swift:5.2.5-focal ONLY_RUN_SWIFT_LINT=no USE_APT_GET=yes
     - os: linux
       dist: xenial
       sudo: required
       services: docker
-      env: DOCKER_IMAGE_TAG=swift:5.2.5-amazonlinux2 USE_SWIFT_LINT=no USE_APT_GET=no
+      env: DOCKER_IMAGE_TAG=swift:5.2.5-amazonlinux2 ONLY_RUN_SWIFT_LINT=no USE_APT_GET=no
     - os: linux
       dist: xenial
       sudo: required
       services: docker
-      env: DOCKER_IMAGE_TAG=swift:5.2.5-centos8 USE_SWIFT_LINT=no USE_APT_GET=no
+      env: DOCKER_IMAGE_TAG=swift:5.2.5-centos8 ONLY_RUN_SWIFT_LINT=no USE_APT_GET=no
 
     - os: linux
       dist: xenial
       sudo: required
       services: docker
-      env: DOCKER_IMAGE_TAG=swift:5.1-bionic USE_SWIFT_LINT=no USE_APT_GET=yes
+      env: DOCKER_IMAGE_TAG=swift:5.1-bionic ONLY_RUN_SWIFT_LINT=no USE_APT_GET=yes
 
+    # Use a docker image that contains the SwiftLint executable the verify the code against the linter.
     - os: linux
       dist: xenial
       sudo: required
       services: docker
-      env: DOCKER_IMAGE_TAG=bytesguy/swiftlint:0.39.2 USE_SWIFT_LINT=yes USE_APT_GET=no
+      env: DOCKER_IMAGE_TAG=bytesguy/swiftlint:0.39.2 ONLY_RUN_SWIFT_LINT=yes USE_APT_GET=no
 
 before_install:
   - docker pull $DOCKER_IMAGE_TAG
 
 script:
-  - docker run -v ${TRAVIS_BUILD_DIR}:/package ${DOCKER_IMAGE_TAG} /bin/bash -c "/package/CITests/run $USE_SWIFT_LINT $USE_APT_GET"
+  - docker run -v ${TRAVIS_BUILD_DIR}:/package ${DOCKER_IMAGE_TAG} /bin/bash -c "/package/CITests/run $ONLY_RUN_SWIFT_LINT $USE_APT_GET"

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,11 +26,6 @@ matrix:
       sudo: required
       services: docker
       env: DOCKER_IMAGE_TAG=swift:5.2.5-centos8 USE_SWIFT_LINT=no USE_APT_GET=no
-    - os: linux
-      dist: xenial
-      sudo: required
-      services: docker
-      env: DOCKER_IMAGE_TAG=swift:5.2.5-centos7 USE_SWIFT_LINT=no USE_APT_GET=no
 
     - os: linux
       dist: xenial

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,25 +5,47 @@ matrix:
       dist: xenial
       sudo: required
       services: docker
-      env: DOCKER_IMAGE_TAG=swift:5.2-bionic USE_SWIFT_LINT=yes
+      env: DOCKER_IMAGE_TAG=swift:5.2.5-bionic USE_SWIFT_LINT=no USE_APT_GET=yes
     - os: linux
       dist: xenial
       sudo: required
       services: docker
-      env: DOCKER_IMAGE_TAG=swift:5.2-xenial USE_SWIFT_LINT=yes
+      env: DOCKER_IMAGE_TAG=swift:5.2.5-xenial USE_SWIFT_LINT=no USE_APT_GET=yes
     - os: linux
       dist: xenial
       sudo: required
       services: docker
-      env: DOCKER_IMAGE_TAG=swift:5.1-bionic USE_SWIFT_LINT=yes
+      env: DOCKER_IMAGE_TAG=swift:5.2.5-focal USE_SWIFT_LINT=no USE_APT_GET=yes
     - os: linux
       dist: xenial
       sudo: required
       services: docker
-      env: DOCKER_IMAGE_TAG=swift:5.1-xenial USE_SWIFT_LINT=yes
+      env: DOCKER_IMAGE_TAG=swift:5.2.5-amazonlinux2 USE_SWIFT_LINT=no USE_APT_GET=no
+    - os: linux
+      dist: xenial
+      sudo: required
+      services: docker
+      env: DOCKER_IMAGE_TAG=swift:5.2.5-centos8 USE_SWIFT_LINT=no USE_APT_GET=no
+    - os: linux
+      dist: xenial
+      sudo: required
+      services: docker
+      env: DOCKER_IMAGE_TAG=swift:5.2.5-centos7 USE_SWIFT_LINT=no USE_APT_GET=no
+
+    - os: linux
+      dist: xenial
+      sudo: required
+      services: docker
+      env: DOCKER_IMAGE_TAG=swift:5.1-bionic USE_SWIFT_LINT=no USE_APT_GET=yes
+
+    - os: linux
+      dist: xenial
+      sudo: required
+      services: docker
+      env: DOCKER_IMAGE_TAG=bytesguy/swiftlint:0.39.2 USE_SWIFT_LINT=yes USE_APT_GET=no
 
 before_install:
   - docker pull $DOCKER_IMAGE_TAG
 
 script:
-  - docker run -v ${TRAVIS_BUILD_DIR}:/package ${DOCKER_IMAGE_TAG} /bin/bash -c "/package/CITests/run $USE_SWIFT_LINT"
+  - docker run -v ${TRAVIS_BUILD_DIR}:/package ${DOCKER_IMAGE_TAG} /bin/bash -c "/package/CITests/run $USE_SWIFT_LINT $USE_APT_GET"

--- a/CITests/run
+++ b/CITests/run
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-USE_SWIFT_LINT=$1
+ONLY_RUN_SWIFT_LINT=$1
 USE_APT_GET=$2
 
 if [ "$USE_APT_GET" == 'yes' ]; then
@@ -11,7 +11,7 @@ fi
 
 cd /package
 
-if [ "$USE_SWIFT_LINT" == 'yes' ]; then
+if [ "$ONLY_RUN_SWIFT_LINT" == 'yes' ]; then
     ls
     swiftlint
 else

--- a/CITests/run
+++ b/CITests/run
@@ -4,27 +4,19 @@ set -e
 swiftLintVersion=0.36.0
 
 USE_SWIFT_LINT=$1
+USE_APT_GET=$2
 
-apt-get update
-apt-get -y install libssl-dev libz-dev
-
-workspaceRoot=($PWD)
-srcRoot=$workspaceRoot/sources
-mkdir -p $srcRoot
-
-if [ "$USE_SWIFT_LINT" == 'yes' ]; then
-    # SwiftLint
-    cd $srcRoot
-    git clone --branch $swiftLintVersion https://github.com/realm/SwiftLint.git
-    cd SwiftLint
-    swift build -c release --build-path .build/native --disable-prefetching
-    cp .build/native/release/swiftlint /usr/bin
+if [ "$USE_APT_GET" == 'yes' ]; then
+    apt-get update
+    apt-get -y install libssl-dev libz-dev
 fi
 
-cd $workspaceRoot/package
-swift build
-swift test
+cd /package
 
 if [ "$USE_SWIFT_LINT" == 'yes' ]; then
+    ls
     swiftlint
+else
+    swift build -c release
+    swift test
 fi

--- a/CITests/run
+++ b/CITests/run
@@ -1,8 +1,6 @@
 #!/bin/bash
 set -e
 
-swiftLintVersion=0.36.0
-
 USE_SWIFT_LINT=$1
 USE_APT_GET=$2
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 <img src="https://img.shields.io/badge/swift-5.1|5.2-orange.svg?style=flat" alt="Swift 5.1, 5.2 Tested">
 </a>
 <img src="https://img.shields.io/badge/ubuntu-16.04|18.04|20.04-yellow.svg?style=flat" alt="Ubuntu 16.04, 18.04 and 20.04 Tested">
-<img src="https://img.shields.io/badge/CentOS-7|8-yellow.svg?style=flat" alt="CentOS 7 and 8 Tested">
+<img src="https://img.shields.io/badge/CentOS-8-yellow.svg?style=flat" alt="CentOS 8 Tested">
 <img src="https://img.shields.io/badge/AmazonLinux-2-yellow.svg?style=flat" alt="Amazon Linux 2 Tested">
 <a href="https://gitter.im/SmokeServerSide">
 <img src="https://img.shields.io/badge/chat-on%20gitter-ee115e.svg?style=flat" alt="Join the Smoke Server Side community on gitter">

--- a/README.md
+++ b/README.md
@@ -3,13 +3,11 @@
 <img src="https://travis-ci.com/amzn/smoke-http.svg?branch=master" alt="Build - Master Branch">
 </a>
 <a href="http://swift.org">
-<img src="https://img.shields.io/badge/swift-5.1-orange.svg?style=flat" alt="Swift 5.1 Tested">
+<img src="https://img.shields.io/badge/swift-5.1|5.2-orange.svg?style=flat" alt="Swift 5.1, 5.2 Tested">
 </a>
-<a href="http://swift.org">
-<img src="https://img.shields.io/badge/swift-5.2-orange.svg?style=flat" alt="Swift 5.2 Tested">
-</a>
-<img src="https://img.shields.io/badge/ubuntu-16.04-yellow.svg?style=flat" alt="Ubuntu 16.04 Tested">
-<img src="https://img.shields.io/badge/ubuntu-18.04-yellow.svg?style=flat" alt="Ubuntu 18.04 Tested">
+<img src="https://img.shields.io/badge/ubuntu-16.04|18.04|20.04-yellow.svg?style=flat" alt="Ubuntu 16.04, 18.04 and 20.04 Tested">
+<img src="https://img.shields.io/badge/CentOS-7|8-yellow.svg?style=flat" alt="CentOS 7 and 8 Tested">
+<img src="https://img.shields.io/badge/AmazonLinux-2-yellow.svg?style=flat" alt="Amazon Linux 2 Tested">
 <a href="https://gitter.im/SmokeServerSide">
 <img src="https://img.shields.io/badge/chat-on%20gitter-ee115e.svg?style=flat" alt="Join the Smoke Server Side community on gitter">
 </a>


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Add CI tests for CentOS 8, Ubuntu 20.04 and Amazon Linux 2.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
