### PR TITLE
Off task async executor

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -12,10 +12,10 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-22.04, ubuntu-20.04]
-        swift: ["5.7.1"]
+        swift: ["5.7.2"]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: swift-actions/setup-swift@v1.20.0
+      - uses: swift-actions/setup-swift@v1.21.0
         with:
           swift-version: ${{ matrix.swift }}
       - uses: actions/checkout@v2
@@ -31,7 +31,7 @@ jobs:
         swift: ["5.6.3", "5.5.3"]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: swift-actions/setup-swift@v1.20.0
+      - uses: swift-actions/setup-swift@v1.21.0
         with:
           swift-version: ${{ matrix.swift }}
       - uses: actions/checkout@v2

--- a/Sources/SmokeHTTPClient/HTTPOperationsClient.swift
+++ b/Sources/SmokeHTTPClient/HTTPOperationsClient.swift
@@ -50,6 +50,7 @@ public struct HTTPOperationsClient {
     /// The `HTTPClient` used for this instance
     private let wrappedHttpClient: HTTPClient
     private let enableAHCLogging: Bool
+    private let offTaskAsyncExecutor = OffTaskAsyncExecutor()
     
     public var eventLoopGroup: EventLoopGroup {
         return self.wrappedHttpClient.eventLoopGroup
@@ -265,11 +266,13 @@ extension HTTPOperationsClient {
             input: InputType,
             invocationContext: HTTPClientInvocationContext<InvocationReportingType, HandlerDelegateType>) async throws
     -> HTTPResponseComponents where InputType: HTTPRequestInputProtocol {
-        let (responseFuture, outwardsRequestContext) = try performExecuteAsync(endpointOverride: endpointOverride,
-                                                                               endpointPath: endpointPath,
-                                                                               httpMethod: httpMethod,
-                                                                               input: input,
-                                                                               invocationContext: invocationContext)
+        let (responseFuture, outwardsRequestContext) = try await self.offTaskAsyncExecutor.execute {
+            try performExecuteAsync(endpointOverride: endpointOverride,
+                                    endpointPath: endpointPath,
+                                    httpMethod: httpMethod,
+                                    input: input,
+                                    invocationContext: invocationContext)
+        }
         
         do {
             let successResult = try await responseFuture.get()
@@ -277,9 +280,11 @@ extension HTTPOperationsClient {
             // a response has been successfully received; this reponse may be a successful response
             // and generate a `HTTPResponseComponents` instance or be a failure response and cause
             // a SmokeHTTPClient.HTTPClientError error to be thrown
-            return try self.handleCompleteResponseThrowingClientError(invocationContext: invocationContext,
-                                                                      outwardsRequestContext: outwardsRequestContext,
-                                                                      result: .success(successResult))
+            return try await self.offTaskAsyncExecutor.execute {
+                try self.handleCompleteResponseThrowingClientError(invocationContext: invocationContext,
+                                                                   outwardsRequestContext: outwardsRequestContext,
+                                                                   result: .success(successResult))
+            }
         } catch {
             // if this error has been thrown from just above
             if let typedError = error as? SmokeHTTPClient.HTTPClientError {
@@ -289,9 +294,11 @@ extension HTTPOperationsClient {
             
             // a response wasn't even able to be generated (for example due to a connection error)
             // make sure this error is thrown correctly as a SmokeHTTPClient.HTTPClientError
-            return try self.handleCompleteResponseThrowingClientError(invocationContext: invocationContext,
-                                                                      outwardsRequestContext: outwardsRequestContext,
-                                                                      result: .failure(error))
+            return try await self.offTaskAsyncExecutor.execute {
+                try self.handleCompleteResponseThrowingClientError(invocationContext: invocationContext,
+                                                                   outwardsRequestContext: outwardsRequestContext,
+                                                                   result: .failure(error))
+            }
         }
     }
     

--- a/Sources/SmokeHTTPClient/OffTaskAsyncExecutor.swift
+++ b/Sources/SmokeHTTPClient/OffTaskAsyncExecutor.swift
@@ -1,0 +1,77 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+//  OffTaskAsyncExecutor.swift
+//  SmokeHTTPClient
+//
+
+import Foundation
+
+/**
+  Executes code off the Swift Concurrency cooperative thread pool.
+  This executor is intended for computationally intensive work such as serialization and deserialization.
+ */
+internal struct OffTaskAsyncExecutor {
+    internal let executorQueue = DispatchQueue(
+                label: "com.amazon.SmokeHTTP.DispatchQueueAsyncExecutor.executorQueue",
+                attributes: [.concurrent],
+                target: DispatchQueue.global())
+    
+    internal func execute(_ body: @escaping () -> ()) async {
+        return await withCheckedContinuation { continuation in
+            self.executorQueue.async {
+                body()
+                
+                continuation.resume()
+            }
+        }
+    }
+    
+    internal func execute(_ body: @escaping () throws -> ()) async throws {
+        return try await withCheckedThrowingContinuation { continuation in
+            self.executorQueue.async {
+                do {
+                    try body()
+                    
+                    continuation.resume()
+                } catch {
+                    continuation.resume(throwing: error)
+                }
+            }
+        }
+    }
+    
+    internal func execute<ReturnType>(_ body: @escaping () -> (ReturnType)) async -> ReturnType {
+        return await withCheckedContinuation { continuation in
+            self.executorQueue.async {
+                let result = body()
+                
+                continuation.resume(returning: result)
+            }
+        }
+    }
+    
+    internal func execute<ReturnType>(_ body: @escaping () throws -> (ReturnType)) async throws -> ReturnType {
+        return try await withCheckedThrowingContinuation { continuation in
+            self.executorQueue.async {
+                do {
+                    let result = try body()
+                    
+                    continuation.resume(returning: result)
+                } catch {
+                    continuation.resume(throwing: error)
+                }
+            }
+        }
+    }
+}

--- a/Sources/SmokeHTTPClient/OffTaskAsyncExecutor.swift
+++ b/Sources/SmokeHTTPClient/OffTaskAsyncExecutor.swift
@@ -22,14 +22,9 @@ import Foundation
   This executor is intended for computationally intensive work such as serialization and deserialization.
  */
 internal struct OffTaskAsyncExecutor {
-    internal let executorQueue = DispatchQueue(
-                label: "com.amazon.SmokeHTTP.DispatchQueueAsyncExecutor.executorQueue",
-                attributes: [.concurrent],
-                target: DispatchQueue.global())
-    
     internal func execute(_ body: @escaping () -> ()) async {
         return await withCheckedContinuation { continuation in
-            self.executorQueue.async {
+            DispatchQueue.global().async {
                 body()
                 
                 continuation.resume()
@@ -39,7 +34,7 @@ internal struct OffTaskAsyncExecutor {
     
     internal func execute(_ body: @escaping () throws -> ()) async throws {
         return try await withCheckedThrowingContinuation { continuation in
-            self.executorQueue.async {
+            DispatchQueue.global().async {
                 do {
                     try body()
                     
@@ -53,7 +48,7 @@ internal struct OffTaskAsyncExecutor {
     
     internal func execute<ReturnType>(_ body: @escaping () -> (ReturnType)) async -> ReturnType {
         return await withCheckedContinuation { continuation in
-            self.executorQueue.async {
+            DispatchQueue.global().async {
                 let result = body()
                 
                 continuation.resume(returning: result)
@@ -63,7 +58,7 @@ internal struct OffTaskAsyncExecutor {
     
     internal func execute<ReturnType>(_ body: @escaping () throws -> (ReturnType)) async throws -> ReturnType {
         return try await withCheckedThrowingContinuation { continuation in
-            self.executorQueue.async {
+            DispatchQueue.global().async {
                 do {
                     let result = try body()
                     


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* For Swift-Concurrency-based APIs, moves the work for serialising and deserialising the request and response bodies from the cooperative thread pool (which could become contended with large request or response bodies due to the limited number of threads in this pool) and onto threads managed by the global dispatch queue itself (which can expand as required). This reduces contention for the cooperative thread pool under these circumstances and provides more stable worse-case latencies.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
