### PR TITLE
Move SmokeAWSClientReportingConfiguration from smoke-aws

### DIFF
--- a/Sources/SmokeHTTPClient/HTTPClientInvocationReporting.swift
+++ b/Sources/SmokeHTTPClient/HTTPClientInvocationReporting.swift
@@ -22,10 +22,9 @@ import Metrics
 private let timeIntervalToMilliseconds: Double = 1000
 
 /**
- A context related to reporting on the invocation of the HTTPClient. This interface extends the
- HTTPClientCoreInvocationReporting protocol by adding metrics emitted by the 
+ A context related to the metrics on the invocation of a SmokeAWS operation.
  */
-public protocol HTTPClientInvocationReporting: HTTPClientCoreInvocationReporting {
+public protocol HTTPClientInvocationMetrics {
     
     /// The `Metrics.Counter` to record the success of this invocation.
     var successCounter: Metrics.Counter? { get }
@@ -42,6 +41,12 @@ public protocol HTTPClientInvocationReporting: HTTPClientCoreInvocationReporting
     /// The `Metrics.Recorder` to record the duration of this invocation.
     var latencyTimer: Metrics.Timer? { get }
 }
+
+/**
+ A context related to reporting on the invocation of the HTTPClient. This interface extends the
+ `HTTPClientCoreInvocationReporting` protocol by adding metrics defined by the `HTTPClientInvocationMetrics` protocol.
+ */
+public typealias HTTPClientInvocationReporting = HTTPClientInvocationMetrics & HTTPClientCoreInvocationReporting
 
 internal extension TimeInterval {
     var milliseconds: Int {

--- a/Sources/SmokeHTTPClient/HTTPClientReportingConfiguration.swift
+++ b/Sources/SmokeHTTPClient/HTTPClientReportingConfiguration.swift
@@ -25,7 +25,7 @@ public struct HTTPClientReportingConfiguration<OperationIdentifer: Hashable> {
         case whitelist(Set<OperationIdentifer>)
         case allowlist(Set<OperationIdentifer>)
         case blacklist(Set<OperationIdentifer>)
-        case restrictlist(Set<OperationIdentifer>)
+        case blocklist(Set<OperationIdentifer>)
         case none
     }
         
@@ -97,8 +97,8 @@ public struct HTTPClientReportingConfiguration<OperationIdentifer: Hashable> {
             return true
         case .whitelist(let allowlist), .allowlist(let allowlist):
             return allowlist.contains(operation)
-        case .blacklist(let restrictlist), .restrictlist(let restrictlist):
-            return !restrictlist.contains(operation)
+        case .blacklist(let blocklist), .blocklist(let blocklist):
+            return !blocklist.contains(operation)
         case .none:
             return false
         }

--- a/Sources/SmokeHTTPClient/HTTPClientReportingConfiguration.swift
+++ b/Sources/SmokeHTTPClient/HTTPClientReportingConfiguration.swift
@@ -1,0 +1,106 @@
+// Copyright 2018-2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+//  HTTPClientReportingConfiguration.swift
+//  SmokeHTTPClient
+//
+
+import Foundation
+
+public struct HTTPClientReportingConfiguration<OperationIdentifer: Hashable> {
+    
+    // TODO: Remove non-inclusive language
+    public enum MatchingOperations {
+        case all
+        case whitelist(Set<OperationIdentifer>)
+        case allowlist(Set<OperationIdentifer>)
+        case blacklist(Set<OperationIdentifer>)
+        case restrictlist(Set<OperationIdentifer>)
+        case none
+    }
+        
+    private let successCounterMatchingOperations: MatchingOperations
+    private let failure5XXCounterMatchingOperations: MatchingOperations
+    private let failure4XXCounterMatchingOperations: MatchingOperations
+    private let retryCountRecorderMatchingOperations: MatchingOperations
+    private let latencyTimerMatchingOperations: MatchingOperations
+    
+    public init(successCounterMatchingOperations: MatchingOperations,
+                failure5XXCounterMatchingOperations: MatchingOperations,
+                failure4XXCounterMatchingOperations: MatchingOperations,
+                retryCountRecorderMatchingOperations: MatchingOperations,
+                latencyTimerMatchingOperations: MatchingOperations) {
+        self.successCounterMatchingOperations = successCounterMatchingOperations
+        self.failure5XXCounterMatchingOperations = failure5XXCounterMatchingOperations
+        self.failure4XXCounterMatchingOperations = failure4XXCounterMatchingOperations
+        self.retryCountRecorderMatchingOperations = retryCountRecorderMatchingOperations
+        self.latencyTimerMatchingOperations = latencyTimerMatchingOperations
+    }
+    
+    public init(matchingOperations: MatchingOperations = .all) {
+        self.successCounterMatchingOperations = matchingOperations
+        self.failure5XXCounterMatchingOperations = matchingOperations
+        self.failure4XXCounterMatchingOperations = matchingOperations
+        self.retryCountRecorderMatchingOperations = matchingOperations
+        self.latencyTimerMatchingOperations = matchingOperations
+    }
+    
+    public static var none: Self {
+        return .init(matchingOperations: .none)
+    }
+    
+    public static var all: Self {
+        return .init(matchingOperations: .all)
+    }
+    
+    public static func onlyForOperations(_ operations: Set<OperationIdentifer>) -> Self {
+        return .init(matchingOperations: .whitelist(operations))
+    }
+
+    public static func exceptForOperations(_ operations: Set<OperationIdentifer>) -> Self {
+        return .init(matchingOperations: .blacklist(operations))
+    }
+    
+    public func reportSuccessForOperation(_ operation: OperationIdentifer) -> Bool {
+        return isMatchingOperation(operation, matchingOperations: successCounterMatchingOperations)
+    }
+    
+    public func reportFailure5XXForOperation(_ operation: OperationIdentifer) -> Bool {
+        return isMatchingOperation(operation, matchingOperations: failure5XXCounterMatchingOperations)
+    }
+    
+    public func reportFailure4XXForOperation(_ operation: OperationIdentifer) -> Bool {
+        return isMatchingOperation(operation, matchingOperations: failure4XXCounterMatchingOperations)
+    }
+    
+    public func reportRetryCountForOperation(_ operation: OperationIdentifer) -> Bool {
+        return isMatchingOperation(operation, matchingOperations: retryCountRecorderMatchingOperations)
+    }
+    
+    public func reportLatencyForOperation(_ operation: OperationIdentifer) -> Bool {
+        return isMatchingOperation(operation, matchingOperations: latencyTimerMatchingOperations)
+    }
+    
+    private func isMatchingOperation(_ operation: OperationIdentifer, matchingOperations: MatchingOperations) -> Bool {
+        switch matchingOperations {
+        case .all:
+            return true
+        case .whitelist(let allowlist), .allowlist(let allowlist):
+            return allowlist.contains(operation)
+        case .blacklist(let restrictlist), .restrictlist(let restrictlist):
+            return !restrictlist.contains(operation)
+        case .none:
+            return false
+        }
+    }
+}


### PR DESCRIPTION

*Issue #, if available:*

*Description of changes:*
Move SmokeAWSClientReportingConfiguration as HTTPClientReportingConfiguration from smoke-aws.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
