### PR TITLE
Delegate to base initializer in the MockCoreInvocationReporting initializer.

### DIFF
--- a/Sources/SmokeHTTPClient/MockCoreInvocationReporting.swift
+++ b/Sources/SmokeHTTPClient/MockCoreInvocationReporting.swift
@@ -27,9 +27,9 @@ public extension MockCoreInvocationReporting {
     init(
             logger: Logger = Logger(label: "com.amazon.SmokeHTTPClient.MockCoreInvocationReporting"),
             internalRequestId: String = "internalRequestId") {
-        self.logger = logger
-        self.internalRequestId = internalRequestId
-        self.traceContext = MockInvocationTraceContext()
+        self.init(logger: logger,
+                  internalRequestId: internalRequestId,
+                  traceContext: MockInvocationTraceContext())
     }
 }
  


### PR DESCRIPTION

*Issue #, if available:* #83

*Description of changes:* Delegate to the StandardHTTPClientCoreInvocationReporting initializer in the MockCoreInvocationReporting initializer. Avoids having to duplicate default-value logic between the two initializers.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
