### PR TITLE
Allow retries on HTTPClientError.getConnectionFromPoolTimeout.

### DIFF
--- a/Sources/SmokeHTTPClient/HTTPOperationsClient.swift
+++ b/Sources/SmokeHTTPClient/HTTPOperationsClient.swift
@@ -383,12 +383,13 @@ public struct HTTPOperationsClient {
     }
     
     private func isRetriableHTTPClientError(clientError: AsyncHTTPClient.HTTPClientError) -> Bool {
-        // special case read, connect or tls handshake timeouts and remote connection closed errors
+        // special case read, connect, connection pool or tls handshake timeouts and remote connection closed errors
         // to a 500 error to allow for retries
         if clientError == AsyncHTTPClient.HTTPClientError.readTimeout
                 || clientError == AsyncHTTPClient.HTTPClientError.connectTimeout
                 || clientError == AsyncHTTPClient.HTTPClientError.tlsHandshakeTimeout
-                || clientError == AsyncHTTPClient.HTTPClientError.remoteConnectionClosed {
+                || clientError == AsyncHTTPClient.HTTPClientError.remoteConnectionClosed
+                || clientError == AsyncHTTPClient.HTTPClientError.getConnectionFromPoolTimeout {
             return true
         }
         


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Allow retries on HTTPClientError.getConnectionFromPoolTimeout.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
