### PR TITLE
Event loop future returning execute variants

### DIFF
--- a/Sources/SmokeHTTPClient/HTTPClientCoreInvocationReporting.swift
+++ b/Sources/SmokeHTTPClient/HTTPClientCoreInvocationReporting.swift
@@ -17,6 +17,7 @@
 
 import Foundation
 import Logging
+import NIO
 
 /**
  A context related to reporting on the invocation of the HTTPClient. This represents the
@@ -36,4 +37,13 @@ public protocol HTTPClientCoreInvocationReporting {
     
     /// The trace context associated with this invocation.
     var traceContext: TraceContextType { get }
+    
+    var eventLoop: EventLoop? { get }
+}
+
+public extension HTTPClientCoreInvocationReporting {
+    // The attribute is being added as a non-breaking change, so add a default implementation that replicates existing behaviour
+    var eventLoop: EventLoop? {
+        return nil
+    }
 }

--- a/Sources/SmokeHTTPClient/HTTPClientInnerRetryInvocationReporting.swift
+++ b/Sources/SmokeHTTPClient/HTTPClientInnerRetryInvocationReporting.swift
@@ -18,6 +18,7 @@
 import Foundation
 import Logging
 import Metrics
+import NIO
 
 /**
  When using retry wrappers, the `HTTPClient` itself shouldn't record any metrics.
@@ -26,6 +27,7 @@ internal struct HTTPClientInnerRetryInvocationReporting<TraceContextType: Invoca
     let internalRequestId: String
     let traceContext: TraceContextType
     let logger: Logging.Logger
+    let eventLoop: EventLoop?
     let successCounter: Metrics.Counter? = nil
     let failure5XXCounter: Metrics.Counter? = nil
     let failure4XXCounter: Metrics.Counter? = nil

--- a/Sources/SmokeHTTPClient/HTTPOperationsClient+executeAsEventLoopFutureRetriableWithOutput.swift
+++ b/Sources/SmokeHTTPClient/HTTPOperationsClient+executeAsEventLoopFutureRetriableWithOutput.swift
@@ -1,0 +1,206 @@
+// Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+//  HTTPOperationsClient+executeAsEventLoopFutureRetriableWithOutput.swift
+//  SmokeHTTPClient
+//
+
+import Foundation
+import NIO
+import NIOHTTP1
+import NIOSSL
+import NIOTLS
+import Logging
+import Metrics
+
+public extension HTTPOperationsClient {
+    /**
+     Helper type that manages the state of a retriable async request.
+     */
+    private class ExecuteAsEventLoopFutureWithOutputRetriable<InputType, OutputType,
+        InvocationReportingType: HTTPClientInvocationReporting, HandlerDelegateType: HTTPClientInvocationDelegate>
+            where InputType: HTTPRequestInputProtocol, OutputType: HTTPResponseOutputProtocol {
+        let endpointOverride: URL?
+        let endpointPath: String
+        let httpMethod: HTTPMethod
+        let input: InputType
+        let invocationContext: HTTPClientInvocationContext<InvocationReportingType, HandlerDelegateType>
+        let innerInvocationContext:
+            HTTPClientInvocationContext<HTTPClientInnerRetryInvocationReporting<InvocationReportingType.TraceContextType>, HandlerDelegateType>
+        let httpClient: HTTPOperationsClient
+        let retryConfiguration: HTTPClientRetryConfiguration
+        let retryOnError: (HTTPClientError) -> Bool
+        let queue = DispatchQueue.global()
+        let latencyMetricDetails: (Date, Metrics.Timer)?
+        
+        var retriesRemaining: Int
+        
+        init(endpointOverride: URL?, endpointPath: String, httpMethod: HTTPMethod, input: InputType,
+             invocationContext: HTTPClientInvocationContext<InvocationReportingType, HandlerDelegateType>,
+             httpClient: HTTPOperationsClient,
+             retryConfiguration: HTTPClientRetryConfiguration,
+             retryOnError: @escaping (HTTPClientError) -> Bool) {
+            self.endpointOverride = endpointOverride
+            self.endpointPath = endpointPath
+            self.httpMethod = httpMethod
+            self.input = input
+            self.invocationContext = invocationContext
+            self.httpClient = httpClient
+            self.retryConfiguration = retryConfiguration
+            self.retriesRemaining = retryConfiguration.numRetries
+            self.retryOnError = retryOnError
+            
+            if let latencyTimer = invocationContext.reporting.latencyTimer {
+                self.latencyMetricDetails = (Date(), latencyTimer)
+            } else {
+                self.latencyMetricDetails = nil
+            }
+            // When using retry wrappers, the `HTTPClient` itself shouldn't record any metrics.
+            let innerReporting = HTTPClientInnerRetryInvocationReporting(internalRequestId: invocationContext.reporting.internalRequestId,
+                                                                         traceContext: invocationContext.reporting.traceContext,
+                                                                         logger: invocationContext.reporting.logger)
+            self.innerInvocationContext = HTTPClientInvocationContext(reporting: innerReporting, handlerDelegate: invocationContext.handlerDelegate)
+        }
+        
+        func executeAsEventLoopFutureWithOutput(eventLoopOverride: EventLoop?) -> EventLoopFuture<OutputType> {
+            // use the specified event loop for pick one for the client to use for all retry attempts
+            let eventLoop = eventLoopOverride ?? self.httpClient.eventLoopGroup.next()
+            
+            // submit the asynchronous request
+            let future: EventLoopFuture<OutputType> = httpClient.executeAsEventLoopFutureWithOutputWithWrappedInvocationContext(
+                endpointOverride: endpointOverride,
+                eventLoopOverride: eventLoop,
+                endpointPath: endpointPath, httpMethod: httpMethod,
+                input: input, invocationContext: innerInvocationContext).flatMapError { error -> EventLoopFuture<OutputType> in
+                let httpClientError: HTTPClientError
+                if let typedError = error as? HTTPClientError {
+                    httpClientError = typedError
+                } else {
+                    // if a non-HTTPClientError is thrown, wrap it
+                    httpClientError = HTTPClientError(responseCode: 400, cause: error)
+                }
+                
+                return self.getNextFuture(error: httpClientError, eventLoop: eventLoop)
+            }
+            
+            future.whenSuccess { _ in
+                self.onSuccess()
+            }
+            
+            return future
+        }
+        
+        func onSuccess() {
+            // report success metric
+            invocationContext.reporting.successCounter?.increment()
+            
+            onComplete()
+        }
+        
+        func getNextFuture(error: HTTPClientError, eventLoop: EventLoop) -> EventLoopFuture<OutputType> {
+            let promise = eventLoop.makePromise(of: OutputType.self)
+            let logger = invocationContext.reporting.logger
+
+            let shouldRetryOnError = retryOnError(error)
+            
+            // if there are retries remaining and we should retry on this error
+            if retriesRemaining > 0 && shouldRetryOnError {
+                // determine the required interval
+                let retryInterval = Int(retryConfiguration.getRetryInterval(retriesRemaining: retriesRemaining))
+                
+                let currentRetriesRemaining = retriesRemaining
+                retriesRemaining -= 1
+                
+                logger.warning(
+                    "Request failed with error: \(error). Remaining retries: \(currentRetriesRemaining). Retrying in \(retryInterval) ms.")
+                let deadline = DispatchTime.now() + .milliseconds(retryInterval)
+                queue.asyncAfter(deadline: deadline) {
+                    logger.debug("Reattempting request due to remaining retries: \(currentRetriesRemaining)")
+                    
+                    let nextFuture = self.executeAsEventLoopFutureWithOutput(eventLoopOverride: eventLoop)
+                    
+                    promise.completeWith(nextFuture)
+                }
+                
+                // return the future that will be completed with the future retry.
+                return promise.futureResult
+            }
+            
+            if !shouldRetryOnError {
+                logger.debug("Request not retried due to error returned: \(error)")
+            } else {
+                logger.debug("Request not retried due to maximum retries: \(retryConfiguration.numRetries)")
+            }
+            
+            // its an error; complete with the provided error
+            promise.fail(error)
+            
+            // report failure metric
+            switch error.category {
+            case .clientError:
+                invocationContext.reporting.failure4XXCounter?.increment()
+            case .serverError:
+                invocationContext.reporting.failure5XXCounter?.increment()
+            }
+            
+            onComplete()
+
+            return promise.futureResult
+        }
+        
+        func onComplete() {
+            // report the retryCount metric
+            let retryCount = retryConfiguration.numRetries - retriesRemaining
+            invocationContext.reporting.retryCountRecorder?.record(retryCount)
+            
+            if let durationMetricDetails = latencyMetricDetails {
+                durationMetricDetails.1.recordMicroseconds(Date().timeIntervalSince(durationMetricDetails.0))
+            }
+        }
+    }
+    
+    /**
+     Submits a request that will return a response body to this client asynchronously as an EventLoopFuture.
+
+     - Parameters:
+        - endpointPath: The endpoint path for this request.
+        - httpMethod: The http method to use for this request.
+        - input: the input body data to send with this request.
+        - invocationContext: context to use for this invocation.
+        - retryConfiguration: the retry configuration for this request.
+        - retryOnError: function that should return if the provided error is retryable.
+     - Returns: A future that will produce the execution result or failure.
+     */
+    func executeAsEventLoopFutureRetriableWithOutput<InputType, OutputType,
+        InvocationReportingType: HTTPClientInvocationReporting, HandlerDelegateType: HTTPClientInvocationDelegate>(
+            endpointOverride: URL? = nil,
+            eventLoopOverride: EventLoop? = nil,
+            endpointPath: String,
+            httpMethod: HTTPMethod,
+            input: InputType,
+            invocationContext: HTTPClientInvocationContext<InvocationReportingType, HandlerDelegateType>,
+            retryConfiguration: HTTPClientRetryConfiguration,
+            retryOnError: @escaping (HTTPClientError) -> Bool) -> EventLoopFuture<OutputType>
+        where InputType: HTTPRequestInputProtocol, OutputType: HTTPResponseOutputProtocol {
+            let wrappingInvocationContext = invocationContext.withOutgoingRequestIdLoggerMetadata()
+            
+            let retriable = ExecuteAsEventLoopFutureWithOutputRetriable<InputType, OutputType, StandardHTTPClientInvocationReporting<InvocationReportingType.TraceContextType>, HandlerDelegateType>(
+                endpointOverride: endpointOverride, endpointPath: endpointPath,
+                httpMethod: httpMethod, input: input,
+                invocationContext: wrappingInvocationContext, httpClient: self,
+                retryConfiguration: retryConfiguration,
+                retryOnError: retryOnError)
+            
+            return retriable.executeAsEventLoopFutureWithOutput(eventLoopOverride: eventLoopOverride)
+    }
+}

