### PR TITLE
Update async/await api availablity on Apple platforms inline with Swi…

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio.git",
         "state": {
           "branch": null,
-          "revision": "d161bf658780b209c185994528e7e24376cf7283",
-          "version": "2.29.0"
+          "revision": "d79e33308b0ac83326b0ead0ea6446e604b8162d",
+          "version": "2.30.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -38,7 +38,7 @@ let package = Package(
             targets: ["ShapeCoding"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-nio.git", from: "2.28.0"),
+        .package(url: "https://github.com/apple/swift-nio.git", from: "2.30.0"),
         .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.0.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-metrics.git", "1.0.0"..<"3.0.0"),

--- a/Sources/_SmokeHTTPClientConcurrency/HTTPOperationsClient+executeRetriableWithOutput.swift
+++ b/Sources/_SmokeHTTPClientConcurrency/HTTPOperationsClient+executeRetriableWithOutput.swift
@@ -15,7 +15,7 @@
 //  _SmokeHTTPClientConcurrency
 //
 
-#if compiler(>=5.5) && $AsyncAwait
+#if compiler(>=5.5)
 
 import Foundation
 import NIO
@@ -38,7 +38,7 @@ public extension HTTPOperationsClient {
      - Returns: the response body.
      - Throws: If an error occurred during the request.
      */
-    @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func executeRetriableWithOutput<InputType, OutputType,
             InvocationReportingType: HTTPClientInvocationReporting, HandlerDelegateType: HTTPClientInvocationDelegate>(
         endpointOverride: URL? = nil,

--- a/Sources/_SmokeHTTPClientConcurrency/HTTPOperationsClient+executeRetriableWithoutOutput.swift
+++ b/Sources/_SmokeHTTPClientConcurrency/HTTPOperationsClient+executeRetriableWithoutOutput.swift
@@ -15,7 +15,7 @@
 //  _SmokeHTTPClientConcurrency
 //
 
-#if compiler(>=5.5) && $AsyncAwait
+#if compiler(>=5.5)
 
 import Foundation
 import NIO
@@ -37,7 +37,7 @@ public extension HTTPOperationsClient {
         - retryOnError: function that should return if the provided error is retryable.
      - Throws: If an error occurred during the request.
      */
-    @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func executeRetriableWithoutOutput<InputType,
             InvocationReportingType: HTTPClientInvocationReporting, HandlerDelegateType: HTTPClientInvocationDelegate>(
         endpointOverride: URL? = nil,

--- a/Sources/_SmokeHTTPClientConcurrency/HTTPOperationsClient+executeWithOutput.swift
+++ b/Sources/_SmokeHTTPClientConcurrency/HTTPOperationsClient+executeWithOutput.swift
@@ -15,7 +15,7 @@
 //  _SmokeHTTPClientConcurrency
 //
 
-#if compiler(>=5.5) && $AsyncAwait
+#if compiler(>=5.5)
 
 import Foundation
 import NIO
@@ -37,7 +37,7 @@ public extension HTTPOperationsClient {
      - Returns: the response body.
      - Throws: If an error occurred during the request.
      */
-    @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func executeWithOutput<InputType, OutputType,
             InvocationReportingType: HTTPClientInvocationReporting, HandlerDelegateType: HTTPClientInvocationDelegate>(
         endpointOverride: URL? = nil,

--- a/Sources/_SmokeHTTPClientConcurrency/HTTPOperationsClient+executeWithoutOutput.swift
+++ b/Sources/_SmokeHTTPClientConcurrency/HTTPOperationsClient+executeWithoutOutput.swift
@@ -15,7 +15,7 @@
 //  _SmokeHTTPClientConcurrency
 //
 
-#if compiler(>=5.5) && $AsyncAwait
+#if compiler(>=5.5)
 
 import Foundation
 import NIO
@@ -37,7 +37,7 @@ public extension HTTPOperationsClient {
         - invocationContext: context to use for this invocation.
      - Throws: If an error occurred during the request.
      */
-    @available(macOS 9999, iOS 9999, watchOS 9999, tvOS 9999, *)
+    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func executeWithoutOutput<InputType,
             InvocationReportingType: HTTPClientInvocationReporting, HandlerDelegateType: HTTPClientInvocationDelegate>(
         endpointOverride: URL? = nil,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Update async/await api availability on Apple platforms inline with SwiftNIO.-
https://github.com/apple/swift-nio/blob/main/Sources/_NIOConcurrency/AsyncAwaitSupport.swift


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
