### PR TITLE
Add initial async/await support.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,13 @@ matrix:
       services: docker
       env: DOCKER_IMAGE_TAG=swiftlang/swift:nightly-5.4-amazonlinux2 ONLY_RUN_SWIFT_LINT=no USE_APT_GET=no
 
+    # Verify against nightly of Swift mainline
+    - os: linux
+      dist: xenial
+      sudo: required
+      services: docker
+      env: DOCKER_IMAGE_TAG=swiftlang/swift:nightly-amazonlinux2 ONLY_RUN_SWIFT_LINT=no USE_APT_GET=no
+
     # Use a docker image that contains the SwiftLint executable the verify the code against the linter.
     - os: linux
       dist: xenial

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/swift-server/async-http-client.git",
         "state": {
           "branch": null,
-          "revision": "a72c5adce3986ff6b5092ae0464a8f2675087860",
-          "version": "1.2.3"
+          "revision": "0dda95cffcdf3d96ca551e5701efd1661cf31374",
+          "version": "1.2.5"
         }
       },
       {
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/apple/swift-log.git",
         "state": {
           "branch": null,
-          "revision": "12d3a8651d32295794a850307f77407f95b8c881",
-          "version": "1.4.1"
+          "revision": "5d66f7ba25daf4f94100e7022febf3c75e37a6c7",
+          "version": "1.4.2"
         }
       },
       {
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio.git",
         "state": {
           "branch": null,
-          "revision": "6d3ca7e54e06a69d0f2612c2ce8bb8b7319085a4",
-          "version": "2.26.0"
+          "revision": "3be4e0980075de10a4bc8dee07491d49175cfd7a",
+          "version": "2.27.0"
         }
       },
       {
@@ -51,8 +51,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio-ssl.git",
         "state": {
           "branch": null,
-          "revision": "4c933e955b8797f5a5a90bd2a0fb411fdb11bb94",
-          "version": "2.10.3"
+          "revision": "07c160b8724ee53a4b776328122be6338ff12bf2",
+          "version": "2.11.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -22,6 +22,9 @@ let package = Package(
             name: "SmokeHTTPClient",
             targets: ["SmokeHTTPClient"]),
         .library(
+            name: "_SmokeHTTPClientConcurrency",
+            targets: ["_SmokeHTTPClientConcurrency"]),
+        .library(
             name: "QueryCoding",
             targets: ["QueryCoding"]),
         .library(
@@ -51,6 +54,10 @@ let package = Package(
                 .product(name: "NIOFoundationCompat", package: "swift-nio"),
                 .product(name: "NIOSSL", package: "swift-nio-ssl"),
                 .product(name: "AsyncHTTPClient", package: "async-http-client"),
+            ]),
+        .target(
+            name: "_SmokeHTTPClientConcurrency", dependencies: [
+                .target(name: "SmokeHTTPClient"),
             ]),
         .target(
             name: "QueryCoding", dependencies: [

--- a/Sources/_SmokeHTTPClientConcurrency/HTTPOperationsClient+executeRetriableWithOutput.swift
+++ b/Sources/_SmokeHTTPClientConcurrency/HTTPOperationsClient+executeRetriableWithOutput.swift
@@ -1,0 +1,61 @@
+// Copyright 2018-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+//  HTTPOperationsClient+executeRetriableWithOutput.swift
+//  _SmokeHTTPClientConcurrency
+//
+
+#if compiler(>=5.4) && $AsyncAwait
+
+import Foundation
+import NIO
+import NIOHTTP1
+import SmokeHTTPClient
+
+public extension HTTPOperationsClient {
+    
+    /**
+     Submits a request that will return a response body to this client asynchronously.
+
+     - Parameters:
+        - endpointPath: The endpoint path for this request.
+        - httpMethod: The http method to use for this request.
+        - input: the input body data to send with this request.
+        - invocationContext: context to use for this invocation.
+        - retryConfiguration: the retry configuration for this request.
+        - retryOnError: function that should return if the provided error is retryable.
+     - Returns: the response body.
+     - Throws: If an error occurred during the request.
+     */
+    func executeRetriableWithOutput<InputType, OutputType,
+            InvocationReportingType: HTTPClientInvocationReporting, HandlerDelegateType: HTTPClientInvocationDelegate>(
+        endpointOverride: URL? = nil,
+        endpointPath: String,
+        httpMethod: HTTPMethod,
+        input: InputType,
+        invocationContext: HTTPClientInvocationContext<InvocationReportingType, HandlerDelegateType>,
+        retryConfiguration: HTTPClientRetryConfiguration,
+        retryOnError: @escaping (HTTPClientError) -> Bool) async throws -> OutputType
+    where InputType: HTTPRequestInputProtocol, OutputType: HTTPResponseOutputProtocol {
+        return try await executeAsEventLoopFutureRetriableWithOutput(
+            endpointOverride: endpointOverride,
+            endpointPath: endpointPath,
+            httpMethod: httpMethod,
+            input: input,
+            invocationContext: invocationContext,
+            retryConfiguration: retryConfiguration,
+            retryOnError: retryOnError).get()
+    }
+}
+
+#endif

--- a/Sources/_SmokeHTTPClientConcurrency/HTTPOperationsClient+executeRetriableWithoutOutput.swift
+++ b/Sources/_SmokeHTTPClientConcurrency/HTTPOperationsClient+executeRetriableWithoutOutput.swift
@@ -1,0 +1,60 @@
+// Copyright 2018-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+//  HTTPOperationsClient+executeRetriableWithoutOutput.swift
+//  _SmokeHTTPClientConcurrency
+//
+
+#if compiler(>=5.4) && $AsyncAwait
+
+import Foundation
+import NIO
+import NIOHTTP1
+import SmokeHTTPClient
+
+public extension HTTPOperationsClient {
+    
+    /**
+     Submits a request that will not return a response body to this client asynchronously.
+
+     - Parameters:
+        - endpointPath: The endpoint path for this request.
+        - httpMethod: The http method to use for this request.
+        - input: the input body data to send with this request.
+        - invocationContext: context to use for this invocation.
+        - retryConfiguration: the retry configuration for this request.
+        - retryOnError: function that should return if the provided error is retryable.
+     - Throws: If an error occurred during the request.
+     */
+    func executeRetriableWithoutOutput<InputType,
+            InvocationReportingType: HTTPClientInvocationReporting, HandlerDelegateType: HTTPClientInvocationDelegate>(
+        endpointOverride: URL? = nil,
+        endpointPath: String,
+        httpMethod: HTTPMethod,
+        input: InputType,
+        invocationContext: HTTPClientInvocationContext<InvocationReportingType, HandlerDelegateType>,
+        retryConfiguration: HTTPClientRetryConfiguration,
+        retryOnError: @escaping (HTTPClientError) -> Bool) async throws
+    where InputType: HTTPRequestInputProtocol {
+        return try await executeAsEventLoopFutureRetriableWithoutOutput(
+            endpointOverride: endpointOverride,
+            endpointPath: endpointPath,
+            httpMethod: httpMethod,
+            input: input,
+            invocationContext: invocationContext,
+            retryConfiguration: retryConfiguration,
+            retryOnError: retryOnError).get()
+    }
+}
+
+#endif

--- a/Sources/_SmokeHTTPClientConcurrency/HTTPOperationsClient+executeWithOutput.swift
+++ b/Sources/_SmokeHTTPClientConcurrency/HTTPOperationsClient+executeWithOutput.swift
@@ -11,7 +11,7 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 //
-//  HTTPOperationsClient+executeAsEventLoopFutureWithOutput.swift
+//  HTTPOperationsClient+executeWithOutput.swift
 //  _SmokeHTTPClientConcurrency
 //
 
@@ -36,7 +36,7 @@ public extension HTTPOperationsClient {
      - Returns: the response body.
      - Throws: If an error occurred during the request.
      */
-    func executeAsEventLoopFutureWithOutput<InputType, OutputType,
+    func executeWithOutput<InputType, OutputType,
             InvocationReportingType: HTTPClientInvocationReporting, HandlerDelegateType: HTTPClientInvocationDelegate>(
         endpointOverride: URL? = nil,
         endpointPath: String,

--- a/Sources/_SmokeHTTPClientConcurrency/HTTPOperationsClient+executeWithOutput.swift
+++ b/Sources/_SmokeHTTPClientConcurrency/HTTPOperationsClient+executeWithOutput.swift
@@ -1,0 +1,56 @@
+// Copyright 2018-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+//  HTTPOperationsClient+executeAsEventLoopFutureWithOutput.swift
+//  _SmokeHTTPClientConcurrency
+//
+
+#if compiler(>=5.4) && $AsyncAwait
+
+import Foundation
+import NIO
+import NIOHTTP1
+import SmokeHTTPClient
+
+public extension HTTPOperationsClient {
+    
+    /**
+     Submits a request that will return a response body to this client asynchronously.
+
+     - Parameters:
+         - endpointPath: The endpoint path for this request.
+         - httpMethod: The http method to use for this request.
+         - input: the input body data to send with this request.
+         - completion: Completion handler called with the response body or any error.
+         - invocationContext: context to use for this invocation.
+     - Returns: the response body.
+     - Throws: If an error occurred during the request.
+     */
+    func executeAsEventLoopFutureWithOutput<InputType, OutputType,
+            InvocationReportingType: HTTPClientInvocationReporting, HandlerDelegateType: HTTPClientInvocationDelegate>(
+        endpointOverride: URL? = nil,
+        endpointPath: String,
+        httpMethod: HTTPMethod,
+        input: InputType,
+        invocationContext: HTTPClientInvocationContext<InvocationReportingType, HandlerDelegateType>) async throws -> OutputType
+    where InputType: HTTPRequestInputProtocol, OutputType: HTTPResponseOutputProtocol {
+        return try await executeAsEventLoopFutureWithOutput(
+            endpointOverride: endpointOverride,
+            endpointPath: endpointPath,
+            httpMethod: httpMethod,
+            input: input,
+            invocationContext: invocationContext).get()
+    }
+}
+
+#endif

--- a/Sources/_SmokeHTTPClientConcurrency/HTTPOperationsClient+executeWithoutOutput.swift
+++ b/Sources/_SmokeHTTPClientConcurrency/HTTPOperationsClient+executeWithoutOutput.swift
@@ -1,0 +1,77 @@
+// Copyright 2018-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+//  HTTPOperationsClient+executeWithoutOutput.swift
+//  _SmokeHTTPClientConcurrency
+//
+
+#if compiler(>=5.4) && $AsyncAwait
+
+import Foundation
+import NIO
+import NIOHTTP1
+import SmokeHTTPClient
+import _Concurrency
+
+// TODO: Remove this when provided by swift-nio itself
+extension EventLoopFuture {
+    /// Get the value/error from an `EventLoopFuture` in an `async` context.
+    ///
+    /// This function can be used to bridge an `EventLoopFuture` into the `async` world. Ie. if you're in an `async`
+    /// function and want to get the result of this future.
+    public func get() async throws -> Value {
+        return try await withUnsafeThrowingContinuation { cont in
+            self.whenComplete { result in
+                switch result {
+                case .success(let value):
+                    cont.resume(returning: value)
+                case .failure(let error):
+                    cont.resume(throwing: error)
+                }
+            }
+        }
+    }
+}
+
+public extension HTTPOperationsClient {
+    
+    /**
+     Submits a request that will not return a response body to this client asynchronously.
+     
+     - Parameters:
+        - endpointPath: The endpoint path for this request.
+        - httpMethod: The http method to use for this request.
+        - input: the input body data to send with this request.
+        - completion: Completion handler called with an error if one occurs or nil otherwise.
+        - asyncResponseInvocationStrategy: The invocation strategy for the response from this request.
+        - invocationContext: context to use for this invocation.
+     - Throws: If an error occurred during the request.
+     */
+    func executeWithoutOutput<InputType,
+            InvocationReportingType: HTTPClientInvocationReporting, HandlerDelegateType: HTTPClientInvocationDelegate>(
+        endpointOverride: URL? = nil,
+        endpointPath: String,
+        httpMethod: HTTPMethod,
+        input: InputType,
+        invocationContext: HTTPClientInvocationContext<InvocationReportingType, HandlerDelegateType>) async throws
+    where InputType: HTTPRequestInputProtocol {
+        return try await executeAsEventLoopFutureWithoutOutput(
+            endpointOverride: endpointOverride,
+            endpointPath: endpointPath,
+            httpMethod: httpMethod,
+            input: input,
+            invocationContext: invocationContext).get()
+    }
+}
+
+#endif


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Add initial async/await support.
1. Following the approach of swift-nio, add these to an underscored package.
2. Front the existing `executeAsEventLoopFuture*` functions.
3. Copies the `EventLoopFuture` async bridge from swift-nio until it is available in a tagged release.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.