### PR TITLE
Final async await support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,22 +5,28 @@ matrix:
       dist: bionic
       sudo: required
       services: docker
-      env: DOCKER_IMAGE_TAG=swift:5.4.0-bionic ONLY_RUN_SWIFT_LINT=no USE_APT_GET=yes
+      env: DOCKER_IMAGE_TAG=swift:5.5.0-bionic ONLY_RUN_SWIFT_LINT=no USE_APT_GET=yes
     - os: linux
       dist: bionic
       sudo: required
       services: docker
-      env: DOCKER_IMAGE_TAG=swift:5.4.0-focal ONLY_RUN_SWIFT_LINT=no USE_APT_GET=yes
+      env: DOCKER_IMAGE_TAG=swift:5.5.0-focal ONLY_RUN_SWIFT_LINT=no USE_APT_GET=yes
     - os: linux
       dist: bionic
       sudo: required
       services: docker
-      env: DOCKER_IMAGE_TAG=swift:5.4.0-amazonlinux2 ONLY_RUN_SWIFT_LINT=no USE_APT_GET=no
+      env: DOCKER_IMAGE_TAG=swift:5.5.0-amazonlinux2 ONLY_RUN_SWIFT_LINT=no USE_APT_GET=no
     - os: linux
       dist: bionic
       sudo: required
       services: docker
-      env: DOCKER_IMAGE_TAG=swift:5.4.0-centos8 ONLY_RUN_SWIFT_LINT=no USE_APT_GET=no
+      env: DOCKER_IMAGE_TAG=swift:5.5.0-centos8 ONLY_RUN_SWIFT_LINT=no USE_APT_GET=no
+
+    - os: linux
+      dist: bionic
+      sudo: required
+      services: docker
+      env: DOCKER_IMAGE_TAG=swift:5.4.3-amazonlinux2 ONLY_RUN_SWIFT_LINT=no USE_APT_GET=no
       
     - os: linux
       dist: bionic
@@ -33,13 +39,6 @@ matrix:
       sudo: required
       services: docker
       env: DOCKER_IMAGE_TAG=swift:5.2.5-bionic ONLY_RUN_SWIFT_LINT=no USE_APT_GET=yes
-
-    # Verify next version of Swift (5.5)
-    - os: linux
-      dist: bionic
-      sudo: required
-      services: docker
-      env: DOCKER_IMAGE_TAG=swiftlang/swift:nightly-5.5-amazonlinux2 ONLY_RUN_SWIFT_LINT=no USE_APT_GET=no
 
     # Use a docker image that contains the SwiftLint executable the verify the code against the linter.
     - os: linux

