### PR TITLE
Don't assume an error thrown by clientDelegate.getResponseError is a client error.

### DIFF
--- a/Sources/SmokeHTTPClient/HTTPOperationsClient.swift
+++ b/Sources/SmokeHTTPClient/HTTPOperationsClient.swift
@@ -458,13 +458,11 @@ extension HTTPOperationsClient {
                 responseError = error
             } catch {
                 // if the provider throws an error, use this error
-                responseError = HTTPClientError(responseCode: Int(response.status.code),
-                                                cause: error)
+                responseError = HTTPClientError(responseCode: Int(response.status.code), cause: error)
             }
             
             invocationReporting.traceContext.handleOutwardsRequestFailure(
-                outwardsRequestContext: outwardsRequestContext,
-                logger: logger,
+                outwardsRequestContext: outwardsRequestContext, logger: logger,
                 internalRequestId: invocationReporting.internalRequestId,
                 response: response, bodyData: bodyData, error: responseError)
 

--- a/Sources/SmokeHTTPClient/HTTPOperationsClient.swift
+++ b/Sources/SmokeHTTPClient/HTTPOperationsClient.swift
@@ -458,7 +458,8 @@ extension HTTPOperationsClient {
                 responseError = error
             } catch {
                 // if the provider throws an error, use this error
-                responseError = HTTPClientError(responseCode: 400, cause: error)
+                responseError = HTTPClientError(responseCode: Int(response.status.code),
+                                                cause: error)
             }
             
             invocationReporting.traceContext.handleOutwardsRequestFailure(


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Don't assume an error thrown by clientDelegate.getResponseError is a client error. Use the status code from the response.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
