### PR TITLE
Extract invocation attributes into separate protocol.

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,17 @@
         "repositoryURL": "https://github.com/swift-server/async-http-client.git",
         "state": {
           "branch": null,
-          "revision": "794dc9d42720af97cedd395e8cd2add9173ffd9a",
-          "version": "1.11.1"
+          "revision": "fc510a39cff61b849bf5cdff17eb2bd6d0777b49",
+          "version": "1.11.5"
+        }
+      },
+      {
+        "package": "swift-atomics",
+        "repositoryURL": "https://github.com/apple/swift-atomics.git",
+        "state": {
+          "branch": null,
+          "revision": "919eb1d83e02121cdb434c7bfc1f0c66ef17febe",
+          "version": "1.0.2"
         }
       },
       {
@@ -15,8 +24,8 @@
         "repositoryURL": "https://github.com/apple/swift-log.git",
         "state": {
           "branch": null,
-          "revision": "5d66f7ba25daf4f94100e7022febf3c75e37a6c7",
-          "version": "1.4.2"
+          "revision": "6fe203dc33195667ce1759bf0182975e4653ba1c",
+          "version": "1.4.4"
         }
       },
       {
@@ -24,8 +33,8 @@
         "repositoryURL": "https://github.com/apple/swift-metrics.git",
         "state": {
           "branch": null,
-          "revision": "1c1408bf8fc21be93713e897d2badf500ea38419",
-          "version": "2.3.1"
+          "revision": "53be78637ecd165d1ddedc4e20de69b8f43ec3b7",
+          "version": "2.3.2"
         }
       },
       {
@@ -33,8 +42,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio.git",
         "state": {
           "branch": null,
-          "revision": "124119f0bb12384cef35aa041d7c3a686108722d",
-          "version": "2.40.0"
+          "revision": "b4e0a274f7f34210e97e2f2c50ab02a10b549250",
+          "version": "2.41.1"
         }
       },
       {
@@ -51,8 +60,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio-http2.git",
         "state": {
           "branch": null,
-          "revision": "108ac15087ea9b79abb6f6742699cf31de0e8772",
-          "version": "1.22.0"
+          "revision": "f9ab1c94c80d568efd762d2a638f25162691d766",
+          "version": "1.22.1"
         }
       },
       {
@@ -60,8 +69,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio-ssl.git",
         "state": {
           "branch": null,
-          "revision": "c30c680c78c99afdabf84805a83c8745387c4ac7",
-          "version": "2.20.2"
+          "revision": "0265283d3539ced108b9b8287eb3328c9d85acdc",
+          "version": "2.21.0"
         }
       },
       {
@@ -69,8 +78,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio-transport-services.git",
         "state": {
           "branch": null,
-          "revision": "2cb54f91ddafc90832c5fa247faf5798d0a7c204",
-          "version": "1.13.0"
+          "revision": "4e02d9cf35cabfb538c96613272fb027dd0c8692",
+          "version": "1.13.1"
         }
       }
     ]

--- a/Sources/SmokeHTTPClient/HTTPClientCoreInvocationReporting.swift
+++ b/Sources/SmokeHTTPClient/HTTPClientCoreInvocationReporting.swift
@@ -77,6 +77,18 @@ public extension OutwardsRequestAggregator {
     }
 }
 
+public protocol HTTPClientInvocationAttributes {
+    /// The `Logging.Logger` to use for logging for this invocation.
+    var logger: Logging.Logger { get }
+
+    /// The internal Request Id associated with this invocation.
+    var internalRequestId: String { get }
+
+    var eventLoop: EventLoop? { get }
+
+    var outwardsRequestAggregator: OutwardsRequestAggregator? { get }
+}
+
 /**
  A context related to reporting on the invocation of the HTTPClient. This represents the
  core requirements for invocation reporting.
@@ -84,21 +96,11 @@ public extension OutwardsRequestAggregator {
  The HTTPClientCoreInvocationReporting protocol can exposed by higher level clients that manage the
  metrics requirements of the HTTPClientInvocationReporting protocol.
  */
-public protocol HTTPClientCoreInvocationReporting {
+public protocol HTTPClientCoreInvocationReporting: HTTPClientInvocationAttributes {
     associatedtype TraceContextType: InvocationTraceContext
-    
-    /// The `Logging.Logger` to use for logging for this invocation.
-    var logger: Logging.Logger { get }
-    
-    /// The internal Request Id associated with this invocation.
-    var internalRequestId: String { get }
     
     /// The trace context associated with this invocation.
     var traceContext: TraceContextType { get }
-    
-    var eventLoop: EventLoop? { get }
-    
-    var outwardsRequestAggregator: OutwardsRequestAggregator? { get }
 }
 
 public extension HTTPClientCoreInvocationReporting {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Extract invocation attributes into separate protocol. Will allow a convenience initializer on clients that accept an instance of this protocol. For example `SmokeServerInvocationReporting` from smoke-framework can be made to conform to this protocol and directly passed to this new convenience initializer.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
