### PR TITLE
Fix compilation under 5.5 and Apple platforms.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,12 +34,12 @@ matrix:
       services: docker
       env: DOCKER_IMAGE_TAG=swift:5.2.5-bionic ONLY_RUN_SWIFT_LINT=no USE_APT_GET=yes
 
-    # Verify against nightly of Swift mainline
+    # Verify next version of Swift (5.5)
     - os: linux
       dist: bionic
       sudo: required
       services: docker
-      env: DOCKER_IMAGE_TAG=swiftlang/swift:nightly-amazonlinux2 ONLY_RUN_SWIFT_LINT=no USE_APT_GET=no
+      env: DOCKER_IMAGE_TAG=swiftlang/swift:nightly-5.5-amazonlinux2 ONLY_RUN_SWIFT_LINT=no USE_APT_GET=no
 
     # Use a docker image that contains the SwiftLint executable the verify the code against the linter.
     - os: linux

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/swift-server/async-http-client.git",
         "state": {
           "branch": null,
-          "revision": "0dda95cffcdf3d96ca551e5701efd1661cf31374",
-          "version": "1.2.5"
+          "revision": "8ccba7328d178ac05a1a9803cf3f2c6660d2f826",
+          "version": "1.3.0"
         }
       },
       {
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio.git",
         "state": {
           "branch": null,
-          "revision": "21782f3bdc9581148d38d0ccaab6ec952ccda56b",
-          "version": "2.28.0"
+          "revision": "d161bf658780b209c185994528e7e24376cf7283",
+          "version": "2.29.0"
         }
       },
       {
@@ -51,8 +51,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio-ssl.git",
         "state": {
           "branch": null,
-          "revision": "07c160b8724ee53a4b776328122be6338ff12bf2",
-          "version": "2.11.0"
+          "revision": "6363cdf6d2fb863e82434f3c4618f4e896e37569",
+          "version": "2.13.1"
         }
       },
       {
@@ -60,8 +60,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio-transport-services.git",
         "state": {
           "branch": null,
-          "revision": "1d28d48e071727f4558a8a4bb1894472abc47a58",
-          "version": "1.9.2"
+          "revision": "657537c2cf1845f8d5201ecc4e48f21f21841128",
+          "version": "1.10.0"
         }
       }
     ]

--- a/Sources/_SmokeHTTPClientConcurrency/HTTPOperationsClient+executeRetriableWithOutput.swift
+++ b/Sources/_SmokeHTTPClientConcurrency/HTTPOperationsClient+executeRetriableWithOutput.swift
@@ -38,6 +38,7 @@ public extension HTTPOperationsClient {
      - Returns: the response body.
      - Throws: If an error occurred during the request.
      */
+    @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
     func executeRetriableWithOutput<InputType, OutputType,
             InvocationReportingType: HTTPClientInvocationReporting, HandlerDelegateType: HTTPClientInvocationDelegate>(
         endpointOverride: URL? = nil,

--- a/Sources/_SmokeHTTPClientConcurrency/HTTPOperationsClient+executeRetriableWithoutOutput.swift
+++ b/Sources/_SmokeHTTPClientConcurrency/HTTPOperationsClient+executeRetriableWithoutOutput.swift
@@ -37,6 +37,7 @@ public extension HTTPOperationsClient {
         - retryOnError: function that should return if the provided error is retryable.
      - Throws: If an error occurred during the request.
      */
+    @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
     func executeRetriableWithoutOutput<InputType,
             InvocationReportingType: HTTPClientInvocationReporting, HandlerDelegateType: HTTPClientInvocationDelegate>(
         endpointOverride: URL? = nil,

--- a/Sources/_SmokeHTTPClientConcurrency/HTTPOperationsClient+executeWithOutput.swift
+++ b/Sources/_SmokeHTTPClientConcurrency/HTTPOperationsClient+executeWithOutput.swift
@@ -37,6 +37,7 @@ public extension HTTPOperationsClient {
      - Returns: the response body.
      - Throws: If an error occurred during the request.
      */
+    @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
     func executeWithOutput<InputType, OutputType,
             InvocationReportingType: HTTPClientInvocationReporting, HandlerDelegateType: HTTPClientInvocationDelegate>(
         endpointOverride: URL? = nil,

--- a/Sources/_SmokeHTTPClientConcurrency/HTTPOperationsClient+executeWithoutOutput.swift
+++ b/Sources/_SmokeHTTPClientConcurrency/HTTPOperationsClient+executeWithoutOutput.swift
@@ -37,6 +37,7 @@ public extension HTTPOperationsClient {
         - invocationContext: context to use for this invocation.
      - Throws: If an error occurred during the request.
      */
+    @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
     func executeWithoutOutput<InputType,
             InvocationReportingType: HTTPClientInvocationReporting, HandlerDelegateType: HTTPClientInvocationDelegate>(
         endpointOverride: URL? = nil,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Fix compilation under 5.5 and Apple platforms.
Added `@available` annotation as required for swift-nio experimental API[1]

[1] https://github.com/apple/swift-nio/blob/main/Sources/_NIOConcurrency/AsyncAwaitSupport.swift#L21


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
