### PR TITLE
Retry and decode on Swift Concurrency threads.

### DIFF
--- a/Sources/SmokeHTTPClient/HTTPClientCoreInvocationReporting.swift
+++ b/Sources/SmokeHTTPClient/HTTPClientCoreInvocationReporting.swift
@@ -54,6 +54,35 @@ public protocol OutwardsRequestAggregator {
     func recordRetriableOutwardsRequest(retriableOutwardsRequest: RetriableOutputRequestRecord)
 }
 
+#if (os(Linux) && compiler(>=5.5)) || (!os(Linux) && compiler(>=5.5.2)) && canImport(_Concurrency)
+extension OutwardsRequestAggregator {
+
+    func recordOutwardsRequest(outputRequestRecord: OutputRequestRecord) async {
+        return await withCheckedContinuation { cont in
+            recordOutwardsRequest(outputRequestRecord: outputRequestRecord) {
+                cont.resume(returning: ())
+            }
+        }
+    }
+    
+    func recordRetryAttempt(retryAttemptRecord: RetryAttemptRecord) async {
+        return await withCheckedContinuation { cont in
+            recordRetryAttempt(retryAttemptRecord: retryAttemptRecord) {
+                cont.resume(returning: ())
+            }
+        }
+    }
+    
+    func recordRetriableOutwardsRequest(retriableOutwardsRequest: RetriableOutputRequestRecord) async {
+        return await withCheckedContinuation { cont in
+            recordRetriableOutwardsRequest(retriableOutwardsRequest: retriableOutwardsRequest) {
+                cont.resume(returning: ())
+            }
+        }
+    }
+}
+#endif
+
 public extension OutwardsRequestAggregator {
     @available(swift, deprecated: 2.0, message: "Not thread-safe")
     func recordOutwardsRequest(outputRequestRecord: OutputRequestRecord, onCompletion: @escaping () -> ()) {

--- a/Sources/SmokeHTTPClient/HTTPOperationsClient+executeRetriableWithOutput.swift
+++ b/Sources/SmokeHTTPClient/HTTPOperationsClient+executeRetriableWithOutput.swift
@@ -32,7 +32,7 @@ internal extension EventLoopFuture {
     /// function and want to get the result of this future.
     @inlinable
     func get() async throws -> Value {
-        return try await withUnsafeThrowingContinuation { cont in
+        return try await withCheckedThrowingContinuation { cont in
             self.whenComplete { result in
                 switch result {
                 case .success(let value):

--- a/Sources/SmokeHTTPClient/HTTPOperationsClient+executeRetriableWithOutput.swift
+++ b/Sources/SmokeHTTPClient/HTTPOperationsClient+executeRetriableWithOutput.swift
@@ -204,19 +204,12 @@ public extension HTTPOperationsClient {
             
             // submit all the request latencies captured by the RetriableOutwardsRequestAggregator
             // to the provided outwardsRequestAggregator if it was provided
-            //if let outwardsRequestAggregators = self.outwardsRequestAggregators {
-            //    let promise = self.eventLoop.makePromise(of: Void.self)
-            //
-            //    outwardsRequestAggregators.1.withRecords { outputRequestRecords in
-            //        outwardsRequestAggregators.0.recordRetriableOutwardsRequest(
-            //            retriableOutwardsRequest: StandardRetriableOutputRequestRecord(outputRequests: outputRequestRecords)) {
-            //                promise.succeed(())
-            //            }
-            //    }
-            //
-            //
-            //    return promise.futureResult
-            //}
+            if let outwardsRequestAggregators = self.outwardsRequestAggregators {
+                let outputRequestRecords = await outwardsRequestAggregators.1.records()
+                
+                await outwardsRequestAggregators.0.recordRetriableOutwardsRequest(
+                    retriableOutwardsRequest: StandardRetriableOutputRequestRecord(outputRequests: outputRequestRecords))
+            }
         }
     }
     

--- a/Sources/SmokeHTTPClient/HTTPOperationsClient+executeRetriableWithOutput.swift
+++ b/Sources/SmokeHTTPClient/HTTPOperationsClient+executeRetriableWithOutput.swift
@@ -152,18 +152,10 @@ public extension HTTPOperationsClient {
                 let currentRetriesRemaining = retriesRemaining
                 retriesRemaining -= 1
                 
-                //let recordFuture: EventLoopFuture<Void>
-                //if let outwardsRequestAggregators = self.outwardsRequestAggregators {
-                //    let promise = self.eventLoop.makePromise(of: Void.self)
-                //    outwardsRequestAggregators.0.recordRetryAttempt(
-                //        retryAttemptRecord: StandardRetryAttemptRecord(retryWait: retryInterval.millisecondsToTimeInterval)) {
-                //            promise.succeed(())
-                //        }
-                //
-                //    recordFuture = promise.futureResult
-                //} else {
-                //    recordFuture = self.eventLoop.makeSucceededVoidFuture()
-                //}
+                if let outwardsRequestAggregators = self.outwardsRequestAggregators {
+                    await outwardsRequestAggregators.0.recordRetryAttempt(
+                        retryAttemptRecord: StandardRetryAttemptRecord(retryWait: retryInterval.millisecondsToTimeInterval))
+                }
                 
                 logger.warning(
                     "Request failed with error: \(error). Remaining retries: \(currentRetriesRemaining). Retrying in \(retryInterval) ms.")

--- a/Sources/SmokeHTTPClient/HTTPOperationsClient+executeRetriableWithOutput.swift
+++ b/Sources/SmokeHTTPClient/HTTPOperationsClient+executeRetriableWithOutput.swift
@@ -20,6 +20,9 @@
 import Foundation
 import NIO
 import NIOHTTP1
+import Metrics
+
+private let millisecondsToNanoSeconds: UInt64 = 1000000
 
 // Copy of extension from SwiftNIO; can be removed when the version in SwiftNIO removes its @available attribute
 internal extension EventLoopFuture {
@@ -43,6 +46,179 @@ internal extension EventLoopFuture {
 }
 
 public extension HTTPOperationsClient {
+    /**
+     Helper type that manages the state of a retriable async request.
+     */
+    private class ExecuteWithOutputRetriable<InputType, OutputType,
+        InvocationReportingType: HTTPClientInvocationReporting, HandlerDelegateType: HTTPClientInvocationDelegate>
+            where InputType: HTTPRequestInputProtocol, OutputType: HTTPResponseOutputProtocol {
+        let endpointOverride: URL?
+        let endpointPath: String
+        let httpMethod: HTTPMethod
+        let input: InputType
+        let invocationContext: HTTPClientInvocationContext<InvocationReportingType, HandlerDelegateType>
+        let eventLoop: EventLoop
+        let innerInvocationContext:
+            HTTPClientInvocationContext<HTTPClientInnerRetryInvocationReporting<InvocationReportingType.TraceContextType>, HandlerDelegateType>
+        let httpClient: HTTPOperationsClient
+        let retryConfiguration: HTTPClientRetryConfiguration
+        let retryOnError: (HTTPClientError) -> Bool
+        let queue = DispatchQueue.global()
+        let latencyMetricDetails: (Date, Metrics.Timer)?
+        let outwardsRequestAggregators: (OutwardsRequestAggregator, RetriableOutwardsRequestAggregator)?
+        
+        var retriesRemaining: Int
+        
+        init(endpointOverride: URL?, endpointPath: String, httpMethod: HTTPMethod, input: InputType,
+             invocationContext: HTTPClientInvocationContext<InvocationReportingType, HandlerDelegateType>,
+             eventLoopOverride eventLoop: EventLoop,
+             httpClient: HTTPOperationsClient,
+             retryConfiguration: HTTPClientRetryConfiguration,
+             retryOnError: @escaping (HTTPClientError) -> Bool) {
+            self.endpointOverride = endpointOverride
+            self.endpointPath = endpointPath
+            self.httpMethod = httpMethod
+            self.input = input
+            self.invocationContext = invocationContext
+            self.eventLoop = eventLoop
+            self.httpClient = httpClient
+            self.retryConfiguration = retryConfiguration
+            self.retriesRemaining = retryConfiguration.numRetries
+            self.retryOnError = retryOnError
+            
+            // if the request latencies need to be aggregated
+            if let outwardsRequestAggregator = invocationContext.reporting.outwardsRequestAggregator {
+                outwardsRequestAggregators = (outwardsRequestAggregator, RetriableOutwardsRequestAggregator())
+            } else {
+                outwardsRequestAggregators = nil
+            }
+            
+            if let latencyTimer = invocationContext.reporting.latencyTimer {
+                self.latencyMetricDetails = (Date(), latencyTimer)
+            } else {
+                self.latencyMetricDetails = nil
+            }
+            // When using retry wrappers, the `HTTPClient` itself shouldn't record any metrics.
+            let innerReporting = HTTPClientInnerRetryInvocationReporting(internalRequestId: invocationContext.reporting.internalRequestId,
+                                                                         traceContext: invocationContext.reporting.traceContext,
+                                                                         logger: invocationContext.reporting.logger,
+                                                                         eventLoop: eventLoop,
+                                                                         outwardsRequestAggregator: outwardsRequestAggregators?.1)
+            self.innerInvocationContext = HTTPClientInvocationContext(reporting: innerReporting, handlerDelegate: invocationContext.handlerDelegate)
+        }
+        
+        func executeWithOutput() async throws -> OutputType {
+            // submit the asynchronous request
+            let result: OutputType
+            do {
+                result = try await httpClient.executeWithOutputWithWrappedInvocationContext(
+                    endpointOverride: endpointOverride,
+                    endpointPath: endpointPath, httpMethod: httpMethod,
+                    input: input, invocationContext: innerInvocationContext)
+            } catch {
+                let httpClientError: HTTPClientError
+                if let typedError = error as? HTTPClientError {
+                    httpClientError = typedError
+                } else {
+                    // if a non-HTTPClientError is thrown, wrap it
+                    httpClientError = HTTPClientError(responseCode: 400, cause: error)
+                }
+                
+                return try await self.retry(error: httpClientError)
+            }
+            
+            await self.onSuccess()
+            
+            return result
+        }
+        
+        func onSuccess() async {
+            // report success metric
+            invocationContext.reporting.successCounter?.increment()
+            
+            await onComplete()
+        }
+        
+        func retry(error: HTTPClientError) async throws -> OutputType {
+            let logger = invocationContext.reporting.logger
+
+            let shouldRetryOnError = retryOnError(error)
+            
+            // if there are retries remaining and we should retry on this error
+            if retriesRemaining > 0 && shouldRetryOnError {
+                // determine the required interval
+                let retryInterval = Int(retryConfiguration.getRetryInterval(retriesRemaining: retriesRemaining))
+                
+                let currentRetriesRemaining = retriesRemaining
+                retriesRemaining -= 1
+                
+                //let recordFuture: EventLoopFuture<Void>
+                //if let outwardsRequestAggregators = self.outwardsRequestAggregators {
+                //    let promise = self.eventLoop.makePromise(of: Void.self)
+                //    outwardsRequestAggregators.0.recordRetryAttempt(
+                //        retryAttemptRecord: StandardRetryAttemptRecord(retryWait: retryInterval.millisecondsToTimeInterval)) {
+                //            promise.succeed(())
+                //        }
+                //
+                //    recordFuture = promise.futureResult
+                //} else {
+                //    recordFuture = self.eventLoop.makeSucceededVoidFuture()
+                //}
+                
+                logger.warning(
+                    "Request failed with error: \(error). Remaining retries: \(currentRetriesRemaining). Retrying in \(retryInterval) ms.")
+                try await Task.sleep(nanoseconds: UInt64(retryInterval) * millisecondsToNanoSeconds)
+                logger.trace("Reattempting request due to remaining retries: \(currentRetriesRemaining)")
+                
+                return try await self.executeWithOutput()
+            }
+            
+            if !shouldRetryOnError {
+                logger.trace("Request not retried due to error returned: \(error)")
+            } else {
+                logger.trace("Request not retried due to maximum retries: \(retryConfiguration.numRetries)")
+            }
+            
+            // report failure metric
+            switch error.category {
+            case .clientError:
+                invocationContext.reporting.failure4XXCounter?.increment()
+            case .serverError:
+                invocationContext.reporting.failure5XXCounter?.increment()
+            }
+            
+            await onComplete()
+
+            // its an error; complete with the provided error
+            throw error
+        }
+        
+        func onComplete() async {
+            // report the retryCount metric
+            let retryCount = retryConfiguration.numRetries - retriesRemaining
+            invocationContext.reporting.retryCountRecorder?.record(retryCount)
+            
+            if let durationMetricDetails = latencyMetricDetails {
+                durationMetricDetails.1.recordMilliseconds(Date().timeIntervalSince(durationMetricDetails.0).milliseconds)
+            }
+            
+            // submit all the request latencies captured by the RetriableOutwardsRequestAggregator
+            // to the provided outwardsRequestAggregator if it was provided
+            //if let outwardsRequestAggregators = self.outwardsRequestAggregators {
+            //    let promise = self.eventLoop.makePromise(of: Void.self)
+            //
+            //    outwardsRequestAggregators.1.withRecords { outputRequestRecords in
+            //        outwardsRequestAggregators.0.recordRetriableOutwardsRequest(
+            //            retriableOutwardsRequest: StandardRetriableOutputRequestRecord(outputRequests: outputRequestRecords)) {
+            //                promise.succeed(())
+            //            }
+            //    }
+            //
+            //
+            //    return promise.futureResult
+            //}
+        }
+    }
     
     /**
      Submits a request that will return a response body to this client asynchronously.

--- a/Sources/SmokeHTTPClient/HTTPOperationsClient+executeRetriableWithoutOutput.swift
+++ b/Sources/SmokeHTTPClient/HTTPOperationsClient+executeRetriableWithoutOutput.swift
@@ -184,18 +184,12 @@ public extension HTTPOperationsClient {
             
             // submit all the request latencies captured by the RetriableOutwardsRequestAggregator
             // to the provided outwardsRequestAggregator if it was provided
-            //if let outwardsRequestAggregators = self.outwardsRequestAggregators {
-            //    let promise = self.eventLoop.makePromise(of: Void.self)
+            if let outwardsRequestAggregators = self.outwardsRequestAggregators {
+                let outputRequestRecords = await outwardsRequestAggregators.1.records()
                 
-            //    outwardsRequestAggregators.1.withRecords { outputRequestRecords in
-            //        outwardsRequestAggregators.0.recordRetriableOutwardsRequest(
-            //            retriableOutwardsRequest: StandardRetriableOutputRequestRecord(outputRequests: outputRequestRecords)) {
-            //                promise.succeed(())
-            //            }
-            //    }
-            //
-            //    return promise.futureResult
-            //}
+                await outwardsRequestAggregators.0.recordRetriableOutwardsRequest(
+                    retriableOutwardsRequest: StandardRetriableOutputRequestRecord(outputRequests: outputRequestRecords))
+            }
         }
     }
     

--- a/Sources/SmokeHTTPClient/HTTPOperationsClient+executeRetriableWithoutOutput.swift
+++ b/Sources/SmokeHTTPClient/HTTPOperationsClient+executeRetriableWithoutOutput.swift
@@ -129,19 +129,10 @@ public extension HTTPOperationsClient {
                 let currentRetriesRemaining = retriesRemaining
                 retriesRemaining -= 1
                 
-                //let recordFuture: EventLoopFuture<Void>
-                //if let outwardsRequestAggregators = self.outwardsRequestAggregators {
-                //    let promise = self.eventLoop.makePromise(of: Void.self)
-                //
-                //    outwardsRequestAggregators.0.recordRetryAttempt(
-                //        retryAttemptRecord: StandardRetryAttemptRecord(retryWait: retryInterval.millisecondsToTimeInterval)) {
-                //            promise.succeed(())
-                //        }
-                //
-                //    recordFuture = promise.futureResult
-                //} else {
-                //    recordFuture = self.eventLoop.makeSucceededVoidFuture()
-                //}
+                if let outwardsRequestAggregators = self.outwardsRequestAggregators {
+                    await outwardsRequestAggregators.0.recordRetryAttempt(
+                        retryAttemptRecord: StandardRetryAttemptRecord(retryWait: retryInterval.millisecondsToTimeInterval))
+                }
                 
                 logger.warning(
                     "Request failed with error: \(error). Remaining retries: \(currentRetriesRemaining). Retrying in \(retryInterval) ms.")

--- a/Sources/SmokeHTTPClient/HTTPOperationsClient+executeWithOutput.swift
+++ b/Sources/SmokeHTTPClient/HTTPOperationsClient+executeWithOutput.swift
@@ -20,6 +20,8 @@
 import Foundation
 import NIO
 import NIOHTTP1
+import AsyncHTTPClient
+import Metrics
 
 public extension HTTPOperationsClient {
     
@@ -43,12 +45,96 @@ public extension HTTPOperationsClient {
         input: InputType,
         invocationContext: HTTPClientInvocationContext<InvocationReportingType, HandlerDelegateType>) async throws -> OutputType
     where InputType: HTTPRequestInputProtocol, OutputType: HTTPResponseOutputProtocol {
-        return try await executeAsEventLoopFutureWithOutput(
+        let wrappingInvocationContext = invocationContext.withOutgoingRequestIdLoggerMetadata()
+        
+        return try await executeWithOutputWithWrappedInvocationContext(
             endpointOverride: endpointOverride,
             endpointPath: endpointPath,
             httpMethod: httpMethod,
             input: input,
-            invocationContext: invocationContext).get()
+            invocationContext: wrappingInvocationContext)
+    }
+    
+    /**
+     Submits a request that will return a response body to this client asynchronously.
+     To be called when the `InvocationContext` has already been wrapped with an outgoingRequestId aware Logger.
+
+     - Parameters:
+         - endpointPath: The endpoint path for this request.
+         - httpMethod: The http method to use for this request.
+         - input: the input body data to send with this request.
+         - asyncResponseInvocationStrategy: The invocation strategy for the response from this request.
+         - invocationContext: context to use for this invocation.
+        - Returns: A future that will produce the execution result or failure.
+     */
+    internal func executeWithOutputWithWrappedInvocationContext<InputType, OutputType,
+        InvocationReportingType: HTTPClientInvocationReporting, HandlerDelegateType: HTTPClientInvocationDelegate>(
+            endpointOverride: URL? = nil,
+            endpointPath: String,
+            httpMethod: HTTPMethod,
+            input: InputType,
+            invocationContext: HTTPClientInvocationContext<InvocationReportingType, HandlerDelegateType>) async throws
+    -> OutputType where InputType: HTTPRequestInputProtocol, OutputType: HTTPResponseOutputProtocol {
+        let durationMetricDetails: (Date, Metrics.Timer?, OutwardsRequestAggregator?)?
+        
+        if invocationContext.reporting.outwardsRequestAggregator != nil ||
+                invocationContext.reporting.latencyTimer != nil {
+            durationMetricDetails = (Date(), invocationContext.reporting.latencyTimer, invocationContext.reporting.outwardsRequestAggregator)
+        } else {
+            durationMetricDetails = nil
+        }
+
+        let requestDelegate = clientDelegate
+        
+        let response: HTTPResponseComponents
+        do {
+            response = try await execute(endpointOverride: endpointOverride,
+                                         endpointPath: endpointPath, httpMethod: httpMethod,
+                                         input: input, invocationContext: invocationContext)
+        } catch {
+            if let typedError = error as? HTTPClientError {
+                // report failure metric
+                switch typedError.category {
+                case .clientError:
+                    invocationContext.reporting.failure4XXCounter?.increment()
+                case .serverError:
+                    invocationContext.reporting.failure5XXCounter?.increment()
+                }
+            }
+            
+            // rethrow the error
+            throw error
+        }
+        
+        let output: OutputType
+        do {
+            // decode the provided body into the desired type
+            output = try requestDelegate.decodeOutput(
+                output: response.body,
+                headers: response.headers,
+                invocationReporting: invocationContext.reporting)
+            
+            // report success metric
+            invocationContext.reporting.successCounter?.increment()
+        } catch {
+            // if there was a decoding error, complete with that error
+            throw HTTPClientError(responseCode: 400, cause: error)
+        }
+        
+        if let durationMetricDetails = durationMetricDetails {
+            let timeInterval = Date().timeIntervalSince(durationMetricDetails.0)
+            
+            if let latencyTimer = durationMetricDetails.1 {
+                latencyTimer.recordMilliseconds(timeInterval.milliseconds)
+            }
+            
+            //if let outwardsRequestAggregator = durationMetricDetails.2 {
+            //    await outwardsRequestAggregator.recordOutwardsRequest(
+            //        outputRequestRecord: StandardOutputRequestRecord(requestLatency: timeInterval))
+            //}
+        }
+        
+        return output
     }
 }
 

--- a/Sources/SmokeHTTPClient/HTTPOperationsClient+executeWithOutput.swift
+++ b/Sources/SmokeHTTPClient/HTTPOperationsClient+executeWithOutput.swift
@@ -127,10 +127,10 @@ public extension HTTPOperationsClient {
                 latencyTimer.recordMilliseconds(timeInterval.milliseconds)
             }
             
-            //if let outwardsRequestAggregator = durationMetricDetails.2 {
-            //    await outwardsRequestAggregator.recordOutwardsRequest(
-            //        outputRequestRecord: StandardOutputRequestRecord(requestLatency: timeInterval))
-            //}
+            if let outwardsRequestAggregator = durationMetricDetails.2 {
+                await outwardsRequestAggregator.recordOutwardsRequest(
+                    outputRequestRecord: StandardOutputRequestRecord(requestLatency: timeInterval))
+            }
         }
         
         return output

--- a/Sources/SmokeHTTPClient/HTTPOperationsClient+executeWithoutOutput.swift
+++ b/Sources/SmokeHTTPClient/HTTPOperationsClient+executeWithoutOutput.swift
@@ -114,10 +114,10 @@ public extension HTTPOperationsClient {
                 latencyTimer.recordMilliseconds(timeInterval.milliseconds)
             }
             
-            //if let outwardsRequestAggregator = durationMetricDetails.2 {
-            //    await outwardsRequestAggregator.recordOutwardsRequest(
-            //        outputRequestRecord: StandardOutputRequestRecord(requestLatency: timeInterval))
-            //}
+            if let outwardsRequestAggregator = durationMetricDetails.2 {
+                await outwardsRequestAggregator.recordOutwardsRequest(
+                    outputRequestRecord: StandardOutputRequestRecord(requestLatency: timeInterval))
+            }
         }
     }
 }

--- a/Sources/SmokeHTTPClient/HTTPOperationsClient+executeWithoutOutput.swift
+++ b/Sources/SmokeHTTPClient/HTTPOperationsClient+executeWithoutOutput.swift
@@ -20,6 +20,7 @@
 import Foundation
 import NIO
 import NIOHTTP1
+import Metrics
 
 public extension HTTPOperationsClient {
     
@@ -43,12 +44,81 @@ public extension HTTPOperationsClient {
         input: InputType,
         invocationContext: HTTPClientInvocationContext<InvocationReportingType, HandlerDelegateType>) async throws
     where InputType: HTTPRequestInputProtocol {
-        return try await executeAsEventLoopFutureWithoutOutput(
+        let wrappingInvocationContext = invocationContext.withOutgoingRequestIdLoggerMetadata()
+        
+        return try await executeWithoutOutputWithWrappedInvocationContext(
             endpointOverride: endpointOverride,
             endpointPath: endpointPath,
             httpMethod: httpMethod,
             input: input,
-            invocationContext: invocationContext).get()
+            invocationContext: wrappingInvocationContext)
+    }
+    
+    /**
+     Submits a request that will not return a response body to this client asynchronously.
+     To be called when the `InvocationContext` has already been wrapped with an outgoingRequestId aware Logger.
+     
+     - Parameters:
+        - endpointPath: The endpoint path for this request.
+        - httpMethod: The http method to use for this request.
+        - input: the input body data to send with this request.
+        - invocationContext: context to use for this invocation.
+     - Returns: A future that will produce a Void result or failure.
+     */
+    internal func executeWithoutOutputWithWrappedInvocationContext<InputType,
+            InvocationReportingType: HTTPClientInvocationReporting, HandlerDelegateType: HTTPClientInvocationDelegate>(
+        endpointOverride: URL? = nil,
+        endpointPath: String,
+        httpMethod: HTTPMethod,
+        input: InputType,
+        invocationContext: HTTPClientInvocationContext<InvocationReportingType, HandlerDelegateType>) async throws
+    where InputType: HTTPRequestInputProtocol {
+        
+        let durationMetricDetails: (Date, Metrics.Timer?, OutwardsRequestAggregator?)?
+        
+        if invocationContext.reporting.outwardsRequestAggregator != nil ||
+            invocationContext.reporting.latencyTimer != nil {
+            durationMetricDetails = (Date(), invocationContext.reporting.latencyTimer, invocationContext.reporting.outwardsRequestAggregator)
+        } else {
+            durationMetricDetails = nil
+        }
+        
+        // submit the asynchronous request
+        do {
+            _ = try await execute(endpointOverride: endpointOverride,
+                                  endpointPath: endpointPath,
+                                  httpMethod: httpMethod,
+                                  input: input,
+                                  invocationContext: invocationContext)
+        } catch {
+            if let typedError = error as? HTTPClientError {
+                // report failure metric
+                switch typedError.category {
+                case .clientError:
+                    invocationContext.reporting.failure4XXCounter?.increment()
+                case .serverError:
+                    invocationContext.reporting.failure5XXCounter?.increment()
+                }
+            }
+            
+            // rethrow the error
+            throw error
+        }
+        
+        invocationContext.reporting.successCounter?.increment()
+        
+        if let durationMetricDetails = durationMetricDetails {
+            let timeInterval = Date().timeIntervalSince(durationMetricDetails.0)
+            
+            if let latencyTimer = durationMetricDetails.1 {
+                latencyTimer.recordMilliseconds(timeInterval.milliseconds)
+            }
+            
+            //if let outwardsRequestAggregator = durationMetricDetails.2 {
+            //    await outwardsRequestAggregator.recordOutwardsRequest(
+            //        outputRequestRecord: StandardOutputRequestRecord(requestLatency: timeInterval))
+            //}
+        }
     }
 }
 

--- a/Sources/SmokeHTTPClient/HTTPOperationsClient.swift
+++ b/Sources/SmokeHTTPClient/HTTPOperationsClient.swift
@@ -256,6 +256,43 @@ public struct HTTPOperationsClient {
         }
     }
     
+    func execute<InputType, InvocationReportingType: HTTPClientInvocationReporting, HandlerDelegateType: HTTPClientInvocationDelegate>(
+            endpointOverride: URL? = nil,
+            endpointPath: String,
+            httpMethod: HTTPMethod,
+            input: InputType,
+            invocationContext: HTTPClientInvocationContext<InvocationReportingType, HandlerDelegateType>) async throws
+    -> HTTPResponseComponents where InputType: HTTPRequestInputProtocol {
+        let (responseFuture, outwardsRequestContext) = try performExecuteAsync(endpointOverride: endpointOverride,
+                                                                               endpointPath: endpointPath,
+                                                                               httpMethod: httpMethod,
+                                                                               input: input,
+                                                                               invocationContext: invocationContext)
+        
+        do {
+            let successResult = try await responseFuture.get()
+            
+            // a response has been successfully received; this reponse may be a successful response
+            // and generate a `HTTPResponseComponents` instance or be a failure response and cause
+            // a SmokeHTTPClient.HTTPClientError error to be thrown
+            return try self.handleCompleteResponseThrowingClientError(invocationContext: invocationContext,
+                                                                      outwardsRequestContext: outwardsRequestContext,
+                                                                      result: .success(successResult))
+        } catch {
+            // if this error has been thrown from just above
+            if let typedError = error as? SmokeHTTPClient.HTTPClientError {
+                // just rethrow the error
+                throw typedError
+            }
+            
+            // a response wasn't even able to be generated (for example due to a connection error)
+            // make sure this error is thrown correctly as a SmokeHTTPClient.HTTPClientError
+            return try self.handleCompleteResponseThrowingClientError(invocationContext: invocationContext,
+                                                                      outwardsRequestContext: outwardsRequestContext,
+                                                                      result: .failure(error))
+        }
+    }
+    
     // To maintain the existing behaviour of async functions, this function will throw for synchronous setup errors and fail
     // the future otherwise.
     private func performExecuteAsync<InputType, InvocationReportingType: HTTPClientInvocationReporting, HandlerDelegateType: HTTPClientInvocationDelegate>(

--- a/Sources/SmokeHTTPClient/HTTPOperationsClient.swift
+++ b/Sources/SmokeHTTPClient/HTTPOperationsClient.swift
@@ -179,7 +179,9 @@ public struct HTTPOperationsClient {
         }
     }
 #endif
-    
+}
+ 
+extension HTTPOperationsClient {
     func executeAsync<InputType, InvocationReportingType: HTTPClientInvocationReporting, HandlerDelegateType: HTTPClientInvocationDelegate>(
             endpointOverride: URL? = nil,
             endpointPath: String,

--- a/Sources/SmokeHTTPClient/HTTPOperationsClient.swift
+++ b/Sources/SmokeHTTPClient/HTTPOperationsClient.swift
@@ -168,7 +168,7 @@ public struct HTTPOperationsClient {
      */
 #if (os(Linux) && compiler(>=5.5)) || (!os(Linux) && compiler(>=5.5.2)) && canImport(_Concurrency)
     public func shutdown() async throws {
-        return try await withUnsafeThrowingContinuation { cont in
+        return try await withCheckedThrowingContinuation { cont in
             self.wrappedHttpClient.shutdown { error in
                 if let error = error {
                     cont.resume(throwing: error)

--- a/Sources/SmokeHTTPClient/RetriableOutwardsRequestLatencyAggregator.swift
+++ b/Sources/SmokeHTTPClient/RetriableOutwardsRequestLatencyAggregator.swift
@@ -58,6 +58,18 @@ internal class RetriableOutwardsRequestAggregator:  OutwardsRequestAggregator {
     }
 }
 
+#if (os(Linux) && compiler(>=5.5)) || (!os(Linux) && compiler(>=5.5.2)) && canImport(_Concurrency)
+extension RetriableOutwardsRequestAggregator {
+    func records() async -> [OutputRequestRecord] {
+        return await withCheckedContinuation { cont in
+            withRecords { records in
+                cont.resume(returning: records)
+            }
+        }
+    }
+}
+#endif
+
 struct StandardOutputRequestRecord: OutputRequestRecord {
     let requestLatency: TimeInterval
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Move delegating to the EventLoopFuture APIs closer to the async-http-client call when the Swift Concurrency APIs are called. This will mean retries and response decoding will occur on Swift Concurrency threads.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
