### PR TITLE
Fix inconsistency in API signatures. Add isRetriable function to HTTPClientError.

### DIFF
--- a/Sources/SmokeHTTPClient/HttpClientError.swift
+++ b/Sources/SmokeHTTPClient/HttpClientError.swift
@@ -37,4 +37,16 @@ public struct HTTPClientError: Error {
             return .serverError
         }
     }
+    
+    public func isRetriable() -> Bool {
+        return self.isRetriableAccordingToCategory
+    }
+    
+    public var isRetriableAccordingToCategory: Bool {
+        if case self.category = Category.clientError {
+            return false
+        } else {
+            return true
+        }
+    }
 }


### PR DESCRIPTION

*Issue #, if available:*

*Description of changes:* Fix inconsistency in API signatures. Add isRetriable function to HTTPClientError.

1. Some APIs were still accepting a Swift.Error for their retryOnError handler. Added overloads to create the correct API signature and added a deprecation annotation to the existing signatures.

2. Added isRetriable function to HTTPClientError to support retrying based on the HTTP response code.

Verified, along with related changes in smoke-aws that errors were not being retried incorrectly.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
