### PR TITLE
Set HTTPClient connect timeout to the same value as read timeout

### DIFF
--- a/Sources/SmokeHTTPClient/HTTPOperationsClient.swift
+++ b/Sources/SmokeHTTPClient/HTTPOperationsClient.swift
@@ -88,7 +88,7 @@ public struct HTTPOperationsClient {
         }
         
         let timeoutValue = TimeAmount.seconds(connectionTimeoutSeconds)
-        let timeout = HTTPClient.Configuration.Timeout(read: timeoutValue)
+        let timeout = HTTPClient.Configuration.Timeout(connect: timeoutValue, read: timeoutValue)
         let connectionPool = connectionPoolConfigurationOptional ?? HTTPClient.Configuration.ConnectionPool()
         
         let clientConfiguration = HTTPClient.Configuration(


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Use the timeout value provided to `HTTPOperationsClient` as both the read timeout and the connect timeout of the wrapped `HTTPClient`. Without this change, the HTTP client uses 10 seconds as the connect timeout. This ensures that client calls will return after at most `timeoutValue` (provided `timeoutValue` is smaller than 10).


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
