### PR TITLE
Import NIOFoundationCompat where it's used.

### DIFF
--- a/Sources/SmokeHTTPClient/HTTPOperationsClient.swift
+++ b/Sources/SmokeHTTPClient/HTTPOperationsClient.swift
@@ -21,6 +21,7 @@ import NIOHTTP1
 import NIOSSL
 import NIOTLS
 import AsyncHTTPClient
+import NIOFoundationCompat
 import Logging
 
 internal struct HttpHeaderNames {


### PR DESCRIPTION
Issue #, if available: #93

Description of changes: Import NIOFoundationCompat where it's used.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.