--- a/Sources/SmokeHTTPClient/HTTPOperationsClient+executeAsEventLoopFutureRetriableWithOutput.swift
+++ b/Sources/SmokeHTTPClient/HTTPOperationsClient+executeAsEventLoopFutureRetriableWithOutput.swift
@@ -73,7 +73,7 @@ public extension HTTPOperationsClient {
         }
         
         func executeAsEventLoopFutureWithOutput(eventLoopOverride: EventLoop?) -> EventLoopFuture<OutputType> {
-            // use the specified event loop for pick one for the client to use for all retry attempts
+            // use the specified event loop or pick one for the client to use for all retry attempts
             let eventLoop = eventLoopOverride ?? self.httpClient.eventLoopGroup.next()
             
             // submit the asynchronous request

--- a/Sources/SmokeHTTPClient/HTTPOperationsClient+executeAsEventLoopFutureRetriableWithoutOutput.swift
+++ b/Sources/SmokeHTTPClient/HTTPOperationsClient+executeAsEventLoopFutureRetriableWithoutOutput.swift
@@ -1,0 +1,206 @@
+// Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+//  HTTPOperationsClient+executeAsEventLoopFutureRetriableWithoutOutput.swift
+//  SmokeHTTPClient
+//
+
+import Foundation
+import NIO
+import NIOHTTP1
+import NIOSSL
+import NIOTLS
+import Logging
+import Metrics
+
+public extension HTTPOperationsClient {
+    /**
+     Helper type that manages the state of a retriable async request.
+     */
+    private class ExecuteAsEventLoopFutureWithoutOutputRetriable<InputType,
+        InvocationReportingType: HTTPClientInvocationReporting, HandlerDelegateType: HTTPClientInvocationDelegate>
+            where InputType: HTTPRequestInputProtocol {
+        let endpointOverride: URL?
+        let endpointPath: String
+        let httpMethod: HTTPMethod
+        let input: InputType
+        let invocationContext: HTTPClientInvocationContext<InvocationReportingType, HandlerDelegateType>
+        let innerInvocationContext:
+            HTTPClientInvocationContext<HTTPClientInnerRetryInvocationReporting<InvocationReportingType.TraceContextType>, HandlerDelegateType>
+        let httpClient: HTTPOperationsClient
+        let retryConfiguration: HTTPClientRetryConfiguration
+        let retryOnError: (HTTPClientError) -> Bool
+        let queue = DispatchQueue.global()
+        let latencyMetricDetails: (Date, Metrics.Timer)?
+        
+        var retriesRemaining: Int
+        
+        init(endpointOverride: URL?, endpointPath: String, httpMethod: HTTPMethod, input: InputType,
+             invocationContext: HTTPClientInvocationContext<InvocationReportingType, HandlerDelegateType>,
+             httpClient: HTTPOperationsClient,
+             retryConfiguration: HTTPClientRetryConfiguration,
+             retryOnError: @escaping (HTTPClientError) -> Bool) {
+            self.endpointOverride = endpointOverride
+            self.endpointPath = endpointPath
+            self.httpMethod = httpMethod
+            self.input = input
+            self.invocationContext = invocationContext
+            self.httpClient = httpClient
+            self.retryConfiguration = retryConfiguration
+            self.retriesRemaining = retryConfiguration.numRetries
+            self.retryOnError = retryOnError
+            
+            if let latencyTimer = invocationContext.reporting.latencyTimer {
+                self.latencyMetricDetails = (Date(), latencyTimer)
+            } else {
+                self.latencyMetricDetails = nil
+            }
+            // When using retry wrappers, the `HTTPClient` itself shouldn't record any metrics.
+            let innerReporting = HTTPClientInnerRetryInvocationReporting(internalRequestId: invocationContext.reporting.internalRequestId,
+                                                                         traceContext: invocationContext.reporting.traceContext,
+                                                                         logger: invocationContext.reporting.logger)
+            self.innerInvocationContext = HTTPClientInvocationContext(reporting: innerReporting, handlerDelegate: invocationContext.handlerDelegate)
+        }
+        
+        func executeAsEventLoopFutureWithoutOutput(eventLoopOverride: EventLoop?) -> EventLoopFuture<Void> {
+            // use the specified event loop for pick one for the client to use for all retry attempts
+            let eventLoop = eventLoopOverride ?? self.httpClient.eventLoopGroup.next()
+            
+            // submit the asynchronous request
+            let future: EventLoopFuture<Void> = httpClient.executeAsEventLoopFutureWithoutOutputWithWrappedInvocationContext(
+                endpointOverride: endpointOverride,
+                eventLoopOverride: eventLoop,
+                endpointPath: endpointPath, httpMethod: httpMethod,
+                input: input, invocationContext: innerInvocationContext).flatMapError { error -> EventLoopFuture<Void> in
+                let httpClientError: HTTPClientError
+                if let typedError = error as? HTTPClientError {
+                    httpClientError = typedError
+                } else {
+                    // if a non-HTTPClientError is thrown, wrap it
+                    httpClientError = HTTPClientError(responseCode: 400, cause: error)
+                }
+                
+                return self.getNextFuture(error: httpClientError, eventLoop: eventLoop)
+            }
+            
+            future.whenSuccess { _ in
+                self.onSuccess()
+            }
+            
+            return future
+        }
+        
+        func onSuccess() {
+            // report success metric
+            invocationContext.reporting.successCounter?.increment()
+            
+            onComplete()
+        }
+        
+        func getNextFuture(error: HTTPClientError, eventLoop: EventLoop) -> EventLoopFuture<Void> {
+            let promise = eventLoop.makePromise(of: Void.self)
+            let logger = invocationContext.reporting.logger
+
+            let shouldRetryOnError = retryOnError(error)
+            
+            // if there are retries remaining and we should retry on this error
+            if retriesRemaining > 0 && shouldRetryOnError {
+                // determine the required interval
+                let retryInterval = Int(retryConfiguration.getRetryInterval(retriesRemaining: retriesRemaining))
+                
+                let currentRetriesRemaining = retriesRemaining
+                retriesRemaining -= 1
+                
+                logger.warning(
+                    "Request failed with error: \(error). Remaining retries: \(currentRetriesRemaining). Retrying in \(retryInterval) ms.")
+                let deadline = DispatchTime.now() + .milliseconds(retryInterval)
+                queue.asyncAfter(deadline: deadline) {
+                    logger.debug("Reattempting request due to remaining retries: \(currentRetriesRemaining)")
+                    
+                    let nextFuture = self.executeAsEventLoopFutureWithoutOutput(eventLoopOverride: eventLoop)
+                    
+                    promise.completeWith(nextFuture)
+                }
+                
+                // return the future that will be completed with the future retry.
+                return promise.futureResult
+            }
+            
+            if !shouldRetryOnError {
+                logger.debug("Request not retried due to error returned: \(error)")
+            } else {
+                logger.debug("Request not retried due to maximum retries: \(retryConfiguration.numRetries)")
+            }
+            
+            // its an error; complete with the provided error
+            promise.fail(error)
+            
+            // report failure metric
+            switch error.category {
+            case .clientError:
+                invocationContext.reporting.failure4XXCounter?.increment()
+            case .serverError:
+                invocationContext.reporting.failure5XXCounter?.increment()
+            }
+            
+            onComplete()
+
+            return promise.futureResult
+        }
+        
+        func onComplete() {
+            // report the retryCount metric
+            let retryCount = retryConfiguration.numRetries - retriesRemaining
+            invocationContext.reporting.retryCountRecorder?.record(retryCount)
+            
+            if let durationMetricDetails = latencyMetricDetails {
+                durationMetricDetails.1.recordMicroseconds(Date().timeIntervalSince(durationMetricDetails.0))
+            }
+        }
+    }
+    
+    /**
+     Submits a request that will not return a response body to this client asynchronously as an EventLoopFuture.
+
+     - Parameters:
+        - endpointPath: The endpoint path for this request.
+        - httpMethod: The http method to use for this request.
+        - input: the input body data to send with this request.
+        - invocationContext: context to use for this invocation.
+        - retryConfiguration: the retry configuration for this request.
+        - retryOnError: function that should return if the provided error is retryable.
+     - Returns: A future that will produce a Void result or failure.
+     */
+    func executeAsEventLoopFutureRetriableWithoutOutput<InputType,
+        InvocationReportingType: HTTPClientInvocationReporting, HandlerDelegateType: HTTPClientInvocationDelegate>(
+            endpointOverride: URL? = nil,
+            eventLoopOverride: EventLoop? = nil,
+            endpointPath: String,
+            httpMethod: HTTPMethod,
+            input: InputType,
+            invocationContext: HTTPClientInvocationContext<InvocationReportingType, HandlerDelegateType>,
+            retryConfiguration: HTTPClientRetryConfiguration,
+            retryOnError: @escaping (HTTPClientError) -> Bool) -> EventLoopFuture<Void>
+        where InputType: HTTPRequestInputProtocol {
+            let wrappingInvocationContext = invocationContext.withOutgoingRequestIdLoggerMetadata()
+            
+            let retriable = ExecuteAsEventLoopFutureWithoutOutputRetriable<InputType, StandardHTTPClientInvocationReporting<InvocationReportingType.TraceContextType>, HandlerDelegateType>(
+                endpointOverride: endpointOverride, endpointPath: endpointPath,
+                httpMethod: httpMethod, input: input,
+                invocationContext: wrappingInvocationContext, httpClient: self,
+                retryConfiguration: retryConfiguration,
+                retryOnError: retryOnError)
+            
+            return retriable.executeAsEventLoopFutureWithoutOutput(eventLoopOverride: eventLoopOverride)
+    }
+}

--- a/Sources/SmokeHTTPClient/HTTPOperationsClient+executeAsEventLoopFutureRetriableWithoutOutput.swift
+++ b/Sources/SmokeHTTPClient/HTTPOperationsClient+executeAsEventLoopFutureRetriableWithoutOutput.swift
@@ -73,7 +73,7 @@ public extension HTTPOperationsClient {
         }
         
         func executeAsEventLoopFutureWithoutOutput(eventLoopOverride: EventLoop?) -> EventLoopFuture<Void> {
-            // use the specified event loop for pick one for the client to use for all retry attempts
+            // use the specified event loop or pick one for the client to use for all retry attempts
             let eventLoop = eventLoopOverride ?? self.httpClient.eventLoopGroup.next()
             
             // submit the asynchronous request

--- a/Sources/SmokeHTTPClient/HTTPOperationsClient+executeAsEventLoopFutureWithOutput.swift
+++ b/Sources/SmokeHTTPClient/HTTPOperationsClient+executeAsEventLoopFutureWithOutput.swift
@@ -1,0 +1,136 @@
+// Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+//  HTTPOperationsClient+executeAsEventLoopFutureWithOutput.swift
+//  SmokeHTTPClient
+//
+
+import Foundation
+import NIO
+import NIOHTTP1
+import AsyncHTTPClient
+import NIOSSL
+import NIOTLS
+import Logging
+import Metrics
+
+public extension HTTPOperationsClient {
+    
+    /**
+     Submits a request that will return a response body to this client asynchronously as an EventLoopFuture.
+
+     - Parameters:
+         - endpointPath: The endpoint path for this request.
+         - httpMethod: The http method to use for this request.
+         - input: the input body data to send with this request.
+         - completion: Completion handler called with the response body or any error.
+         - invocationContext: context to use for this invocation.
+     - Returns: A future that will produce the execution result or failure.
+     */
+    func executeAsEventLoopFutureWithOutput<InputType, OutputType,
+        InvocationReportingType: HTTPClientInvocationReporting, HandlerDelegateType: HTTPClientInvocationDelegate>(
+            endpointOverride: URL? = nil,
+            eventLoopOverride: EventLoop? = nil,
+            endpointPath: String,
+            httpMethod: HTTPMethod,
+            input: InputType,
+            invocationContext: HTTPClientInvocationContext<InvocationReportingType, HandlerDelegateType>) -> EventLoopFuture<OutputType>
+            where InputType: HTTPRequestInputProtocol, OutputType: HTTPResponseOutputProtocol {
+            let wrappingInvocationContext = invocationContext.withOutgoingRequestIdLoggerMetadata()
+            
+            return executeAsEventLoopFutureWithOutputWithWrappedInvocationContext(
+                endpointOverride: endpointOverride,
+                eventLoopOverride: eventLoopOverride,
+                endpointPath: endpointPath,
+                httpMethod: httpMethod,
+                input: input,
+                invocationContext: wrappingInvocationContext)
+    }
+
+    /**
+     Submits a request that will return a response body to this client asynchronously using an EventLoopFuture.
+     To be called when the `InvocationContext` has already been wrapped with an outgoingRequestId aware Logger.
+
+     - Parameters:
+         - endpointPath: The endpoint path for this request.
+         - httpMethod: The http method to use for this request.
+         - input: the input body data to send with this request.
+         - asyncResponseInvocationStrategy: The invocation strategy for the response from this request.
+         - invocationContext: context to use for this invocation.
+        - Returns: A future that will produce the execution result or failure.
+     */
+    internal func executeAsEventLoopFutureWithOutputWithWrappedInvocationContext<InputType, OutputType,
+        InvocationReportingType: HTTPClientInvocationReporting, HandlerDelegateType: HTTPClientInvocationDelegate>(
+            endpointOverride: URL? = nil,
+            eventLoopOverride: EventLoop?,
+            endpointPath: String,
+            httpMethod: HTTPMethod,
+            input: InputType,
+            invocationContext: HTTPClientInvocationContext<InvocationReportingType, HandlerDelegateType>) -> EventLoopFuture<OutputType>
+            where InputType: HTTPRequestInputProtocol, OutputType: HTTPResponseOutputProtocol {
+        let durationMetricDetails: (Date, Metrics.Timer)?
+        if let durationTimer = invocationContext.reporting.latencyTimer {
+            durationMetricDetails = (Date(), durationTimer)
+        } else {
+            durationMetricDetails = nil
+        }
+
+        let requestDelegate = clientDelegate
+        // create a wrapping completion handler to pass to the ChannelInboundHandler
+        // that will decode the returned body into the desired decodable type.
+        
+        let future = executeAsEventLoopFuture(endpointOverride: endpointOverride,
+                                              eventLoopOverride: eventLoopOverride,
+                                              endpointPath: endpointPath, httpMethod: httpMethod,
+                                              input: input, invocationContext: invocationContext)
+            .flatMapThrowing { (response) -> OutputType in
+                do {
+                    // decode the provided body into the desired type
+                    let output: OutputType = try requestDelegate.decodeOutput(
+                        output: response.body,
+                        headers: response.headers,
+                        invocationReporting: invocationContext.reporting)
+                    
+                    // report success metric
+                    invocationContext.reporting.successCounter?.increment()
+                    
+                    // complete with the decoded type
+                    return output
+                } catch {
+                    // if there was a decoding error, complete with that error
+                    throw HTTPClientError(responseCode: 400, cause: error)
+                }
+            } .flatMapErrorThrowing { error -> OutputType in
+                if let typedError = error as? HTTPClientError {
+                    // report failure metric
+                    switch typedError.category {
+                    case .clientError:
+                        invocationContext.reporting.failure4XXCounter?.increment()
+                    case .serverError:
+                        invocationContext.reporting.failure5XXCounter?.increment()
+                    }
+                }
+                
+                // rethrow the error
+                throw error
+            }
+        
+        future.whenComplete { _ in
+            if let durationMetricDetails = durationMetricDetails {
+                durationMetricDetails.1.recordMicroseconds(Date().timeIntervalSince(durationMetricDetails.0))
+            }
+        }
+        
+        return future
+    }
+}

--- a/Sources/SmokeHTTPClient/HTTPOperationsClient+executeAsEventLoopFutureWithOutput.swift
+++ b/Sources/SmokeHTTPClient/HTTPOperationsClient+executeAsEventLoopFutureWithOutput.swift
@@ -24,6 +24,20 @@ import NIOTLS
 import Logging
 import Metrics
 
+public extension EventLoopFuture {
+    func complete<ErrorType: Error>(on completion: @escaping (Result<Value, ErrorType>) -> (),
+                                    typedErrorProvider: @escaping (Swift.Error) -> ErrorType){
+        self.whenComplete { result in
+            switch result {
+            case .success(let output):
+                completion(.success(output))
+            case .failure(let error):
+                completion(.failure(typedErrorProvider(error)))
+            }
+        }
+    }
+}
+
 public extension HTTPOperationsClient {
     
     /**

--- a/Sources/SmokeHTTPClient/HTTPOperationsClient+executeAsEventLoopFutureWithOutput.swift
+++ b/Sources/SmokeHTTPClient/HTTPOperationsClient+executeAsEventLoopFutureWithOutput.swift
@@ -25,7 +25,7 @@ import Logging
 import Metrics
 
 public extension EventLoopFuture {
-    func completewithResult<ErrorType: Error>(on completion: @escaping (Result<Value, ErrorType>) -> (),
+    func completeWithResult<ErrorType: Error>(on completion: @escaping (Result<Value, ErrorType>) -> (),
                                               typedErrorProvider: @escaping (Swift.Error) -> ErrorType){
         self.whenComplete { result in
             switch result {

--- a/Sources/SmokeHTTPClient/HTTPOperationsClient+executeAsEventLoopFutureWithOutput.swift
+++ b/Sources/SmokeHTTPClient/HTTPOperationsClient+executeAsEventLoopFutureWithOutput.swift
@@ -25,8 +25,8 @@ import Logging
 import Metrics
 
 public extension EventLoopFuture {
-    func complete<ErrorType: Error>(on completion: @escaping (Result<Value, ErrorType>) -> (),
-                                    typedErrorProvider: @escaping (Swift.Error) -> ErrorType){
+    func completewithResult<ErrorType: Error>(on completion: @escaping (Result<Value, ErrorType>) -> (),
+                                              typedErrorProvider: @escaping (Swift.Error) -> ErrorType){
         self.whenComplete { result in
             switch result {
             case .success(let output):

--- a/Sources/SmokeHTTPClient/HTTPOperationsClient+executeAsEventLoopFutureWithOutput.swift
+++ b/Sources/SmokeHTTPClient/HTTPOperationsClient+executeAsEventLoopFutureWithOutput.swift
@@ -40,7 +40,6 @@ public extension HTTPOperationsClient {
     func executeAsEventLoopFutureWithOutput<InputType, OutputType,
         InvocationReportingType: HTTPClientInvocationReporting, HandlerDelegateType: HTTPClientInvocationDelegate>(
             endpointOverride: URL? = nil,
-            eventLoopOverride: EventLoop? = nil,
             endpointPath: String,
             httpMethod: HTTPMethod,
             input: InputType,
@@ -50,7 +49,6 @@ public extension HTTPOperationsClient {
             
             return executeAsEventLoopFutureWithOutputWithWrappedInvocationContext(
                 endpointOverride: endpointOverride,
-                eventLoopOverride: eventLoopOverride,
                 endpointPath: endpointPath,
                 httpMethod: httpMethod,
                 input: input,
@@ -72,7 +70,6 @@ public extension HTTPOperationsClient {
     internal func executeAsEventLoopFutureWithOutputWithWrappedInvocationContext<InputType, OutputType,
         InvocationReportingType: HTTPClientInvocationReporting, HandlerDelegateType: HTTPClientInvocationDelegate>(
             endpointOverride: URL? = nil,
-            eventLoopOverride: EventLoop?,
             endpointPath: String,
             httpMethod: HTTPMethod,
             input: InputType,
@@ -90,7 +87,6 @@ public extension HTTPOperationsClient {
         // that will decode the returned body into the desired decodable type.
         
         let future = executeAsEventLoopFuture(endpointOverride: endpointOverride,
-                                              eventLoopOverride: eventLoopOverride,
                                               endpointPath: endpointPath, httpMethod: httpMethod,
                                               input: input, invocationContext: invocationContext)
             .flatMapThrowing { (response) -> OutputType in

--- a/Sources/SmokeHTTPClient/HTTPOperationsClient+executeAsEventLoopFutureWithoutOutput.swift
+++ b/Sources/SmokeHTTPClient/HTTPOperationsClient+executeAsEventLoopFutureWithoutOutput.swift
@@ -25,8 +25,8 @@ import Logging
 import Metrics
 
 public extension EventLoopFuture where Value == Void {
-    func complete<ErrorType: Error>(on completion: @escaping (Swift.Error?) -> (),
-                                    typedErrorProvider: @escaping (Swift.Error) -> ErrorType){
+    func completeWithoutResult<ErrorType: Error>(on completion: @escaping (Swift.Error?) -> (),
+                                                 typedErrorProvider: @escaping (Swift.Error) -> ErrorType){
         self.whenComplete { result in
             switch result {
             case .success:

--- a/Sources/SmokeHTTPClient/HTTPOperationsClient+executeAsEventLoopFutureWithoutOutput.swift
+++ b/Sources/SmokeHTTPClient/HTTPOperationsClient+executeAsEventLoopFutureWithoutOutput.swift
@@ -41,7 +41,6 @@ public extension HTTPOperationsClient {
     func executeAsEventLoopFutureWithoutOutput<InputType,
             InvocationReportingType: HTTPClientInvocationReporting, HandlerDelegateType: HTTPClientInvocationDelegate>(
         endpointOverride: URL? = nil,
-        eventLoopOverride: EventLoop? = nil,
         endpointPath: String,
         httpMethod: HTTPMethod,
         input: InputType,
@@ -51,7 +50,6 @@ public extension HTTPOperationsClient {
             
             return executeAsEventLoopFutureWithoutOutputWithWrappedInvocationContext(
                 endpointOverride: endpointOverride,
-                eventLoopOverride: eventLoopOverride,
                 endpointPath: endpointPath,
                 httpMethod: httpMethod,
                 input: input,
@@ -72,7 +70,6 @@ public extension HTTPOperationsClient {
     internal func executeAsEventLoopFutureWithoutOutputWithWrappedInvocationContext<InputType,
             InvocationReportingType: HTTPClientInvocationReporting, HandlerDelegateType: HTTPClientInvocationDelegate>(
         endpointOverride: URL? = nil,
-        eventLoopOverride: EventLoop?,
         endpointPath: String,
         httpMethod: HTTPMethod,
         input: InputType,
@@ -88,7 +85,6 @@ public extension HTTPOperationsClient {
         
             // submit the asynchronous request
             let future = executeAsEventLoopFuture(endpointOverride: endpointOverride,
-                                                  eventLoopOverride: eventLoopOverride,
                                                   endpointPath: endpointPath,
                                                   httpMethod: httpMethod,
                                                   input: input,

--- a/Sources/SmokeHTTPClient/HTTPOperationsClient+executeAsEventLoopFutureWithoutOutput.swift
+++ b/Sources/SmokeHTTPClient/HTTPOperationsClient+executeAsEventLoopFutureWithoutOutput.swift
@@ -25,7 +25,7 @@ import Logging
 import Metrics
 
 public extension EventLoopFuture where Value == Void {
-    func completeWithoutResult<ErrorType: Error>(on completion: @escaping (Swift.Error?) -> (),
+    func completeWithoutResult<ErrorType: Error>(on completion: @escaping (ErrorType?) -> (),
                                                  typedErrorProvider: @escaping (Swift.Error) -> ErrorType){
         self.whenComplete { result in
             switch result {

--- a/Sources/SmokeHTTPClient/HTTPOperationsClient+executeAsEventLoopFutureWithoutOutput.swift
+++ b/Sources/SmokeHTTPClient/HTTPOperationsClient+executeAsEventLoopFutureWithoutOutput.swift
@@ -1,0 +1,121 @@
+// Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+//  HTTPOperationsClient+executeAsEventLoopFutureWithoutOutput.swift
+//  SmokeHTTPClient
+//
+
+import Foundation
+import NIO
+import NIOHTTP1
+import AsyncHTTPClient
+import NIOSSL
+import NIOTLS
+import Logging
+import Metrics
+
+public extension HTTPOperationsClient {
+    
+    /**
+     Submits a request that will not return a response body to this client asynchronously as an EventLoopFuture.
+     
+     - Parameters:
+        - endpointPath: The endpoint path for this request.
+        - httpMethod: The http method to use for this request.
+        - input: the input body data to send with this request.
+        - completion: Completion handler called with an error if one occurs or nil otherwise.
+        - asyncResponseInvocationStrategy: The invocation strategy for the response from this request.
+        - invocationContext: context to use for this invocation.
+     - Returns: A future that will produce the execution result or failure.
+     */
+    func executeAsEventLoopFutureWithoutOutput<InputType,
+            InvocationReportingType: HTTPClientInvocationReporting, HandlerDelegateType: HTTPClientInvocationDelegate>(
+        endpointOverride: URL? = nil,
+        eventLoopOverride: EventLoop? = nil,
+        endpointPath: String,
+        httpMethod: HTTPMethod,
+        input: InputType,
+        invocationContext: HTTPClientInvocationContext<InvocationReportingType, HandlerDelegateType>) -> EventLoopFuture<Void>
+        where InputType: HTTPRequestInputProtocol {
+            let wrappingInvocationContext = invocationContext.withOutgoingRequestIdLoggerMetadata()
+            
+            return executeAsEventLoopFutureWithoutOutputWithWrappedInvocationContext(
+                endpointOverride: endpointOverride,
+                eventLoopOverride: eventLoopOverride,
+                endpointPath: endpointPath,
+                httpMethod: httpMethod,
+                input: input,
+                invocationContext: wrappingInvocationContext)
+    }
+    
+    /**
+     Submits a request that will not return a response body to this client asynchronously as an EventLoopFuture.
+     To be called when the `InvocationContext` has already been wrapped with an outgoingRequestId aware Logger.
+     
+     - Parameters:
+        - endpointPath: The endpoint path for this request.
+        - httpMethod: The http method to use for this request.
+        - input: the input body data to send with this request.
+        - invocationContext: context to use for this invocation.
+     - Returns: A future that will produce a Void result or failure.
+     */
+    internal func executeAsEventLoopFutureWithoutOutputWithWrappedInvocationContext<InputType,
+            InvocationReportingType: HTTPClientInvocationReporting, HandlerDelegateType: HTTPClientInvocationDelegate>(
+        endpointOverride: URL? = nil,
+        eventLoopOverride: EventLoop?,
+        endpointPath: String,
+        httpMethod: HTTPMethod,
+        input: InputType,
+        invocationContext: HTTPClientInvocationContext<InvocationReportingType, HandlerDelegateType>) -> EventLoopFuture<Void>
+        where InputType: HTTPRequestInputProtocol {
+            
+            let latencyMetricDetails: (Date, Metrics.Timer)?
+            if let latencyTimer = invocationContext.reporting.latencyTimer {
+                latencyMetricDetails = (Date(), latencyTimer)
+            } else {
+                latencyMetricDetails = nil
+            }
+        
+            // submit the asynchronous request
+            let future = executeAsEventLoopFuture(endpointOverride: endpointOverride,
+                                                  eventLoopOverride: eventLoopOverride,
+                                                  endpointPath: endpointPath,
+                                                  httpMethod: httpMethod,
+                                                  input: input,
+                                                  invocationContext: invocationContext)
+                .map { _ -> Void in
+                    invocationContext.reporting.successCounter?.increment()
+                } .flatMapErrorThrowing { error in
+                    if let typedError = error as? HTTPClientError {
+                        // report failure metric
+                        switch typedError.category {
+                        case .clientError:
+                            invocationContext.reporting.failure4XXCounter?.increment()
+                        case .serverError:
+                            invocationContext.reporting.failure5XXCounter?.increment()
+                        }
+                    }
+                    
+                    // rethrow the error
+                    throw error
+                }
+            
+            future.whenComplete { _ in
+                if let durationMetricDetails = latencyMetricDetails {
+                    durationMetricDetails.1.recordMicroseconds(Date().timeIntervalSince(durationMetricDetails.0))
+                }
+            }
+            
+            return future
+    }
+}

--- a/Sources/SmokeHTTPClient/HTTPOperationsClient+executeAsEventLoopFutureWithoutOutput.swift
+++ b/Sources/SmokeHTTPClient/HTTPOperationsClient+executeAsEventLoopFutureWithoutOutput.swift
@@ -24,6 +24,20 @@ import NIOTLS
 import Logging
 import Metrics
 
+public extension EventLoopFuture where Value == Void {
+    func complete<ErrorType: Error>(on completion: @escaping (Swift.Error?) -> (),
+                                    typedErrorProvider: @escaping (Swift.Error) -> ErrorType){
+        self.whenComplete { result in
+            switch result {
+            case .success:
+                completion(nil)
+            case .failure(let error):
+                completion(typedErrorProvider(error))
+            }
+        }
+    }
+}
+
 public extension HTTPOperationsClient {
     
     /**

--- a/Sources/SmokeHTTPClient/HTTPOperationsClient.swift
+++ b/Sources/SmokeHTTPClient/HTTPOperationsClient.swift
@@ -113,6 +113,80 @@ public struct HTTPOperationsClient {
             completion: @escaping (Result<HTTPResponseComponents, HTTPClientError>) -> (),
             invocationContext: HTTPClientInvocationContext<InvocationReportingType, HandlerDelegateType>) throws -> EventLoopFuture<HTTPClient.Response>
             where InputType: HTTPRequestInputProtocol {
+        let (responseFuture, outwardsRequestContext) = try performExecuteAsync(endpointOverride: endpointOverride,
+                                                                               eventLoopOverride: nil,
+                                                                               endpointPath: endpointPath,
+                                                                               httpMethod: httpMethod,
+                                                                               input: input,
+                                                                               invocationContext: invocationContext)
+
+        responseFuture.whenComplete { result in
+            do {
+                let responseComponents = try self.handleCompleteResponse(invocationContext: invocationContext,
+                                                                         outwardsRequestContext: outwardsRequestContext,
+                                                                         result: result)
+                completion(.success(responseComponents))
+            } catch let error as HTTPClientError {
+                completion(.failure(error))
+            } catch {
+                // if a non-HTTPClientError is thrown, wrap it
+                let responseError = HTTPClientError(responseCode: 400, cause: error)
+                completion(.failure(responseError))
+            }
+        }
+                
+        return responseFuture
+    }
+    
+    func executeAsEventLoopFuture<InputType, InvocationReportingType: HTTPClientInvocationReporting, HandlerDelegateType: HTTPClientInvocationDelegate>(
+            endpointOverride: URL? = nil,
+            eventLoopOverride: EventLoop? = nil,
+            endpointPath: String,
+            httpMethod: HTTPMethod,
+            input: InputType,
+            invocationContext: HTTPClientInvocationContext<InvocationReportingType, HandlerDelegateType>) -> EventLoopFuture<HTTPResponseComponents>
+            where InputType: HTTPRequestInputProtocol {
+        do {
+            let (responseFuture, outwardsRequestContext) = try performExecuteAsync(endpointOverride: endpointOverride,
+                                                                                   eventLoopOverride: eventLoopOverride,
+                                                                                   endpointPath: endpointPath,
+                                                                                   httpMethod: httpMethod,
+                                                                                   input: input,
+                                                                                   invocationContext: invocationContext)
+            return responseFuture.flatMapThrowing { result in
+                return try self.handleCompleteResponse(invocationContext: invocationContext,
+                                                       outwardsRequestContext: outwardsRequestContext,
+                                                       result: .success(result))
+            } .flatMapErrorThrowing { error in
+                if error is HTTPClientError {
+                    throw error
+                } else {
+                    // if a non-HTTPClientError is thrown, wrap it
+                    throw HTTPClientError(responseCode: 400, cause: error)
+                }
+            }
+        } catch {
+            let eventLoop = eventLoopOverride ?? self.eventLoopGroup.next()
+            
+            let promise = eventLoop.makePromise(of: HTTPResponseComponents.self)
+            
+            promise.fail(error)
+            
+            return promise.futureResult
+        }
+    }
+    
+    // To maintain the existing behaviour of async functions, this function will throw for synchronous setup errors and fail
+    // the future otherwise.
+    private func performExecuteAsync<InputType, InvocationReportingType: HTTPClientInvocationReporting, HandlerDelegateType: HTTPClientInvocationDelegate>(
+            endpointOverride: URL? = nil,
+            eventLoopOverride: EventLoop?,
+            endpointPath: String,
+            httpMethod: HTTPMethod,
+            input: InputType,
+            invocationContext: HTTPClientInvocationContext<InvocationReportingType, HandlerDelegateType>) throws
+        -> (EventLoopFuture<HTTPClient.Response>, InvocationReportingType.TraceContextType.OutwardsRequestContext)
+            where InputType: HTTPRequestInputProtocol {
 
         let endpointHostName = endpointOverride?.host ?? self.endpointHostName
         let endpointPort = endpointOverride?.port ?? self.endpointPort
@@ -156,16 +230,15 @@ public struct HTTPOperationsClient {
         let request = try HTTPClient.Request(url: endpoint, method: httpMethod,
                                              headers: requestHeaders, body: .data(sendBody))
                 
- 
-        let responseFuture = self.wrappedHttpClient.execute(request: request)
-        responseFuture.whenComplete { result in
-            self.handleCompleteResponse(invocationContext: invocationContext,
-                                        outwardsRequestContext: outwardsRequestContext,
-                                        completion: completion,
-                                        result: result)
+        let responseFuture: EventLoopFuture<HTTPClient.Response>
+        if let eventLoopOverride = eventLoopOverride {
+            responseFuture = self.wrappedHttpClient.execute(request: request,
+                                                            eventLoop: .delegateAndChannel(on: eventLoopOverride))
+        } else {
+            responseFuture = self.wrappedHttpClient.execute(request: request)
         }
-                
-        return responseFuture
+        
+        return (responseFuture, outwardsRequestContext)
     }
     
     /*
@@ -175,8 +248,7 @@ public struct HTTPOperationsClient {
                 HandlerDelegateType: HTTPClientInvocationDelegate>(
             invocationContext: HTTPClientInvocationContext<InvocationReportingType, HandlerDelegateType>,
             outwardsRequestContext: InvocationReportingType.TraceContextType.OutwardsRequestContext,
-            completion: @escaping (Result<HTTPResponseComponents, HTTPClientError>) -> (),
-            result: Result<HTTPClient.Response, Error>) {
+            result: Result<HTTPClient.Response, Error>) throws -> HTTPResponseComponents {
         let invocationReporting = invocationContext.reporting
         let logger = invocationReporting.logger
         
@@ -212,8 +284,7 @@ public struct HTTPOperationsClient {
                     response: response, bodyData: bodyData)
                 
                 // complete with the response data (potentially empty)
-                completion(.success(responseComponents))
-                return
+                return responseComponents
             }
 
             // Handle client delegated errors
@@ -226,8 +297,7 @@ public struct HTTPOperationsClient {
                     internalRequestId: invocationReporting.internalRequestId,
                     response: response, bodyData: bodyData, error: error)
                 
-                completion(.failure(error))
-                return
+                throw error
             }
 
             let responseError: HTTPClientError
@@ -250,10 +320,9 @@ public struct HTTPOperationsClient {
                 response: response, bodyData: bodyData, error: responseError)
 
             // complete with the error
-            completion(.failure(responseError))
+            throw responseError
             
         case .failure(let error):
-            let cause: HTTPError
             let wrappingError: HTTPClientError
             
             let errorDescription = String(describing: error)
@@ -261,15 +330,15 @@ public struct HTTPOperationsClient {
             switch error {
             // for retriable HTTPClientErrors
             case let clientError as AsyncHTTPClient.HTTPClientError where isRetriableHTTPClientError(clientError: clientError):
-                cause = HTTPError.connectionError(errorDescription)
+                let cause = HTTPError.connectionError(errorDescription)
                 wrappingError = HTTPClientError(responseCode: 500, cause: cause)
             // for non-retriable HTTPClientErrors
             case _ as AsyncHTTPClient.HTTPClientError:
-                cause = HTTPError.badResponse(errorDescription)
+                let cause = HTTPError.badResponse(errorDescription)
                 wrappingError = HTTPClientError(responseCode: 400, cause: cause)
             // by default treat all other errors as 500 so they can be retried
             default:
-                cause = HTTPError.connectionError(errorDescription)
+                let cause = HTTPError.connectionError(errorDescription)
                 wrappingError = HTTPClientError(responseCode: 500, cause: cause)
             }
             
@@ -280,7 +349,7 @@ public struct HTTPOperationsClient {
                 response: nil, bodyData: nil, error: error)
 
             // complete with this error
-            completion(.failure(wrappingError))
+            throw wrappingError
         }
     }
     

--- a/Sources/SmokeHTTPClient/HTTPOperationsClient.swift
+++ b/Sources/SmokeHTTPClient/HTTPOperationsClient.swift
@@ -227,7 +227,9 @@ public struct HTTPOperationsClient {
                                              headers: requestHeaders, body: .data(sendBody))
                 
         let responseFuture: EventLoopFuture<HTTPClient.Response>
-        if let eventLoopOverride = invocationContext.reporting.eventLoop {
+        // if an event loop is provided that can be used with this client
+        if let eventLoopOverride = invocationContext.reporting.eventLoop,
+           self.eventLoopGroup.makeIterator().contains(where: { $0 === eventLoopOverride }) {
             responseFuture = self.wrappedHttpClient.execute(request: request,
                                                             eventLoop: .delegateAndChannel(on: eventLoopOverride))
         } else {

--- a/Sources/SmokeHTTPClient/StandardHTTPClientCoreInvocationReporting.swift
+++ b/Sources/SmokeHTTPClient/StandardHTTPClientCoreInvocationReporting.swift
@@ -16,6 +16,7 @@
 //
 import Foundation
 import Logging
+import NIO
 
 /**
   A type conforming to the `HTTPClientCoreInvocationReporting` protocol..
@@ -24,12 +25,15 @@ public struct StandardHTTPClientCoreInvocationReporting<TraceContextType: Invoca
     public let logger: Logger
     public var internalRequestId: String
     public var traceContext: TraceContextType
+    public var eventLoop: EventLoop?
     
     public init(logger: Logger,
                 internalRequestId: String,
-                traceContext: TraceContextType) {
+                traceContext: TraceContextType,
+                eventLoop: EventLoop? = nil) {
         self.logger = logger
         self.internalRequestId = internalRequestId
         self.traceContext = traceContext
+        self.eventLoop = eventLoop
     }
 }

--- a/Sources/SmokeHTTPClient/StandardHTTPClientInvocationReporting.swift
+++ b/Sources/SmokeHTTPClient/StandardHTTPClientInvocationReporting.swift
@@ -18,11 +18,13 @@
 import Foundation
 import Logging
 import Metrics
+import NIO
 
 public struct StandardHTTPClientInvocationReporting<TraceContextType: InvocationTraceContext>: HTTPClientInvocationReporting {
     public let internalRequestId: String
     public let traceContext: TraceContextType
     public let logger: Logging.Logger
+    public var eventLoop: EventLoop?
     public let successCounter: Metrics.Counter?
     public let failure5XXCounter: Metrics.Counter?
     public let failure4XXCounter: Metrics.Counter?
@@ -32,12 +34,14 @@ public struct StandardHTTPClientInvocationReporting<TraceContextType: Invocation
     public init(internalRequestId: String,
                 traceContext: TraceContextType,
                 logger: Logging.Logger = Logger(label: "com.amazon.SmokeHTTP.SmokeHTTPClient.StandardHTTPClientInvocationReporting"),
+                eventLoop: EventLoop? = nil,
                 successCounter: Metrics.Counter? = nil,
                 failure5XXCounter: Metrics.Counter? = nil,
                 failure4XXCounter: Metrics.Counter? = nil,
                 retryCountRecorder: Metrics.Recorder? = nil,
                 latencyTimer: Metrics.Timer? = nil) {
         self.logger = logger
+        self.eventLoop = eventLoop
         self.internalRequestId = internalRequestId
         self.traceContext = traceContext
         self.successCounter = successCounter


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Add Event loop future returning execute variants.

The added files mirror the existing completion handler based `HTTPOperationsClient +executeAsync*` files and contain the same logic.

Combines with https://github.com/amzn/smoke-framework/pull/67 to pass through the eventloop used by an incoming smoke-framework request to any smoke-http based clients.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
