### PR TITLE
Remove @available annotation from async APIs.

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04]
-        swift: ["5.4.3", "5.3.3", "5.2.5"]
+        swift: ["5.4.3", "5.3.3"]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: marcprux/setup-swift@a990bc57c514a77d232b645843ade099af21aa5e

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/swift-server/async-http-client.git",
         "state": {
           "branch": null,
-          "revision": "8fa7f082b155ea325bcf7b2dbffaf81d4eea1ae4",
-          "version": "1.5.1"
+          "revision": "1081b0b0541f535ca088acdb56f5ca5598bc6247",
+          "version": "1.6.3"
         }
       },
       {
@@ -47,12 +47,21 @@
         }
       },
       {
+        "package": "swift-nio-http2",
+        "repositoryURL": "https://github.com/apple/swift-nio-http2.git",
+        "state": {
+          "branch": null,
+          "revision": "326f7f9a8c8c8402e3691adac04911cac9f9d87f",
+          "version": "1.18.4"
+        }
+      },
+      {
         "package": "swift-nio-ssl",
         "repositoryURL": "https://github.com/apple/swift-nio-ssl.git",
         "state": {
           "branch": null,
-          "revision": "044f90dfa0a7015446b40f5e578b06343ae1affe",
-          "version": "2.16.0"
+          "revision": "5e68c1ded15619bb281b273fa8c2d8fd7f7b2b7d",
+          "version": "2.16.1"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -17,6 +17,9 @@ import PackageDescription
 
 let package = Package(
     name: "smoke-http",
+    platforms: [
+        .macOS(.v10_15), .iOS(.v13), .tvOS(.v13)
+        ],
     products: [
         .library(
             name: "SmokeHTTPClient",

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 <img src="https://github.com/amzn/smoke-http/actions/workflows/swift.yml/badge.svg?branch=main" alt="Build - Main Branch">
 </a>
 <a href="http://swift.org">
-<img src="https://img.shields.io/badge/swift-5.2|5.3|5.4|5.5-orange.svg?style=flat" alt="Swift 5.2, 5.3, 5.4 and 5.5 Tested">
+<img src="https://img.shields.io/badge/swift-5.3|5.4|5.5-orange.svg?style=flat" alt="Swift 5.3, 5.4 and 5.5 Tested">
 </a>
 <img src="https://img.shields.io/badge/ubuntu-18.04|20.04-yellow.svg?style=flat" alt="Ubuntu 18.04 and 20.04 Tested">
 <img src="https://img.shields.io/badge/CentOS-8-yellow.svg?style=flat" alt="CentOS 8 Tested">

--- a/Sources/SmokeHTTPClient/HTTPClientRetryConfiguration.swift
+++ b/Sources/SmokeHTTPClient/HTTPClientRetryConfiguration.swift
@@ -60,15 +60,7 @@ public struct HTTPClientRetryConfiguration {
         
         if jitter {
             if boundedMsInterval > 0 {
-                #if swift(>=4.2)
-                    return RetryInterval.random(in: 0 ..< boundedMsInterval)
-                #else
-                    #if os(Linux)
-                        return RetryInterval(random() % Int(boundedMsInterval))
-                    #else
-                        return arc4random_uniform(boundedMsInterval)
-                    #endif
-                #endif
+                return RetryInterval.random(in: 0 ..< boundedMsInterval)
             } else {
                 return 0
             }

--- a/Sources/SmokeHTTPClient/HTTPOperationsClient+executeRetriableWithoutOutput.swift
+++ b/Sources/SmokeHTTPClient/HTTPOperationsClient+executeRetriableWithoutOutput.swift
@@ -15,7 +15,7 @@
 //  SmokeHTTPClient
 //
 
-#if compiler(>=5.5) && canImport(_Concurrency)
+#if (os(Linux) && compiler(>=5.5)) || (!os(Linux) && compiler(>=5.5.2)) && canImport(_Concurrency)
 
 import Foundation
 import NIO
@@ -35,7 +35,6 @@ public extension HTTPOperationsClient {
         - retryOnError: function that should return if the provided error is retryable.
      - Throws: If an error occurred during the request.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func executeRetriableWithoutOutput<InputType,
             InvocationReportingType: HTTPClientInvocationReporting, HandlerDelegateType: HTTPClientInvocationDelegate>(
         endpointOverride: URL? = nil,

--- a/Sources/SmokeHTTPClient/HTTPOperationsClient+executeWithOutput.swift
+++ b/Sources/SmokeHTTPClient/HTTPOperationsClient+executeWithOutput.swift
@@ -15,7 +15,7 @@
 //  SmokeHTTPClient
 //
 
-#if compiler(>=5.5) && canImport(_Concurrency)
+#if (os(Linux) && compiler(>=5.5)) || (!os(Linux) && compiler(>=5.5.2)) && canImport(_Concurrency)
 
 import Foundation
 import NIO
@@ -35,7 +35,6 @@ public extension HTTPOperationsClient {
      - Returns: the response body.
      - Throws: If an error occurred during the request.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func executeWithOutput<InputType, OutputType,
             InvocationReportingType: HTTPClientInvocationReporting, HandlerDelegateType: HTTPClientInvocationDelegate>(
         endpointOverride: URL? = nil,

--- a/Sources/SmokeHTTPClient/HTTPOperationsClient+executeWithoutOutput.swift
+++ b/Sources/SmokeHTTPClient/HTTPOperationsClient+executeWithoutOutput.swift
@@ -15,7 +15,7 @@
 //  SmokeHTTPClient
 //
 
-#if compiler(>=5.5) && canImport(_Concurrency)
+#if (os(Linux) && compiler(>=5.5)) || (!os(Linux) && compiler(>=5.5.2)) && canImport(_Concurrency)
 
 import Foundation
 import NIO
@@ -35,7 +35,6 @@ public extension HTTPOperationsClient {
         - invocationContext: context to use for this invocation.
      - Throws: If an error occurred during the request.
      */
-    @available(macOS 12, iOS 15, tvOS 15, watchOS 8, *)
     func executeWithoutOutput<InputType,
             InvocationReportingType: HTTPClientInvocationReporting, HandlerDelegateType: HTTPClientInvocationDelegate>(
         endpointOverride: URL? = nil,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
1. Remove @available annotation from async APIs, increase the requirement for non Linux platforms to the upcoming 5.5.2 (which will backport async support to the earlier Apple OSs).
2. Remove Swift 5.2 from CI checks as it has dropped out of its support window.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
