### PR TITLE
Add retryOnErrorOverride provider to the HTTPClientRetryConfiguration

### DIFF
--- a/Sources/SmokeHTTPClient/HTTPClientRetryConfiguration.swift
+++ b/Sources/SmokeHTTPClient/HTTPClientRetryConfiguration.swift
@@ -25,15 +25,18 @@ public typealias RetryInterval = UInt32
  */
 public struct HTTPClientRetryConfiguration {
     // Number of retries to be attempted
-    public let numRetries: Int
+    public var numRetries: Int
     // First interval of retry in millis
-    public let baseRetryInterval: RetryInterval
+    public var baseRetryInterval: RetryInterval
     // Max amount of cumulative time to attempt retries in millis
-    public let maxRetryInterval: RetryInterval
+    public var maxRetryInterval: RetryInterval
     // Exponential backoff for each retry
-    public let exponentialBackoff: Double
+    public var exponentialBackoff: Double
     // Ramdomized backoff
-    public let jitter: Bool
+    public var jitter: Bool
+    // provider that determines if the retry policy should be applied to a thrown error
+    // if nil, errors will be retried according to the client's policy.
+    public var retryOnError: ((HTTPClientError) -> Bool)?
  
     /**
      Initializer.
@@ -44,14 +47,18 @@ public struct HTTPClientRetryConfiguration {
          - maxRetryInterval: max amount of cumulative time to attempt retries in millis
          - exponentialBackoff: exponential backoff for each retry
          - jitter: ramdomized backoff
+         - retryOnError: provider that determines if the retry policy should be applied to a thrown error
+                     if nil, errors will be retried according to the client's policy.
      */
     public init(numRetries: Int, baseRetryInterval: RetryInterval, maxRetryInterval: RetryInterval,
-                exponentialBackoff: Double, jitter: Bool = true) {
+                exponentialBackoff: Double, jitter: Bool = true,
+                retryOnError: ((HTTPClientError) -> Bool)? = nil) {
         self.numRetries = numRetries
         self.baseRetryInterval = baseRetryInterval
         self.maxRetryInterval = maxRetryInterval
         self.exponentialBackoff = exponentialBackoff
         self.jitter = jitter
+        self.retryOnError = retryOnError
     }
     
     public func getRetryInterval(retriesRemaining: Int) -> RetryInterval {

--- a/Sources/SmokeHTTPClient/HTTPClientRetryConfiguration.swift
+++ b/Sources/SmokeHTTPClient/HTTPClientRetryConfiguration.swift
@@ -35,8 +35,8 @@ public struct HTTPClientRetryConfiguration {
     // Ramdomized backoff
     public var jitter: Bool
     // provider that determines if the retry policy should be applied to a thrown error
-    // if nil, errors will be retried according to the client's policy.
-    public var retryOnError: ((HTTPClientError) -> Bool)?
+    // if nil or returning nil, errors will be retried according to the client's policy.
+    public var retryOnErrorOverride: ((HTTPClientError) -> Bool?)?
  
     /**
      Initializer.
@@ -48,17 +48,17 @@ public struct HTTPClientRetryConfiguration {
          - exponentialBackoff: exponential backoff for each retry
          - jitter: ramdomized backoff
          - retryOnError: provider that determines if the retry policy should be applied to a thrown error
-                     if nil, errors will be retried according to the client's policy.
+                     if nil or returning nil, errors will be retried according to the client's policy.
      */
     public init(numRetries: Int, baseRetryInterval: RetryInterval, maxRetryInterval: RetryInterval,
                 exponentialBackoff: Double, jitter: Bool = true,
-                retryOnError: ((HTTPClientError) -> Bool)? = nil) {
+                retryOnErrorOverride: ((HTTPClientError) -> Bool?)? = nil) {
         self.numRetries = numRetries
         self.baseRetryInterval = baseRetryInterval
         self.maxRetryInterval = maxRetryInterval
         self.exponentialBackoff = exponentialBackoff
         self.jitter = jitter
-        self.retryOnError = retryOnError
+        self.retryOnErrorOverride = retryOnErrorOverride
     }
     
     public func getRetryInterval(retriesRemaining: Int) -> RetryInterval {

--- a/Sources/SmokeHTTPClient/HTTPOperationsClient +executeAsyncRetriableWithOutput.swift
+++ b/Sources/SmokeHTTPClient/HTTPOperationsClient +executeAsyncRetriableWithOutput.swift
@@ -109,7 +109,7 @@ public extension HTTPOperationsClient {
 
             switch innerResult {
             case .failure(let error):
-                let shouldRetryOnError = retryConfiguration.retryOnError?(error) ?? retryOnError(error)
+                let shouldRetryOnError = retryConfiguration.retryOnErrorOverride?(error) ?? retryOnError(error)
                 
                 // if there are retries remaining and we should retry on this error
                 if retriesRemaining > 0 && shouldRetryOnError {

--- a/Sources/SmokeHTTPClient/HTTPOperationsClient +executeAsyncRetriableWithOutput.swift
+++ b/Sources/SmokeHTTPClient/HTTPOperationsClient +executeAsyncRetriableWithOutput.swift
@@ -109,7 +109,7 @@ public extension HTTPOperationsClient {
 
             switch innerResult {
             case .failure(let error):
-                let shouldRetryOnError = retryOnError(error)
+                let shouldRetryOnError = retryConfiguration.retryOnError?(error) ?? retryOnError(error)
                 
                 // if there are retries remaining and we should retry on this error
                 if retriesRemaining > 0 && shouldRetryOnError {

--- a/Sources/SmokeHTTPClient/HTTPOperationsClient +executeSyncRetriableWithOutput.swift
+++ b/Sources/SmokeHTTPClient/HTTPOperationsClient +executeSyncRetriableWithOutput.swift
@@ -150,7 +150,7 @@ public extension HTTPOperationsClient {
                 // never retry
                 shouldRetryOnError = false
             case .serverError:
-                shouldRetryOnError = retryOnError(error)
+                shouldRetryOnError = retryConfiguration.retryOnError?(error) ?? retryOnError(error)
             }
             let logger = invocationContext.reporting.logger
             

--- a/Sources/SmokeHTTPClient/HTTPOperationsClient +executeSyncRetriableWithOutput.swift
+++ b/Sources/SmokeHTTPClient/HTTPOperationsClient +executeSyncRetriableWithOutput.swift
@@ -150,7 +150,7 @@ public extension HTTPOperationsClient {
                 // never retry
                 shouldRetryOnError = false
             case .serverError:
-                shouldRetryOnError = retryConfiguration.retryOnError?(error) ?? retryOnError(error)
+                shouldRetryOnError = retryConfiguration.retryOnErrorOverride?(error) ?? retryOnError(error)
             }
             let logger = invocationContext.reporting.logger
             

--- a/Sources/SmokeHTTPClient/HTTPOperationsClient +executeSyncRetriableWithoutOutput.swift
+++ b/Sources/SmokeHTTPClient/HTTPOperationsClient +executeSyncRetriableWithoutOutput.swift
@@ -152,7 +152,7 @@ public extension HTTPOperationsClient {
                 // never retry
                 shouldRetryOnError = false
             case .serverError:
-                shouldRetryOnError = retryConfiguration.retryOnError?(error) ?? retryOnError(error)
+                shouldRetryOnError = retryConfiguration.retryOnErrorOverride?(error) ?? retryOnError(error)
             }
             let logger = invocationContext.reporting.logger
             

--- a/Sources/SmokeHTTPClient/HTTPOperationsClient +executeSyncRetriableWithoutOutput.swift
+++ b/Sources/SmokeHTTPClient/HTTPOperationsClient +executeSyncRetriableWithoutOutput.swift
@@ -152,7 +152,7 @@ public extension HTTPOperationsClient {
                 // never retry
                 shouldRetryOnError = false
             case .serverError:
-                shouldRetryOnError = retryOnError(error)
+                shouldRetryOnError = retryConfiguration.retryOnError?(error) ?? retryOnError(error)
             }
             let logger = invocationContext.reporting.logger
             

--- a/Sources/SmokeHTTPClient/HTTPOperationsClient+executeAsEventLoopFutureRetriableWithOutput.swift
+++ b/Sources/SmokeHTTPClient/HTTPOperationsClient+executeAsEventLoopFutureRetriableWithOutput.swift
@@ -118,7 +118,7 @@ public extension HTTPOperationsClient {
             let promise = self.eventLoop.makePromise(of: OutputType.self)
             let logger = invocationContext.reporting.logger
 
-            let shouldRetryOnError = retryConfiguration.retryOnError?(error) ?? retryOnError(error)
+            let shouldRetryOnError = retryConfiguration.retryOnErrorOverride?(error) ?? retryOnError(error)
             
             // if there are retries remaining and we should retry on this error
             if retriesRemaining > 0 && shouldRetryOnError {

--- a/Sources/SmokeHTTPClient/HTTPOperationsClient+executeAsEventLoopFutureRetriableWithOutput.swift
+++ b/Sources/SmokeHTTPClient/HTTPOperationsClient+executeAsEventLoopFutureRetriableWithOutput.swift
@@ -118,7 +118,7 @@ public extension HTTPOperationsClient {
             let promise = self.eventLoop.makePromise(of: OutputType.self)
             let logger = invocationContext.reporting.logger
 
-            let shouldRetryOnError = retryOnError(error)
+            let shouldRetryOnError = retryConfiguration.retryOnError?(error) ?? retryOnError(error)
             
             // if there are retries remaining and we should retry on this error
             if retriesRemaining > 0 && shouldRetryOnError {

--- a/Sources/SmokeHTTPClient/HTTPOperationsClient+executeAsEventLoopFutureRetriableWithoutOutput.swift
+++ b/Sources/SmokeHTTPClient/HTTPOperationsClient+executeAsEventLoopFutureRetriableWithoutOutput.swift
@@ -118,7 +118,7 @@ public extension HTTPOperationsClient {
             let promise = eventLoop.makePromise(of: Void.self)
             let logger = invocationContext.reporting.logger
 
-            let shouldRetryOnError = retryOnError(error)
+            let shouldRetryOnError = retryConfiguration.retryOnError?(error) ?? retryOnError(error)
             
             // if there are retries remaining and we should retry on this error
             if retriesRemaining > 0 && shouldRetryOnError {

--- a/Sources/SmokeHTTPClient/HTTPOperationsClient+executeAsEventLoopFutureRetriableWithoutOutput.swift
+++ b/Sources/SmokeHTTPClient/HTTPOperationsClient+executeAsEventLoopFutureRetriableWithoutOutput.swift
@@ -118,7 +118,7 @@ public extension HTTPOperationsClient {
             let promise = eventLoop.makePromise(of: Void.self)
             let logger = invocationContext.reporting.logger
 
-            let shouldRetryOnError = retryConfiguration.retryOnError?(error) ?? retryOnError(error)
+            let shouldRetryOnError = retryConfiguration.retryOnErrorOverride?(error) ?? retryOnError(error)
             
             // if there are retries remaining and we should retry on this error
             if retriesRemaining > 0 && shouldRetryOnError {

--- a/Sources/SmokeHTTPClient/HTTPOperationsClient+executeAsyncRetriableWithoutOutput.swift
+++ b/Sources/SmokeHTTPClient/HTTPOperationsClient+executeAsyncRetriableWithoutOutput.swift
@@ -105,7 +105,7 @@ public extension HTTPOperationsClient {
             let logger = invocationContext.reporting.logger
 
             if let innerError = innerError {
-                let shouldRetryOnError = retryConfiguration.retryOnError?(innerError) ?? retryOnError(innerError)
+                let shouldRetryOnError = retryConfiguration.retryOnErrorOverride?(innerError) ?? retryOnError(innerError)
                 
                 // if there are retries remaining and we should retry on this error
                 if retriesRemaining > 0 && shouldRetryOnError {

--- a/Sources/SmokeHTTPClient/HTTPOperationsClient+executeAsyncRetriableWithoutOutput.swift
+++ b/Sources/SmokeHTTPClient/HTTPOperationsClient+executeAsyncRetriableWithoutOutput.swift
@@ -105,7 +105,7 @@ public extension HTTPOperationsClient {
             let logger = invocationContext.reporting.logger
 
             if let innerError = innerError {
-                let shouldRetryOnError = retryOnError(innerError)
+                let shouldRetryOnError = retryConfiguration.retryOnError?(innerError) ?? retryOnError(innerError)
                 
                 // if there are retries remaining and we should retry on this error
                 if retriesRemaining > 0 && shouldRetryOnError {

--- a/Sources/SmokeHTTPClient/HTTPOperationsClient+executeRetriableWithOutput.swift
+++ b/Sources/SmokeHTTPClient/HTTPOperationsClient+executeRetriableWithOutput.swift
@@ -142,7 +142,7 @@ public extension HTTPOperationsClient {
         func retry(error: HTTPClientError) async throws -> OutputType {
             let logger = invocationContext.reporting.logger
 
-            let shouldRetryOnError = retryConfiguration.retryOnError?(error) ?? retryOnError(error)
+            let shouldRetryOnError = retryConfiguration.retryOnErrorOverride?(error) ?? retryOnError(error)
             
             // if there are retries remaining and we should retry on this error
             if retriesRemaining > 0 && shouldRetryOnError {

--- a/Sources/SmokeHTTPClient/HTTPOperationsClient+executeRetriableWithOutput.swift
+++ b/Sources/SmokeHTTPClient/HTTPOperationsClient+executeRetriableWithOutput.swift
@@ -142,7 +142,7 @@ public extension HTTPOperationsClient {
         func retry(error: HTTPClientError) async throws -> OutputType {
             let logger = invocationContext.reporting.logger
 
-            let shouldRetryOnError = retryOnError(error)
+            let shouldRetryOnError = retryConfiguration.retryOnError?(error) ?? retryOnError(error)
             
             // if there are retries remaining and we should retry on this error
             if retriesRemaining > 0 && shouldRetryOnError {

--- a/Sources/SmokeHTTPClient/HTTPOperationsClient+executeRetriableWithoutOutput.swift
+++ b/Sources/SmokeHTTPClient/HTTPOperationsClient+executeRetriableWithoutOutput.swift
@@ -119,7 +119,7 @@ public extension HTTPOperationsClient {
         func retry(error: HTTPClientError) async throws {
             let logger = invocationContext.reporting.logger
 
-            let shouldRetryOnError = retryConfiguration.retryOnError?(error) ?? retryOnError(error)
+            let shouldRetryOnError = retryConfiguration.retryOnErrorOverride?(error) ?? retryOnError(error)
             
             // if there are retries remaining and we should retry on this error
             if retriesRemaining > 0 && shouldRetryOnError {

--- a/Sources/SmokeHTTPClient/HTTPOperationsClient+executeRetriableWithoutOutput.swift
+++ b/Sources/SmokeHTTPClient/HTTPOperationsClient+executeRetriableWithoutOutput.swift
@@ -119,7 +119,7 @@ public extension HTTPOperationsClient {
         func retry(error: HTTPClientError) async throws {
             let logger = invocationContext.reporting.logger
 
-            let shouldRetryOnError = retryOnError(error)
+            let shouldRetryOnError = retryConfiguration.retryOnError?(error) ?? retryOnError(error)
             
             // if there are retries remaining and we should retry on this error
             if retriesRemaining > 0 && shouldRetryOnError {

--- a/Sources/SmokeHTTPClient/HTTPOperationsClient.swift
+++ b/Sources/SmokeHTTPClient/HTTPOperationsClient.swift
@@ -458,13 +458,11 @@ extension HTTPOperationsClient {
                 responseError = error
             } catch {
                 // if the provider throws an error, use this error
-                responseError = HTTPClientError(responseCode: Int(response.status.code),
-                                                cause: error)
+                responseError = HTTPClientError(responseCode: Int(response.status.code), cause: error)
             }
             
             invocationReporting.traceContext.handleOutwardsRequestFailure(
-                outwardsRequestContext: outwardsRequestContext,
-                logger: logger,
+                outwardsRequestContext: outwardsRequestContext, logger: logger,
                 internalRequestId: invocationReporting.internalRequestId,
                 response: response, bodyData: bodyData, error: responseError)
 

--- a/Sources/SmokeHTTPClient/HTTPOperationsClient.swift
+++ b/Sources/SmokeHTTPClient/HTTPOperationsClient.swift
@@ -458,7 +458,8 @@ extension HTTPOperationsClient {
                 responseError = error
             } catch {
                 // if the provider throws an error, use this error
-                responseError = HTTPClientError(responseCode: 400, cause: error)
+                responseError = HTTPClientError(responseCode: Int(response.status.code),
+                                                cause: error)
             }
             
             invocationReporting.traceContext.handleOutwardsRequestFailure(


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* 

1. Add retryOnErrorOverride provider to the HTTPClientRetryConfiguration. This will allow a user to customise what errors are retried by the client.
2. Don't assume an error thrown by clientDelegate.getResponseError is a client error. Use the error code provided by the response.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
