### PR TITLE
Don't double wrap errors.

### DIFF
--- a/Sources/SmokeHTTPClient/HTTPOperationsClient.swift
+++ b/Sources/SmokeHTTPClient/HTTPOperationsClient.swift
@@ -158,6 +158,12 @@ public struct HTTPOperationsClient {
                                                                           outwardsRequestContext: outwardsRequestContext,
                                                                           result: .success(successResult))
             } .flatMapErrorThrowing { error in
+                // if this error has been thrown from just above
+                if let typedError = error as? SmokeHTTPClient.HTTPClientError {
+                    // just rethrow the error
+                    throw typedError
+                }
+                
                 // a response wasn't even able to be generated (for example due to a connection error)
                 // make sure this error is thrown correctly as a SmokeHTTPClient.HTTPClientError
                 return try self.handleCompleteResponseThrowingClientError(invocationContext: invocationContext,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Don't double wrap errors. If an error from created from the http response, it would be wrapped in the appropriate SmokeHTTPClient.HTTPClientError by the `flatMapThrowing` handler (which is desired and was happening previously to #89) and then wrapped in a 500 SmokeHTTPClient.HTTPClientError by the `flatMapErrorThrowing` handler (which didn't happen previously to #89). This change avoid the second wrapping.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
