### PR TITLE
Add the ability to aggregate info about output requests.

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/swift-server/async-http-client.git",
         "state": {
           "branch": null,
-          "revision": "0a8dddbe15cd72f7bb5e47951fb7c1eb0836dfc2",
-          "version": "1.2.2"
+          "revision": "a72c5adce3986ff6b5092ae0464a8f2675087860",
+          "version": "1.2.3"
         }
       },
       {
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/apple/swift-log.git",
         "state": {
           "branch": null,
-          "revision": "173f567a2dfec11d74588eea82cecea555bdc0bc",
-          "version": "1.4.0"
+          "revision": "12d3a8651d32295794a850307f77407f95b8c881",
+          "version": "1.4.1"
         }
       },
       {
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio.git",
         "state": {
           "branch": null,
-          "revision": "2bae395344d41710dffab456265d534d7dc34ab8",
-          "version": "2.25.0"
+          "revision": "6d3ca7e54e06a69d0f2612c2ce8bb8b7319085a4",
+          "version": "2.26.0"
         }
       },
       {
@@ -42,8 +42,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio-extras.git",
         "state": {
           "branch": null,
-          "revision": "e5b5d191a80667a14827bfeb0ae4a511f7677942",
-          "version": "1.7.0"
+          "revision": "de1c80ad1fdff1ba772bcef6b392c3ef735f39a6",
+          "version": "1.8.0"
         }
       },
       {
@@ -51,8 +51,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio-ssl.git",
         "state": {
           "branch": null,
-          "revision": "901a01423316c4ce672b1b58ce62aecb8069cb1f",
-          "version": "2.10.1"
+          "revision": "4c933e955b8797f5a5a90bd2a0fb411fdb11bb94",
+          "version": "2.10.3"
         }
       },
       {
@@ -60,8 +60,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio-transport-services.git",
         "state": {
           "branch": null,
-          "revision": "5a352330c09a323e59ebd99afdf4ca3964c217bc",
-          "version": "1.9.1"
+          "revision": "1d28d48e071727f4558a8a4bb1894472abc47a58",
+          "version": "1.9.2"
         }
       }
     ]

--- a/Sources/SmokeHTTPClient/HTTPClientCoreInvocationReporting.swift
+++ b/Sources/SmokeHTTPClient/HTTPClientCoreInvocationReporting.swift
@@ -19,6 +19,26 @@ import Foundation
 import Logging
 import NIO
 
