### PR TITLE
Make connectTimeout and tlsHandshakeTimeout retriable errors

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/swift-server/async-http-client.git",
         "state": {
           "branch": null,
-          "revision": "8ccba7328d178ac05a1a9803cf3f2c6660d2f826",
-          "version": "1.3.0"
+          "revision": "8e4d51908dd49272667126403bf977c5c503f78f",
+          "version": "1.5.0"
         }
       },
       {
@@ -42,8 +42,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio-extras.git",
         "state": {
           "branch": null,
-          "revision": "de1c80ad1fdff1ba772bcef6b392c3ef735f39a6",
-          "version": "1.8.0"
+          "revision": "f72c4688f89c28502105509186eadc49a49cb922",
+          "version": "1.10.0"
         }
       },
       {
@@ -51,8 +51,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio-ssl.git",
         "state": {
           "branch": null,
-          "revision": "6363cdf6d2fb863e82434f3c4618f4e896e37569",
-          "version": "2.13.1"
+          "revision": "9db7cee4b62c39160a6bd513a47a1ecdcceac18a",
+          "version": "2.14.0"
         }
       },
       {
@@ -60,8 +60,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio-transport-services.git",
         "state": {
           "branch": null,
-          "revision": "657537c2cf1845f8d5201ecc4e48f21f21841128",
-          "version": "1.10.0"
+          "revision": "39587bceccda72780e2a8a8c5e857e42a9df2fa8",
+          "version": "1.11.0"
         }
       }
     ]

--- a/Sources/SmokeHTTPClient/HTTPClientDelegate.swift
+++ b/Sources/SmokeHTTPClient/HTTPClientDelegate.swift
@@ -73,7 +73,10 @@ public extension HTTPClientDelegate {
         #else
         let certificateVerification = CertificateVerification.fullVerification
         #endif
+        
+        var tlsConfiguration = TLSConfiguration.makeClientConfiguration()
+        tlsConfiguration.certificateVerification = certificateVerification
 
-        return TLSConfiguration.forClient(certificateVerification: certificateVerification)
+        return tlsConfiguration
     }
 }

--- a/Sources/SmokeHTTPClient/HTTPOperationsClient.swift
+++ b/Sources/SmokeHTTPClient/HTTPOperationsClient.swift
@@ -354,6 +354,8 @@ public struct HTTPOperationsClient {
     private func isRetriableHTTPClientError(clientError: AsyncHTTPClient.HTTPClientError) -> Bool {
         // special case a read timeout and remote connection closed errors to a 500 to allow for retries
         if clientError == AsyncHTTPClient.HTTPClientError.readTimeout
+                || clientError == AsyncHTTPClient.HTTPClientError.connectTimeout
+                || clientError == AsyncHTTPClient.HTTPClientError.tlsHandshakeTimeout
                 || clientError == AsyncHTTPClient.HTTPClientError.remoteConnectionClosed {
             return true
         }

--- a/Sources/SmokeHTTPClient/HTTPOperationsClient.swift
+++ b/Sources/SmokeHTTPClient/HTTPOperationsClient.swift
@@ -352,7 +352,8 @@ public struct HTTPOperationsClient {
     }
     
     private func isRetriableHTTPClientError(clientError: AsyncHTTPClient.HTTPClientError) -> Bool {
-        // special case a read timeout and remote connection closed errors to a 500 to allow for retries
+        // special case read, connect or tls handshake timeouts and remote connection closed errors
+        // to a 500 error to allow for retries
         if clientError == AsyncHTTPClient.HTTPClientError.readTimeout
                 || clientError == AsyncHTTPClient.HTTPClientError.connectTimeout
                 || clientError == AsyncHTTPClient.HTTPClientError.tlsHandshakeTimeout


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* 
1. Remove use of deprecated swift-nio API. Walked through the swift-nio code to ensure this code path is equivalent. 
2. Make HTTPClientError.connectTimeout and HTTPClientError.tlsHandshakeTimeout retriable errors


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