--- a/Package.resolved
+++ b/Package.resolved
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio.git",
         "state": {
           "branch": null,
-          "revision": "fb48bdd8279799f655da5f8b4e0a21430eca6012",
-          "version": "2.32.3"
+          "revision": "6aa9347d9bc5bbfe6a84983aec955c17ffea96ef",
+          "version": "2.33.0"
         }
       },
       {

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/swift-server/async-http-client.git",
         "state": {
           "branch": null,
-          "revision": "8e4d51908dd49272667126403bf977c5c503f78f",
-          "version": "1.5.0"
+          "revision": "8fa7f082b155ea325bcf7b2dbffaf81d4eea1ae4",
+          "version": "1.5.1"
         }
       },
       {
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/apple/swift-metrics.git",
         "state": {
           "branch": null,
-          "revision": "e382458581b05839a571c578e90060fff499f101",
-          "version": "2.1.1"
+          "revision": "3edd2f57afc4e68e23c3e4956bc8b65ca6b5b2ff",
+          "version": "2.2.0"
         }
       },
       {
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio.git",
         "state": {
           "branch": null,
-          "revision": "d79e33308b0ac83326b0ead0ea6446e604b8162d",
-          "version": "2.30.0"
+          "revision": "fb48bdd8279799f655da5f8b4e0a21430eca6012",
+          "version": "2.32.3"
         }
       },
       {
@@ -42,8 +42,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio-extras.git",
         "state": {
           "branch": null,
-          "revision": "f72c4688f89c28502105509186eadc49a49cb922",
-          "version": "1.10.0"
+          "revision": "f73ca5ee9c6806800243f1ac415fcf82de9a4c91",
+          "version": "1.10.2"
         }
       },
       {
@@ -51,8 +51,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio-ssl.git",
         "state": {
           "branch": null,
-          "revision": "9db7cee4b62c39160a6bd513a47a1ecdcceac18a",
-          "version": "2.14.0"
+          "revision": "044f90dfa0a7015446b40f5e578b06343ae1affe",
+          "version": "2.16.0"
         }
       },
       {
@@ -60,8 +60,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio-transport-services.git",
         "state": {
           "branch": null,
-          "revision": "39587bceccda72780e2a8a8c5e857e42a9df2fa8",
-          "version": "1.11.0"
+          "revision": "e7f5278a26442dc46783ba7e063643d524e414a0",
+          "version": "1.11.3"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -15,6 +15,21 @@
 
 import PackageDescription
 
+var smokeHttpClientDependencies: [Target.Dependency] = [
+    .product(name: "Logging", package: "swift-log"),
+    .product(name: "Metrics", package: "swift-metrics"),
+    .product(name: "NIO", package: "swift-nio"),
+    .product(name: "NIOHTTP1", package: "swift-nio"),
+    .product(name: "NIOFoundationCompat", package: "swift-nio"),
+    .product(name: "NIOSSL", package: "swift-nio-ssl"),
+    .product(name: "AsyncHTTPClient", package: "async-http-client"),
+]
+
+#if compiler(>=5.5) && canImport(_Concurrency)
+// required for concurrency, import only when needed as its not considered a stable package
+smokeHttpClientDependencies.append(.product(name: "_NIOConcurrency", package: "swift-nio"))
+#endif
+
 let package = Package(
     name: "smoke-http",
     products: [
@@ -46,19 +61,10 @@ let package = Package(
     ],
     targets: [
         .target(
-            name: "SmokeHTTPClient", dependencies: [
-                .product(name: "Logging", package: "swift-log"),
-                .product(name: "Metrics", package: "swift-metrics"),
-                .product(name: "NIO", package: "swift-nio"),
-                .product(name: "NIOHTTP1", package: "swift-nio"),
-                .product(name: "NIOFoundationCompat", package: "swift-nio"),
-                .product(name: "NIOSSL", package: "swift-nio-ssl"),
-                .product(name: "AsyncHTTPClient", package: "async-http-client"),
-            ]),
+            name: "SmokeHTTPClient", dependencies: smokeHttpClientDependencies),
         .target(
             name: "_SmokeHTTPClientConcurrency", dependencies: [
                 .target(name: "SmokeHTTPClient"),
-                .product(name: "_NIOConcurrency", package: "swift-nio"),
             ]),
         .target(
             name: "QueryCoding", dependencies: [

--- a/Package.swift
+++ b/Package.swift
@@ -15,21 +15,6 @@
 
 import PackageDescription
 
-var smokeHttpClientDependencies: [Target.Dependency] = [
-    .product(name: "Logging", package: "swift-log"),
-    .product(name: "Metrics", package: "swift-metrics"),
-    .product(name: "NIO", package: "swift-nio"),
-    .product(name: "NIOHTTP1", package: "swift-nio"),
-    .product(name: "NIOFoundationCompat", package: "swift-nio"),
-    .product(name: "NIOSSL", package: "swift-nio-ssl"),
-    .product(name: "AsyncHTTPClient", package: "async-http-client"),
-]
-
-#if compiler(>=5.5) && canImport(_Concurrency)
-// required for concurrency, import only when needed as its not considered a stable package
-smokeHttpClientDependencies.append(.product(name: "_NIOConcurrency", package: "swift-nio"))
-#endif
-
 let package = Package(
     name: "smoke-http",
     products: [
@@ -53,15 +38,23 @@ let package = Package(
             targets: ["ShapeCoding"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-nio.git", from: "2.30.0"),
-        .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.0.0"),
+        .package(url: "https://github.com/apple/swift-nio.git", from: "2.33.0"),
+        .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.14.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-metrics.git", "1.0.0"..<"3.0.0"),
-        .package(url: "https://github.com/swift-server/async-http-client.git", from: "1.0.0")
+        .package(url: "https://github.com/swift-server/async-http-client.git", from: "1.5.1")
     ],
     targets: [
         .target(
-            name: "SmokeHTTPClient", dependencies: smokeHttpClientDependencies),
+            name: "SmokeHTTPClient", dependencies: [
+                .product(name: "Logging", package: "swift-log"),
+                .product(name: "Metrics", package: "swift-metrics"),
+                .product(name: "NIO", package: "swift-nio"),
+                .product(name: "NIOHTTP1", package: "swift-nio"),
+                .product(name: "NIOFoundationCompat", package: "swift-nio"),
+                .product(name: "NIOSSL", package: "swift-nio-ssl"),
+                .product(name: "AsyncHTTPClient", package: "async-http-client"),
+            ]),
         .target(
             name: "_SmokeHTTPClientConcurrency", dependencies: [
                 .target(name: "SmokeHTTPClient"),

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 <img src="https://travis-ci.com/amzn/smoke-http.svg?branch=master" alt="Build - Master Branch">
 </a>
 <a href="http://swift.org">
-<img src="https://img.shields.io/badge/swift-5.2|5.3|5.4-orange.svg?style=flat" alt="Swift 5.2, 5.3 and 5.4 Tested">
+<img src="https://img.shields.io/badge/swift-5.2|5.3|5.4|5.5-orange.svg?style=flat" alt="Swift 5.2, 5.3, 5.4 and 5.5 Tested">
 </a>
 <img src="https://img.shields.io/badge/ubuntu-18.04|20.04-yellow.svg?style=flat" alt="Ubuntu 18.04 and 20.04 Tested">
 <img src="https://img.shields.io/badge/CentOS-8-yellow.svg?style=flat" alt="CentOS 8 Tested">

--- a/Sources/SmokeHTTPClient/HTTPOperationsClient+executeRetriableWithOutput.swift
+++ b/Sources/SmokeHTTPClient/HTTPOperationsClient+executeRetriableWithOutput.swift
@@ -20,7 +20,6 @@
 import Foundation
 import NIO
 import NIOHTTP1
-import SmokeHTTPClient
 import _NIOConcurrency
 
 public extension HTTPOperationsClient {

--- a/Sources/SmokeHTTPClient/HTTPOperationsClient+executeRetriableWithOutput.swift
+++ b/Sources/SmokeHTTPClient/HTTPOperationsClient+executeRetriableWithOutput.swift
@@ -11,11 +11,11 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 //
-//  HTTPOperationsClient+executeRetriableWithoutOutput.swift
-//  _SmokeHTTPClientConcurrency
+//  HTTPOperationsClient+executeRetriableWithOutput.swift
+//  SmokeHTTPClient
 //
 
-#if compiler(>=5.5)
+#if compiler(>=5.5) && canImport(_Concurrency)
 
 import Foundation
 import NIO
@@ -26,7 +26,7 @@ import _NIOConcurrency
 public extension HTTPOperationsClient {
     
     /**
-     Submits a request that will not return a response body to this client asynchronously.
+     Submits a request that will return a response body to this client asynchronously.
 
      - Parameters:
         - endpointPath: The endpoint path for this request.
@@ -35,10 +35,11 @@ public extension HTTPOperationsClient {
         - invocationContext: context to use for this invocation.
         - retryConfiguration: the retry configuration for this request.
         - retryOnError: function that should return if the provided error is retryable.
+     - Returns: the response body.
      - Throws: If an error occurred during the request.
      */
     @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
-    func executeRetriableWithoutOutput<InputType,
+    func executeRetriableWithOutput<InputType, OutputType,
             InvocationReportingType: HTTPClientInvocationReporting, HandlerDelegateType: HTTPClientInvocationDelegate>(
         endpointOverride: URL? = nil,
         endpointPath: String,
@@ -46,9 +47,9 @@ public extension HTTPOperationsClient {
         input: InputType,
         invocationContext: HTTPClientInvocationContext<InvocationReportingType, HandlerDelegateType>,
         retryConfiguration: HTTPClientRetryConfiguration,
-        retryOnError: @escaping (HTTPClientError) -> Bool) async throws
-    where InputType: HTTPRequestInputProtocol {
-        return try await executeAsEventLoopFutureRetriableWithoutOutput(
+        retryOnError: @escaping (HTTPClientError) -> Bool) async throws -> OutputType
+    where InputType: HTTPRequestInputProtocol, OutputType: HTTPResponseOutputProtocol {
+        return try await executeAsEventLoopFutureRetriableWithOutput(
             endpointOverride: endpointOverride,
             endpointPath: endpointPath,
             httpMethod: httpMethod,

--- a/Sources/SmokeHTTPClient/HTTPOperationsClient+executeRetriableWithOutput.swift
+++ b/Sources/SmokeHTTPClient/HTTPOperationsClient+executeRetriableWithOutput.swift
@@ -20,7 +20,6 @@
 import Foundation
 import NIO
 import NIOHTTP1
-import _NIOConcurrency
 
 public extension HTTPOperationsClient {
     

--- a/Sources/SmokeHTTPClient/HTTPOperationsClient+executeRetriableWithoutOutput.swift
+++ b/Sources/SmokeHTTPClient/HTTPOperationsClient+executeRetriableWithoutOutput.swift
@@ -20,7 +20,6 @@
 import Foundation
 import NIO
 import NIOHTTP1
-import SmokeHTTPClient
 import _NIOConcurrency
 
 public extension HTTPOperationsClient {

--- a/Sources/SmokeHTTPClient/HTTPOperationsClient+executeRetriableWithoutOutput.swift
+++ b/Sources/SmokeHTTPClient/HTTPOperationsClient+executeRetriableWithoutOutput.swift
@@ -11,11 +11,11 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 //
-//  HTTPOperationsClient+executeRetriableWithOutput.swift
-//  _SmokeHTTPClientConcurrency
+//  HTTPOperationsClient+executeRetriableWithoutOutput.swift
+//  SmokeHTTPClient
 //
 
-#if compiler(>=5.5)
+#if compiler(>=5.5) && canImport(_Concurrency)
 
 import Foundation
 import NIO
@@ -26,7 +26,7 @@ import _NIOConcurrency
 public extension HTTPOperationsClient {
     
     /**
-     Submits a request that will return a response body to this client asynchronously.
+     Submits a request that will not return a response body to this client asynchronously.
 
      - Parameters:
         - endpointPath: The endpoint path for this request.
@@ -35,11 +35,10 @@ public extension HTTPOperationsClient {
         - invocationContext: context to use for this invocation.
         - retryConfiguration: the retry configuration for this request.
         - retryOnError: function that should return if the provided error is retryable.
-     - Returns: the response body.
      - Throws: If an error occurred during the request.
      */
     @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
-    func executeRetriableWithOutput<InputType, OutputType,
+    func executeRetriableWithoutOutput<InputType,
             InvocationReportingType: HTTPClientInvocationReporting, HandlerDelegateType: HTTPClientInvocationDelegate>(
         endpointOverride: URL? = nil,
         endpointPath: String,
@@ -47,9 +46,9 @@ public extension HTTPOperationsClient {
         input: InputType,
         invocationContext: HTTPClientInvocationContext<InvocationReportingType, HandlerDelegateType>,
         retryConfiguration: HTTPClientRetryConfiguration,
-        retryOnError: @escaping (HTTPClientError) -> Bool) async throws -> OutputType
-    where InputType: HTTPRequestInputProtocol, OutputType: HTTPResponseOutputProtocol {
-        return try await executeAsEventLoopFutureRetriableWithOutput(
+        retryOnError: @escaping (HTTPClientError) -> Bool) async throws
+    where InputType: HTTPRequestInputProtocol {
+        return try await executeAsEventLoopFutureRetriableWithoutOutput(
             endpointOverride: endpointOverride,
             endpointPath: endpointPath,
             httpMethod: httpMethod,

--- a/Sources/SmokeHTTPClient/HTTPOperationsClient+executeRetriableWithoutOutput.swift
+++ b/Sources/SmokeHTTPClient/HTTPOperationsClient+executeRetriableWithoutOutput.swift
@@ -20,7 +20,6 @@
 import Foundation
 import NIO
 import NIOHTTP1
-import _NIOConcurrency
 
 public extension HTTPOperationsClient {
     

--- a/Sources/SmokeHTTPClient/HTTPOperationsClient+executeWithOutput.swift
+++ b/Sources/SmokeHTTPClient/HTTPOperationsClient+executeWithOutput.swift
@@ -20,7 +20,6 @@
 import Foundation
 import NIO
 import NIOHTTP1
-import SmokeHTTPClient
 import _NIOConcurrency
 
 public extension HTTPOperationsClient {

--- a/Sources/SmokeHTTPClient/HTTPOperationsClient+executeWithOutput.swift
+++ b/Sources/SmokeHTTPClient/HTTPOperationsClient+executeWithOutput.swift
@@ -20,7 +20,6 @@
 import Foundation
 import NIO
 import NIOHTTP1
-import _NIOConcurrency
 
 public extension HTTPOperationsClient {
     

--- a/Sources/SmokeHTTPClient/HTTPOperationsClient+executeWithOutput.swift
+++ b/Sources/SmokeHTTPClient/HTTPOperationsClient+executeWithOutput.swift
@@ -12,10 +12,10 @@
 // permissions and limitations under the License.
 //
 //  HTTPOperationsClient+executeWithOutput.swift
-//  _SmokeHTTPClientConcurrency
+//  SmokeHTTPClient
 //
 
-#if compiler(>=5.5)
+#if compiler(>=5.5) && canImport(_Concurrency)
 
 import Foundation
 import NIO

--- a/Sources/SmokeHTTPClient/HTTPOperationsClient+executeWithoutOutput.swift
+++ b/Sources/SmokeHTTPClient/HTTPOperationsClient+executeWithoutOutput.swift
@@ -12,10 +12,10 @@
 // permissions and limitations under the License.
 //
 //  HTTPOperationsClient+executeWithoutOutput.swift
-//  _SmokeHTTPClientConcurrency
+//  SmokeHTTPClient
 //
 
-#if compiler(>=5.5)
+#if compiler(>=5.5) && canImport(_Concurrency)
 
 import Foundation
 import NIO

--- a/Sources/SmokeHTTPClient/HTTPOperationsClient+executeWithoutOutput.swift
+++ b/Sources/SmokeHTTPClient/HTTPOperationsClient+executeWithoutOutput.swift
@@ -20,7 +20,6 @@
 import Foundation
 import NIO
 import NIOHTTP1
-import SmokeHTTPClient
 import _NIOConcurrency
 
 public extension HTTPOperationsClient {

--- a/Sources/SmokeHTTPClient/HTTPOperationsClient+executeWithoutOutput.swift
+++ b/Sources/SmokeHTTPClient/HTTPOperationsClient+executeWithoutOutput.swift
@@ -20,7 +20,6 @@
 import Foundation
 import NIO
 import NIOHTTP1
-import _NIOConcurrency
 
 public extension HTTPOperationsClient {
     

--- a/Sources/_SmokeHTTPClientConcurrency/Export.swift
+++ b/Sources/_SmokeHTTPClientConcurrency/Export.swift
@@ -1,0 +1,19 @@
+// Copyright 2018-2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+//  Export.swift
+//  _SmokeHTTPClientConcurrency
+//
+
+// TODO: https://github.com/amzn/smoke-http/issues/91
+@_exported import SmokeHTTPClient


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
1. Update CI and README for Swift 5.5
2. Move async function APIs into SmokeHTTPClient
3. Re-export SmokeHTTPClient as _SmokeHTTPClientConcurrency to avoid breaking anyone who imported the under-scored package.
4. Update `swift-nio` (also swift-nio-ssl and async-http-client based on advice from @fabianfett) dependency and remove `_NIOConcurrency` imports as they are no longer required.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