+public protocol OutputRequestRecord {
+    var requestLatency: TimeInterval { get }
+}
+
+public protocol RetriableOutputRequestRecord {
+    var outputRequests: [OutputRequestRecord] { get }
+}
+
+/**
+  Provide the ability to record the info about the outward requests for a particular invocation reporting instance.
+ 
+  This is really a stop-gap measure until distributed tracing comes along and we can do this in a more standardised way.
+ */
+public protocol OutwardsRequestAggregator {
+    
+    func recordOutwardsRequest(outputRequestRecord: OutputRequestRecord)
+    
+    func recordRetriableOutwardsRequest(retriableOutwardsRequest: RetriableOutputRequestRecord)
+}
+
 /**
  A context related to reporting on the invocation of the HTTPClient. This represents the
  core requirements for invocation reporting.
@@ -39,11 +59,18 @@ public protocol HTTPClientCoreInvocationReporting {
     var traceContext: TraceContextType { get }
     
     var eventLoop: EventLoop? { get }
+    
+    var outwardsRequestAggregator: OutwardsRequestAggregator? { get }
 }
 
 public extension HTTPClientCoreInvocationReporting {
     // The attribute is being added as a non-breaking change, so add a default implementation that replicates existing behaviour
     var eventLoop: EventLoop? {
+        return nil
+    }
+    
+    // The attribute is being added as a non-breaking change, so add a default implementation that replicates existing behaviour
+    var outwardsRequestAggregator: OutwardsRequestAggregator? {
         return nil
     }
 }

--- a/Sources/SmokeHTTPClient/HTTPClientCoreInvocationReporting.swift
+++ b/Sources/SmokeHTTPClient/HTTPClientCoreInvocationReporting.swift
@@ -27,6 +27,10 @@ public protocol RetriableOutputRequestRecord {
     var outputRequests: [OutputRequestRecord] { get }
 }
 
+public protocol RetryAttemptRecord {
+    var retryWait: TimeInterval { get }
+}
+
 /**
   Provide the ability to record the info about the outward requests for a particular invocation reporting instance.
  
@@ -35,6 +39,8 @@ public protocol RetriableOutputRequestRecord {
 public protocol OutwardsRequestAggregator {
     
     func recordOutwardsRequest(outputRequestRecord: OutputRequestRecord)
+    
+    func recordRetryAttempt(retryAttemptRecord: RetryAttemptRecord)
     
     func recordRetriableOutwardsRequest(retriableOutwardsRequest: RetriableOutputRequestRecord)
 }

--- a/Sources/SmokeHTTPClient/HTTPClientInnerRetryInvocationReporting.swift
+++ b/Sources/SmokeHTTPClient/HTTPClientInnerRetryInvocationReporting.swift
@@ -28,6 +28,7 @@ internal struct HTTPClientInnerRetryInvocationReporting<TraceContextType: Invoca
     let traceContext: TraceContextType
     let logger: Logging.Logger
     let eventLoop: EventLoop?
+    let outwardsRequestAggregator: OutwardsRequestAggregator?
     let successCounter: Metrics.Counter? = nil
     let failure5XXCounter: Metrics.Counter? = nil
     let failure4XXCounter: Metrics.Counter? = nil

--- a/Sources/SmokeHTTPClient/HTTPClientInvocationContext.swift
+++ b/Sources/SmokeHTTPClient/HTTPClientInvocationContext.swift
@@ -45,6 +45,8 @@ extension HTTPClientInvocationContext {
             internalRequestId: reporting.internalRequestId,
             traceContext: reporting.traceContext,
             logger: outwardInvocationLogger,
+            eventLoop: reporting.eventLoop,
+            outwardsRequestAggregator: reporting.outwardsRequestAggregator,
             successCounter: reporting.successCounter,
             failure5XXCounter: reporting.failure5XXCounter,
             failure4XXCounter: reporting.failure4XXCounter,

--- a/Sources/SmokeHTTPClient/HTTPClientInvocationReporting.swift
+++ b/Sources/SmokeHTTPClient/HTTPClientInvocationReporting.swift
@@ -19,6 +19,8 @@ import Foundation
 import Logging
 import Metrics
 
+private let timeIntervalToMilliseconds: Double = 1000
+
 /**
  A context related to reporting on the invocation of the HTTPClient. This interface extends the
  HTTPClientCoreInvocationReporting protocol by adding metrics emitted by the 
@@ -39,4 +41,10 @@ public protocol HTTPClientInvocationReporting: HTTPClientCoreInvocationReporting
     
     /// The `Metrics.Recorder` to record the duration of this invocation.
     var latencyTimer: Metrics.Timer? { get }
+}
+
+internal extension TimeInterval {
+    var milliseconds: Int {
+        return Int(self * timeIntervalToMilliseconds)
+    }
 }

--- a/Sources/SmokeHTTPClient/HTTPClientInvocationReporting.swift
+++ b/Sources/SmokeHTTPClient/HTTPClientInvocationReporting.swift
@@ -48,3 +48,9 @@ internal extension TimeInterval {
         return Int(self * timeIntervalToMilliseconds)
     }
 }
+
+internal extension Int {
+    var millisecondsToTimeInterval: TimeInterval {
+        return TimeInterval(self) / timeIntervalToMilliseconds
+    }
+}

--- a/Sources/SmokeHTTPClient/HTTPOperationsClient +executeAsyncRetriableWithOutput.swift
+++ b/Sources/SmokeHTTPClient/HTTPOperationsClient +executeAsyncRetriableWithOutput.swift
@@ -47,6 +47,7 @@ public extension HTTPOperationsClient {
         let retryOnError: (HTTPClientError) -> Bool
         let queue = DispatchQueue.global()
         let latencyMetricDetails: (Date, Metrics.Timer)?
+        let outwardsRequestAggregators: (OutwardsRequestAggregator, RetriableOutwardsRequestAggregator)?
         
         var retriesRemaining: Int
         
@@ -71,6 +72,13 @@ public extension HTTPOperationsClient {
             self.retriesRemaining = retryConfiguration.numRetries
             self.retryOnError = retryOnError
             
+            // if the request latencies need to be aggregated
+            if let outwardsRequestAggregator = invocationContext.reporting.outwardsRequestAggregator {
+                outwardsRequestAggregators = (outwardsRequestAggregator, RetriableOutwardsRequestAggregator())
+            } else {
+                outwardsRequestAggregators = nil
+            }
+            
             if let latencyTimer = invocationContext.reporting.latencyTimer {
                 self.latencyMetricDetails = (Date(), latencyTimer)
             } else {
@@ -80,7 +88,8 @@ public extension HTTPOperationsClient {
             let innerReporting = HTTPClientInnerRetryInvocationReporting(internalRequestId: invocationContext.reporting.internalRequestId,
                                                                          traceContext: invocationContext.reporting.traceContext,
                                                                          logger: invocationContext.reporting.logger,
-                                                                         eventLoop: eventLoop)
+                                                                         eventLoop: eventLoop,
+                                                                         outwardsRequestAggregator: outwardsRequestAggregators?.1)
             self.innerInvocationContext = HTTPClientInvocationContext(reporting: innerReporting, handlerDelegate: invocationContext.handlerDelegate)
         }
         
@@ -156,8 +165,15 @@ public extension HTTPOperationsClient {
             let retryCount = retryConfiguration.numRetries - retriesRemaining
             invocationContext.reporting.retryCountRecorder?.record(retryCount)
             
-            if let durationMetricDetails = latencyMetricDetails {
-                durationMetricDetails.1.recordMicroseconds(Date().timeIntervalSince(durationMetricDetails.0))
+            if let durationMetricDetails = self.latencyMetricDetails {
+                durationMetricDetails.1.recordMilliseconds(Date().timeIntervalSince(durationMetricDetails.0).milliseconds)
+            }
+            
+            // submit all the request latencies captured by the RetriableOutwardsRequestAggregator
+            // to the provided outwardsRequestAggregator if it was provided
+            if let outwardsRequestAggregators = self.outwardsRequestAggregators {
+                outwardsRequestAggregators.0.recordRetriableOutwardsRequest(
+                    retriableOutwardsRequest: StandardRetriableOutputRequestRecord(outputRequests: outwardsRequestAggregators.1.outputRequestRecords))
             }
 
             outerCompletion(result)

--- a/Sources/SmokeHTTPClient/HTTPOperationsClient +executeAsyncRetriableWithOutput.swift
+++ b/Sources/SmokeHTTPClient/HTTPOperationsClient +executeAsyncRetriableWithOutput.swift
@@ -119,6 +119,11 @@ public extension HTTPOperationsClient {
                     let currentRetriesRemaining = retriesRemaining
                     retriesRemaining -= 1
                     
+                    if let outwardsRequestAggregators = self.outwardsRequestAggregators {
+                        outwardsRequestAggregators.0.recordRetryAttempt(
+                            retryAttemptRecord: StandardRetryAttemptRecord(retryWait: retryInterval.millisecondsToTimeInterval))
+                    }
+                    
                     logger.warning(
                         "Request failed with error: \(error). Remaining retries: \(currentRetriesRemaining). Retrying in \(retryInterval) ms.")
                     let deadline = DispatchTime.now() + .milliseconds(retryInterval)

--- a/Sources/SmokeHTTPClient/HTTPOperationsClient +executeSyncRetriableWithOutput.swift
+++ b/Sources/SmokeHTTPClient/HTTPOperationsClient +executeSyncRetriableWithOutput.swift
@@ -42,6 +42,7 @@ public extension HTTPOperationsClient {
         let retryConfiguration: HTTPClientRetryConfiguration
         let retryOnError: (HTTPClientError) -> Bool
         let latencyMetricDetails: (Date, Metrics.Timer)?
+        let outwardsRequestAggregators: (OutwardsRequestAggregator, RetriableOutwardsRequestAggregator)?
         
         var retriesRemaining: Int
         
@@ -64,6 +65,13 @@ public extension HTTPOperationsClient {
             self.retriesRemaining = retryConfiguration.numRetries
             self.retryOnError = retryOnError
             
+            // if the request latencies need to be aggregated
+            if let outwardsRequestAggregator = invocationContext.reporting.outwardsRequestAggregator {
+                outwardsRequestAggregators = (outwardsRequestAggregator, RetriableOutwardsRequestAggregator())
+            } else {
+                outwardsRequestAggregators = nil
+            }
+            
             if let latencyTimer = invocationContext.reporting.latencyTimer {
                 self.latencyMetricDetails = (Date(), latencyTimer)
             } else {
@@ -73,7 +81,8 @@ public extension HTTPOperationsClient {
             let innerReporting = HTTPClientInnerRetryInvocationReporting(internalRequestId: invocationContext.reporting.internalRequestId,
                                                                          traceContext: invocationContext.reporting.traceContext,
                                                                          logger: invocationContext.reporting.logger,
-                                                                         eventLoop: eventLoop)
+                                                                         eventLoop: eventLoop,
+                                                                         outwardsRequestAggregator: outwardsRequestAggregators?.1)
             self.innerInvocationContext = HTTPClientInvocationContext(reporting: innerReporting, handlerDelegate: invocationContext.handlerDelegate)
         }
         
@@ -84,7 +93,14 @@ public extension HTTPOperationsClient {
                 invocationContext.reporting.retryCountRecorder?.record(retryCount)
                 
                 if let durationMetricDetails = latencyMetricDetails {
-                    durationMetricDetails.1.recordMicroseconds(Date().timeIntervalSince(durationMetricDetails.0))
+                    durationMetricDetails.1.recordMilliseconds(Date().timeIntervalSince(durationMetricDetails.0).milliseconds)
+                }
+                
+                // submit all the request latencies captured by the RetriableOutwardsRequestAggregator
+                // to the provided outwardsRequestAggregator if it was provided
+                if let outwardsRequestAggregators = self.outwardsRequestAggregators {
+                    outwardsRequestAggregators.0.recordRetriableOutwardsRequest(
+                        retriableOutwardsRequest: StandardRetriableOutputRequestRecord(outputRequests: outwardsRequestAggregators.1.outputRequestRecords))
                 }
             }
             

--- a/Sources/SmokeHTTPClient/HTTPOperationsClient +executeSyncRetriableWithOutput.swift
+++ b/Sources/SmokeHTTPClient/HTTPOperationsClient +executeSyncRetriableWithOutput.swift
@@ -152,6 +152,11 @@ public extension HTTPOperationsClient {
                 let currentRetriesRemaining = retriesRemaining
                 retriesRemaining -= 1
                 
+                if let outwardsRequestAggregators = self.outwardsRequestAggregators {
+                    outwardsRequestAggregators.0.recordRetryAttempt(
+                        retryAttemptRecord: StandardRetryAttemptRecord(retryWait: retryInterval.millisecondsToTimeInterval))
+                }
+                
                 logger.debug("Request failed with error: \(error). Remaining retries: \(currentRetriesRemaining). Retrying in \(retryInterval) ms.")
                 usleep(useconds_t(retryInterval * milliToMicroSeconds))
                 logger.debug("Reattempting request due to remaining retries: \(currentRetriesRemaining)")

--- a/Sources/SmokeHTTPClient/HTTPOperationsClient +executeSyncRetriableWithoutOutput.swift
+++ b/Sources/SmokeHTTPClient/HTTPOperationsClient +executeSyncRetriableWithoutOutput.swift
@@ -47,6 +47,7 @@ public extension HTTPOperationsClient {
         let retryConfiguration: HTTPClientRetryConfiguration
         let retryOnError: (HTTPClientError) -> Bool
         let latencyMetricDetails: (Date, Metrics.Timer)?
+        let outwardsRequestAggregators: (OutwardsRequestAggregator, RetriableOutwardsRequestAggregator)?
         
         var retriesRemaining: Int
         
@@ -67,6 +68,13 @@ public extension HTTPOperationsClient {
             self.retriesRemaining = retryConfiguration.numRetries
             self.retryOnError = retryOnError
             
+            // if the request latencies need to be aggregated
+            if let outwardsRequestAggregator = invocationContext.reporting.outwardsRequestAggregator {
+                outwardsRequestAggregators = (outwardsRequestAggregator, RetriableOutwardsRequestAggregator())
+            } else {
+                outwardsRequestAggregators = nil
+            }
+            
             if let latencyTimer = invocationContext.reporting.latencyTimer {
                 self.latencyMetricDetails = (Date(), latencyTimer)
             } else {
@@ -76,7 +84,8 @@ public extension HTTPOperationsClient {
             let innerReporting = HTTPClientInnerRetryInvocationReporting(internalRequestId: invocationContext.reporting.internalRequestId,
                                                                          traceContext: invocationContext.reporting.traceContext,
                                                                          logger: invocationContext.reporting.logger,
-                                                                         eventLoop: eventLoop)
+                                                                         eventLoop: eventLoop,
+                                                                         outwardsRequestAggregator: outwardsRequestAggregators?.1)
             self.innerInvocationContext = HTTPClientInvocationContext(reporting: innerReporting, handlerDelegate: invocationContext.handlerDelegate)
         }
         
@@ -87,7 +96,14 @@ public extension HTTPOperationsClient {
                 invocationContext.reporting.retryCountRecorder?.record(retryCount)
                 
                 if let durationMetricDetails = latencyMetricDetails {
-                    durationMetricDetails.1.recordMicroseconds(Date().timeIntervalSince(durationMetricDetails.0))
+                    durationMetricDetails.1.recordMilliseconds(Date().timeIntervalSince(durationMetricDetails.0).milliseconds)
+                }
+                
+                // submit all the request latencies captured by the RetriableOutwardsRequestAggregator
+                // to the provided outwardsRequestAggregator if it was provided
+                if let outwardsRequestAggregators = self.outwardsRequestAggregators {
+                    outwardsRequestAggregators.0.recordRetriableOutwardsRequest(
+                        retriableOutwardsRequest: StandardRetriableOutputRequestRecord(outputRequests: outwardsRequestAggregators.1.outputRequestRecords))
                 }
             }
             

--- a/Sources/SmokeHTTPClient/HTTPOperationsClient +executeSyncRetriableWithoutOutput.swift
+++ b/Sources/SmokeHTTPClient/HTTPOperationsClient +executeSyncRetriableWithoutOutput.swift
@@ -153,6 +153,11 @@ public extension HTTPOperationsClient {
                 let currentRetriesRemaining = retriesRemaining
                 retriesRemaining -= 1
                 
+                if let outwardsRequestAggregators = self.outwardsRequestAggregators {
+                    outwardsRequestAggregators.0.recordRetryAttempt(
+                        retryAttemptRecord: StandardRetryAttemptRecord(retryWait: retryInterval.millisecondsToTimeInterval))
+                }
+                
                 logger.debug("Request failed with error: \(error). Remaining retries: \(currentRetriesRemaining). Retrying in \(retryInterval) ms.")
                 usleep(useconds_t(retryInterval.milliFromMicroSeconds))
                 logger.debug("Reattempting request due to remaining retries: \(currentRetriesRemaining)")

--- a/Sources/SmokeHTTPClient/HTTPOperationsClient+executeAsEventLoopFutureRetriableWithOutput.swift
+++ b/Sources/SmokeHTTPClient/HTTPOperationsClient+executeAsEventLoopFutureRetriableWithOutput.swift
@@ -130,6 +130,11 @@ public extension HTTPOperationsClient {
                 let currentRetriesRemaining = retriesRemaining
                 retriesRemaining -= 1
                 
+                if let outwardsRequestAggregators = self.outwardsRequestAggregators {
+                    outwardsRequestAggregators.0.recordRetryAttempt(
+                        retryAttemptRecord: StandardRetryAttemptRecord(retryWait: retryInterval.millisecondsToTimeInterval))
+                }
+                
                 logger.warning(
                     "Request failed with error: \(error). Remaining retries: \(currentRetriesRemaining). Retrying in \(retryInterval) ms.")
                 let deadline = DispatchTime.now() + .milliseconds(retryInterval)

--- a/Sources/SmokeHTTPClient/HTTPOperationsClient+executeAsEventLoopFutureRetriableWithoutOutput.swift
+++ b/Sources/SmokeHTTPClient/HTTPOperationsClient+executeAsEventLoopFutureRetriableWithoutOutput.swift
@@ -130,6 +130,11 @@ public extension HTTPOperationsClient {
                 let currentRetriesRemaining = retriesRemaining
                 retriesRemaining -= 1
                 
+                if let outwardsRequestAggregators = self.outwardsRequestAggregators {
+                    outwardsRequestAggregators.0.recordRetryAttempt(
+                        retryAttemptRecord: StandardRetryAttemptRecord(retryWait: retryInterval.millisecondsToTimeInterval))
+                }
+                
                 logger.warning(
                     "Request failed with error: \(error). Remaining retries: \(currentRetriesRemaining). Retrying in \(retryInterval) ms.")
                 let deadline = DispatchTime.now() + .milliseconds(retryInterval)

--- a/Sources/SmokeHTTPClient/HTTPOperationsClient+executeAsyncRetriableWithoutOutput.swift
+++ b/Sources/SmokeHTTPClient/HTTPOperationsClient+executeAsyncRetriableWithoutOutput.swift
@@ -115,6 +115,11 @@ public extension HTTPOperationsClient {
                     let currentRetriesRemaining = retriesRemaining
                     retriesRemaining -= 1
                     
+                    if let outwardsRequestAggregators = self.outwardsRequestAggregators {
+                        outwardsRequestAggregators.0.recordRetryAttempt(
+                            retryAttemptRecord: StandardRetryAttemptRecord(retryWait: retryInterval.millisecondsToTimeInterval))
+                    }
+                    
                     let retryDescription = "Remaining retries: \(currentRetriesRemaining). Retrying in \(retryInterval) ms."
                     logger.warning("Request failed with error: \(innerError). \(retryDescription)")
                     let deadline = DispatchTime.now() + .milliseconds(retryInterval)

--- a/Sources/SmokeHTTPClient/RetriableOutwardsRequestLatencyAggregator.swift
+++ b/Sources/SmokeHTTPClient/RetriableOutwardsRequestLatencyAggregator.swift
@@ -1,0 +1,29 @@
+//
+//  RetriableOutwardsRequestAggregator.swift
+//
+
+import Foundation
+
+internal class RetriableOutwardsRequestAggregator:  OutwardsRequestAggregator {
+    private(set) var outputRequestRecords: [OutputRequestRecord]
+    
+    init() {
+        self.outputRequestRecords = []
+    }
+    
+    func recordOutwardsRequest(outputRequestRecord: OutputRequestRecord) {
+        self.outputRequestRecords.append(outputRequestRecord)
+    }
+    
+    func recordRetriableOutwardsRequest(retriableOutwardsRequest: RetriableOutputRequestRecord) {
+        self.outputRequestRecords.append(contentsOf: retriableOutwardsRequest.outputRequests)
+    }
+}
+
+struct StandardOutputRequestRecord: OutputRequestRecord {
+    let requestLatency: TimeInterval
+}
+
+struct StandardRetriableOutputRequestRecord: RetriableOutputRequestRecord {
+    var outputRequests: [OutputRequestRecord]
+}

--- a/Sources/SmokeHTTPClient/RetriableOutwardsRequestLatencyAggregator.swift
+++ b/Sources/SmokeHTTPClient/RetriableOutwardsRequestLatencyAggregator.swift
@@ -4,6 +4,10 @@
 
 import Foundation
 
+/**
+  An internal type conforming to the `OutwardsRequestAggregator` protocol that is used to aggregate
+  the outputRequest records for the same output request that is optentially retried.
+ */
 internal class RetriableOutwardsRequestAggregator:  OutwardsRequestAggregator {
     private(set) var outputRequestRecords: [OutputRequestRecord]
     
@@ -15,6 +19,10 @@ internal class RetriableOutwardsRequestAggregator:  OutwardsRequestAggregator {
         self.outputRequestRecords.append(outputRequestRecord)
     }
     
+    func recordRetryAttempt(retryAttemptRecord: RetryAttemptRecord) {
+        // for this internal type, we don't need to record retry attempts
+    }
+    
     func recordRetriableOutwardsRequest(retriableOutwardsRequest: RetriableOutputRequestRecord) {
         self.outputRequestRecords.append(contentsOf: retriableOutwardsRequest.outputRequests)
     }
@@ -22,6 +30,10 @@ internal class RetriableOutwardsRequestAggregator:  OutwardsRequestAggregator {
 
 struct StandardOutputRequestRecord: OutputRequestRecord {
     let requestLatency: TimeInterval
+}
+
+struct StandardRetryAttemptRecord: RetryAttemptRecord {
+    let retryWait: TimeInterval
 }
 
 struct StandardRetriableOutputRequestRecord: RetriableOutputRequestRecord {

--- a/Sources/SmokeHTTPClient/StandardHTTPClientCoreInvocationReporting.swift
+++ b/Sources/SmokeHTTPClient/StandardHTTPClientCoreInvocationReporting.swift
@@ -26,14 +26,17 @@ public struct StandardHTTPClientCoreInvocationReporting<TraceContextType: Invoca
     public var internalRequestId: String
     public var traceContext: TraceContextType
     public var eventLoop: EventLoop?
+    public var outwardsRequestAggregator: OutwardsRequestAggregator?
     
     public init(logger: Logger,
                 internalRequestId: String,
                 traceContext: TraceContextType,
-                eventLoop: EventLoop? = nil) {
+                eventLoop: EventLoop? = nil,
+                outwardsRequestAggregator: OutwardsRequestAggregator? = nil) {
         self.logger = logger
         self.internalRequestId = internalRequestId
         self.traceContext = traceContext
         self.eventLoop = eventLoop
+        self.outwardsRequestAggregator = outwardsRequestAggregator
     }
 }

--- a/Sources/SmokeHTTPClient/StandardHTTPClientInvocationReporting.swift
+++ b/Sources/SmokeHTTPClient/StandardHTTPClientInvocationReporting.swift
@@ -25,6 +25,7 @@ public struct StandardHTTPClientInvocationReporting<TraceContextType: Invocation
     public let traceContext: TraceContextType
     public let logger: Logging.Logger
     public var eventLoop: EventLoop?
+    public var outwardsRequestAggregator: OutwardsRequestAggregator?
     public let successCounter: Metrics.Counter?
     public let failure5XXCounter: Metrics.Counter?
     public let failure4XXCounter: Metrics.Counter?
@@ -35,6 +36,7 @@ public struct StandardHTTPClientInvocationReporting<TraceContextType: Invocation
                 traceContext: TraceContextType,
                 logger: Logging.Logger = Logger(label: "com.amazon.SmokeHTTP.SmokeHTTPClient.StandardHTTPClientInvocationReporting"),
                 eventLoop: EventLoop? = nil,
+                outwardsRequestAggregator: OutwardsRequestAggregator? = nil,
                 successCounter: Metrics.Counter? = nil,
                 failure5XXCounter: Metrics.Counter? = nil,
                 failure4XXCounter: Metrics.Counter? = nil,
@@ -42,6 +44,7 @@ public struct StandardHTTPClientInvocationReporting<TraceContextType: Invocation
                 latencyTimer: Metrics.Timer? = nil) {
         self.logger = logger
         self.eventLoop = eventLoop
+        self.outwardsRequestAggregator = outwardsRequestAggregator
         self.internalRequestId = internalRequestId
         self.traceContext = traceContext
         self.successCounter = successCounter


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Add the ability to aggregate info about output requests.

As mentioned in the code, this is likely going to be able to be standardised when distributed tracing comes along (https://github.com/apple/swift-distributed-tracing) but this provides us with this information until then.

Example log message this allows to be emitted by smoke-framework: 

```
Request completed in 17 milliseconds; 8 milliseconds excluding service calls (there was 1). 0 outward service calls were retried. 
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
