### PR TITLE
Decorate request logger with endpoint and operation.

### DIFF
--- a/Sources/SmokeHTTPClient/HTTPClientInvocationContext.swift
+++ b/Sources/SmokeHTTPClient/HTTPClientInvocationContext.swift
@@ -20,6 +20,8 @@ import Logging
 import Metrics
 
 private let outgoingRequestId = "outgoingRequestId"
+private let outgoingEndpointKey = "outgoingEndpoint"
+private let outgoingOperationKey = "outgoingOperation"
 
 /**
  A context related to the invocation of the HTTPClient.
@@ -36,10 +38,18 @@ public struct HTTPClientInvocationContext<InvocationReportingType: HTTPClientInv
 }
 
 extension HTTPClientInvocationContext {
-    func withOutgoingRequestIdLoggerMetadata() ->
-            HTTPClientInvocationContext<StandardHTTPClientInvocationReporting<InvocationReportingType.TraceContextType>, HandlerDelegateType> {
+    func withOutgoingDecoratedLogger(endpoint endpointOptional: URL?, outgoingOperation outgoingOperationOptional: String?)
+    -> HTTPClientInvocationContext<StandardHTTPClientInvocationReporting<InvocationReportingType.TraceContextType>, HandlerDelegateType> {
         var outwardInvocationLogger = reporting.logger
         outwardInvocationLogger[metadataKey: outgoingRequestId] = "\(UUID().uuidString)"
+                
+        if let endpoint = endpointOptional {
+            outwardInvocationLogger[metadataKey: outgoingEndpointKey] = "\(endpoint.absoluteString)"
+        }
+                
+        if let outgoingOperation = outgoingOperationOptional {
+            outwardInvocationLogger[metadataKey: outgoingOperationKey] = "\(outgoingOperation)"
+        }
         
         let wrappingInvocationReporting = StandardHTTPClientInvocationReporting(
             internalRequestId: reporting.internalRequestId,

--- a/Sources/SmokeHTTPClient/HTTPOperationsClient +executeAsyncRetriableWithOutput.swift
+++ b/Sources/SmokeHTTPClient/HTTPOperationsClient +executeAsyncRetriableWithOutput.swift
@@ -216,6 +216,7 @@ public extension HTTPOperationsClient {
             endpointOverride: URL? = nil,
             endpointPath: String,
             httpMethod: HTTPMethod,
+            operation: String? = nil,
             input: InputType,
             completion: @escaping (Result<OutputType, HTTPClientError>) -> (),
             invocationContext: HTTPClientInvocationContext<InvocationReportingType, HandlerDelegateType>,
@@ -226,6 +227,7 @@ public extension HTTPOperationsClient {
                 endpointOverride: endpointOverride,
                 endpointPath: endpointPath,
                 httpMethod: httpMethod,
+                operation: operation,
                 input: input,
                 completion: completion,
                 asyncResponseInvocationStrategy: GlobalDispatchQueueAsyncResponseInvocationStrategy<Result<OutputType, HTTPClientError>>(),
@@ -252,6 +254,7 @@ public extension HTTPOperationsClient {
             endpointOverride: URL? = nil,
             endpointPath: String,
             httpMethod: HTTPMethod,
+            operation: String? = nil,
             input: InputType,
             completion: @escaping (Result<OutputType, HTTPClientError>) -> (),
             asyncResponseInvocationStrategy: InvocationStrategyType,
@@ -261,7 +264,8 @@ public extension HTTPOperationsClient {
         where InputType: HTTPRequestInputProtocol, InvocationStrategyType: AsyncResponseInvocationStrategy,
         InvocationStrategyType.OutputType == Result<OutputType, HTTPClientError>,
         OutputType: HTTPResponseOutputProtocol {
-            let wrappingInvocationContext = invocationContext.withOutgoingRequestIdLoggerMetadata()
+            let endpoint = getEndpoint(endpointOverride: endpointOverride, path: endpointPath)
+            let wrappingInvocationContext = invocationContext.withOutgoingDecoratedLogger(endpoint: endpoint, outgoingOperation: operation)
         
             // use the specified event loop or pick one for the client to use for all retry attempts
             let eventLoop = invocationContext.reporting.eventLoop ?? self.eventLoopGroup.next()

--- a/Sources/SmokeHTTPClient/HTTPOperationsClient +executeAsyncWithOutput.swift
+++ b/Sources/SmokeHTTPClient/HTTPOperationsClient +executeAsyncWithOutput.swift
@@ -42,6 +42,7 @@ public extension HTTPOperationsClient {
             endpointOverride: URL? = nil,
             endpointPath: String,
             httpMethod: HTTPMethod,
+            operation: String? = nil,
             input: InputType,
             completion: @escaping (Result<OutputType, HTTPClientError>) -> (),
             invocationContext: HTTPClientInvocationContext<InvocationReportingType, HandlerDelegateType>) throws -> EventLoopFuture<HTTPClient.Response>
@@ -50,6 +51,7 @@ public extension HTTPOperationsClient {
                 endpointOverride: endpointOverride,
                 endpointPath: endpointPath,
                 httpMethod: httpMethod,
+                operation: operation,
                 input: input,
                 completion: completion,
                 asyncResponseInvocationStrategy: GlobalDispatchQueueAsyncResponseInvocationStrategy<Result<OutputType, HTTPClientError>>(),
@@ -72,6 +74,7 @@ public extension HTTPOperationsClient {
             endpointOverride: URL? = nil,
             endpointPath: String,
             httpMethod: HTTPMethod,
+            operation: String? = nil,
             input: InputType,
             completion: @escaping (Result<OutputType, HTTPClientError>) -> (),
             asyncResponseInvocationStrategy: InvocationStrategyType,
@@ -79,7 +82,8 @@ public extension HTTPOperationsClient {
             where InputType: HTTPRequestInputProtocol, InvocationStrategyType: AsyncResponseInvocationStrategy,
         InvocationStrategyType.OutputType == Result<OutputType, HTTPClientError>,
         OutputType: HTTPResponseOutputProtocol {
-            let wrappingInvocationContext = invocationContext.withOutgoingRequestIdLoggerMetadata()
+            let endpoint = getEndpoint(endpointOverride: endpointOverride, path: endpointPath)
+            let wrappingInvocationContext = invocationContext.withOutgoingDecoratedLogger(endpoint: endpoint, outgoingOperation: operation)
             
             return try executeAsyncWithOutputWithWrappedInvocationContext(
                 endpointOverride: endpointOverride,

--- a/Sources/SmokeHTTPClient/HTTPOperationsClient +executeAsyncWithoutOutput.swift
+++ b/Sources/SmokeHTTPClient/HTTPOperationsClient +executeAsyncWithoutOutput.swift
@@ -41,6 +41,7 @@ public extension HTTPOperationsClient {
         endpointOverride: URL? = nil,
         endpointPath: String,
         httpMethod: HTTPMethod,
+        operation: String? = nil,
         input: InputType,
         completion: @escaping (HTTPClientError?) -> (),
         invocationContext: HTTPClientInvocationContext<InvocationReportingType, HandlerDelegateType>) throws -> EventLoopFuture<HTTPClient.Response>
@@ -49,6 +50,7 @@ public extension HTTPOperationsClient {
                 endpointOverride: endpointOverride,
                 endpointPath: endpointPath,
                 httpMethod: httpMethod,
+                operation: operation,
                 input: input,
                 completion: completion,
                 asyncResponseInvocationStrategy: GlobalDispatchQueueAsyncResponseInvocationStrategy<HTTPClientError?>(),
@@ -71,13 +73,15 @@ public extension HTTPOperationsClient {
         endpointOverride: URL? = nil,
         endpointPath: String,
         httpMethod: HTTPMethod,
+        operation: String? = nil,
         input: InputType,
         completion: @escaping (HTTPClientError?) -> (),
         asyncResponseInvocationStrategy: InvocationStrategyType,
         invocationContext: HTTPClientInvocationContext<InvocationReportingType, HandlerDelegateType>) throws -> EventLoopFuture<HTTPClient.Response>
         where InputType: HTTPRequestInputProtocol, InvocationStrategyType: AsyncResponseInvocationStrategy,
         InvocationStrategyType.OutputType == HTTPClientError? {
-            let wrappingInvocationContext = invocationContext.withOutgoingRequestIdLoggerMetadata()
+            let endpoint = getEndpoint(endpointOverride: endpointOverride, path: endpointPath)
+            let wrappingInvocationContext = invocationContext.withOutgoingDecoratedLogger(endpoint: endpoint, outgoingOperation: operation)
             
             return try executeAsyncWithoutOutputWithWrappedInvocationContext(
                 endpointOverride: endpointOverride,

--- a/Sources/SmokeHTTPClient/HTTPOperationsClient +executeSyncRetriableWithOutput.swift
+++ b/Sources/SmokeHTTPClient/HTTPOperationsClient +executeSyncRetriableWithOutput.swift
@@ -205,13 +205,15 @@ public extension HTTPOperationsClient {
         endpointOverride: URL? = nil,
         endpointPath: String,
         httpMethod: HTTPMethod,
+        operation: String? = nil,
         input: InputType,
         invocationContext: HTTPClientInvocationContext<InvocationReportingType, HandlerDelegateType>,
         retryConfiguration: HTTPClientRetryConfiguration,
         retryOnError: @escaping (HTTPClientError) -> Bool) throws -> OutputType
         where InputType: HTTPRequestInputProtocol,
         OutputType: HTTPResponseOutputProtocol {
-            let wrappingInvocationContext = invocationContext.withOutgoingRequestIdLoggerMetadata()
+            let endpoint = getEndpoint(endpointOverride: endpointOverride, path: endpointPath)
+            let wrappingInvocationContext = invocationContext.withOutgoingDecoratedLogger(endpoint: endpoint, outgoingOperation: operation)
         
             // use the specified event loop or pick one for the client to use for all retry attempts
             let eventLoop = invocationContext.reporting.eventLoop ?? self.eventLoopGroup.next()
@@ -233,13 +235,15 @@ public extension HTTPOperationsClient {
         endpointOverride: URL? = nil,
         endpointPath: String,
         httpMethod: HTTPMethod,
+        operation: String? = nil,
         input: InputType,
         invocationContext: HTTPClientInvocationContext<InvocationReportingType, HandlerDelegateType>,
         retryConfiguration: HTTPClientRetryConfiguration,
         retryOnError: @escaping (Swift.Error) -> Bool) throws -> OutputType
         where InputType: HTTPRequestInputProtocol,
         OutputType: HTTPResponseOutputProtocol {
-            let wrappingInvocationContext = invocationContext.withOutgoingRequestIdLoggerMetadata()
+            let endpoint = getEndpoint(endpointOverride: endpointOverride, path: endpointPath)
+            let wrappingInvocationContext = invocationContext.withOutgoingDecoratedLogger(endpoint: endpoint, outgoingOperation: operation)
         
             // use the specified event loop or pick one for the client to use for all retry attempts
             let eventLoop = invocationContext.reporting.eventLoop ?? self.eventLoopGroup.next()

--- a/Sources/SmokeHTTPClient/HTTPOperationsClient +executeSyncRetriableWithoutOutput.swift
+++ b/Sources/SmokeHTTPClient/HTTPOperationsClient +executeSyncRetriableWithoutOutput.swift
@@ -207,12 +207,14 @@ public extension HTTPOperationsClient {
         endpointOverride: URL? = nil,
         endpointPath: String,
         httpMethod: HTTPMethod,
+        operation: String? = nil,
         input: InputType,
         invocationContext: HTTPClientInvocationContext<InvocationReportingType, HandlerDelegateType>,
         retryConfiguration: HTTPClientRetryConfiguration,
         retryOnError: @escaping (HTTPClientError) -> Bool) throws
         where InputType: HTTPRequestInputProtocol {
-            let wrappingInvocationContext = invocationContext.withOutgoingRequestIdLoggerMetadata()
+            let endpoint = getEndpoint(endpointOverride: endpointOverride, path: endpointPath)
+            let wrappingInvocationContext = invocationContext.withOutgoingDecoratedLogger(endpoint: endpoint, outgoingOperation: operation)
         
             // use the specified event loop or pick one for the client to use for all retry attempts
             let eventLoop = invocationContext.reporting.eventLoop ?? self.eventLoopGroup.next()
@@ -233,12 +235,14 @@ public extension HTTPOperationsClient {
         endpointOverride: URL? = nil,
         endpointPath: String,
         httpMethod: HTTPMethod,
+        operation: String? = nil,
         input: InputType,
         invocationContext: HTTPClientInvocationContext<InvocationReportingType, HandlerDelegateType>,
         retryConfiguration: HTTPClientRetryConfiguration,
         retryOnError: @escaping (Swift.Error) -> Bool) throws
         where InputType: HTTPRequestInputProtocol {
-            let wrappingInvocationContext = invocationContext.withOutgoingRequestIdLoggerMetadata()
+            let endpoint = getEndpoint(endpointOverride: endpointOverride, path: endpointPath)
+            let wrappingInvocationContext = invocationContext.withOutgoingDecoratedLogger(endpoint: endpoint, outgoingOperation: operation)
         
             // use the specified event loop or pick one for the client to use for all retry attempts
             let eventLoop = invocationContext.reporting.eventLoop ?? self.eventLoopGroup.next()

--- a/Sources/SmokeHTTPClient/HTTPOperationsClient +executeSyncWithOutput.swift
+++ b/Sources/SmokeHTTPClient/HTTPOperationsClient +executeSyncWithOutput.swift
@@ -38,11 +38,13 @@ public extension HTTPOperationsClient {
         endpointOverride: URL? = nil,
         endpointPath: String,
         httpMethod: HTTPMethod,
+        operation: String? = nil,
         input: InputType,
         invocationContext: HTTPClientInvocationContext<InvocationReportingType, HandlerDelegateType>) throws -> OutputType
         where InputType: HTTPRequestInputProtocol,
         OutputType: HTTPResponseOutputProtocol {
-            let wrappingInvocationContext = invocationContext.withOutgoingRequestIdLoggerMetadata()
+            let endpoint = getEndpoint(endpointOverride: endpointOverride, path: endpointPath)
+            let wrappingInvocationContext = invocationContext.withOutgoingDecoratedLogger(endpoint: endpoint, outgoingOperation: operation)
             
             return try executeSyncWithOutputWithWrappedInvocationContext(
                 endpointOverride: endpointOverride,

--- a/Sources/SmokeHTTPClient/HTTPOperationsClient +executeSyncWithoutOutput.swift
+++ b/Sources/SmokeHTTPClient/HTTPOperationsClient +executeSyncWithoutOutput.swift
@@ -38,10 +38,12 @@ public extension HTTPOperationsClient {
         endpointOverride: URL? = nil,
         endpointPath: String,
         httpMethod: HTTPMethod,
+        operation: String? = nil,
         input: InputType,
         invocationContext: HTTPClientInvocationContext<InvocationReportingType, HandlerDelegateType>) throws
         where InputType: HTTPRequestInputProtocol {
-            let wrappingInvocationContext = invocationContext.withOutgoingRequestIdLoggerMetadata()
+            let endpoint = getEndpoint(endpointOverride: endpointOverride, path: endpointPath)
+            let wrappingInvocationContext = invocationContext.withOutgoingDecoratedLogger(endpoint: endpoint, outgoingOperation: operation)
         
             try executeSyncWithoutOutputWithWrappedInvocationContext(
                 endpointOverride: endpointOverride,

--- a/Sources/SmokeHTTPClient/HTTPOperationsClient+executeAsEventLoopFutureRetriableWithOutput.swift
+++ b/Sources/SmokeHTTPClient/HTTPOperationsClient+executeAsEventLoopFutureRetriableWithOutput.swift
@@ -224,12 +224,14 @@ public extension HTTPOperationsClient {
             endpointOverride: URL? = nil,
             endpointPath: String,
             httpMethod: HTTPMethod,
+            operation: String? = nil,
             input: InputType,
             invocationContext: HTTPClientInvocationContext<InvocationReportingType, HandlerDelegateType>,
             retryConfiguration: HTTPClientRetryConfiguration,
             retryOnError: @escaping (HTTPClientError) -> Bool) -> EventLoopFuture<OutputType>
         where InputType: HTTPRequestInputProtocol, OutputType: HTTPResponseOutputProtocol {
-            let wrappingInvocationContext = invocationContext.withOutgoingRequestIdLoggerMetadata()
+            let endpoint = getEndpoint(endpointOverride: endpointOverride, path: endpointPath)
+            let wrappingInvocationContext = invocationContext.withOutgoingDecoratedLogger(endpoint: endpoint, outgoingOperation: operation)
         
             // use the specified event loop or pick one for the client to use for all retry attempts
             let eventLoop = invocationContext.reporting.eventLoop ?? self.eventLoopGroup.next()

--- a/Sources/SmokeHTTPClient/HTTPOperationsClient+executeAsEventLoopFutureRetriableWithoutOutput.swift
+++ b/Sources/SmokeHTTPClient/HTTPOperationsClient+executeAsEventLoopFutureRetriableWithoutOutput.swift
@@ -224,12 +224,14 @@ public extension HTTPOperationsClient {
             endpointOverride: URL? = nil,
             endpointPath: String,
             httpMethod: HTTPMethod,
+            operation: String? = nil,
             input: InputType,
             invocationContext: HTTPClientInvocationContext<InvocationReportingType, HandlerDelegateType>,
             retryConfiguration: HTTPClientRetryConfiguration,
             retryOnError: @escaping (HTTPClientError) -> Bool) -> EventLoopFuture<Void>
         where InputType: HTTPRequestInputProtocol {
-            let wrappingInvocationContext = invocationContext.withOutgoingRequestIdLoggerMetadata()
+            let endpoint = getEndpoint(endpointOverride: endpointOverride, path: endpointPath)
+            let wrappingInvocationContext = invocationContext.withOutgoingDecoratedLogger(endpoint: endpoint, outgoingOperation: operation)
         
             // use the specified event loop or pick one for the client to use for all retry attempts
             let eventLoop = invocationContext.reporting.eventLoop ?? self.eventLoopGroup.next()

--- a/Sources/SmokeHTTPClient/HTTPOperationsClient+executeAsEventLoopFutureWithOutput.swift
+++ b/Sources/SmokeHTTPClient/HTTPOperationsClient+executeAsEventLoopFutureWithOutput.swift
@@ -56,10 +56,12 @@ public extension HTTPOperationsClient {
             endpointOverride: URL? = nil,
             endpointPath: String,
             httpMethod: HTTPMethod,
+            operation: String? = nil,
             input: InputType,
-            invocationContext: HTTPClientInvocationContext<InvocationReportingType, HandlerDelegateType>) -> EventLoopFuture<OutputType>
-            where InputType: HTTPRequestInputProtocol, OutputType: HTTPResponseOutputProtocol {
-            let wrappingInvocationContext = invocationContext.withOutgoingRequestIdLoggerMetadata()
+            invocationContext: HTTPClientInvocationContext<InvocationReportingType, HandlerDelegateType>)
+    -> EventLoopFuture<OutputType> where InputType: HTTPRequestInputProtocol, OutputType: HTTPResponseOutputProtocol {
+            let endpoint = getEndpoint(endpointOverride: endpointOverride, path: endpointPath)
+            let wrappingInvocationContext = invocationContext.withOutgoingDecoratedLogger(endpoint: endpoint, outgoingOperation: operation)
             
             return executeAsEventLoopFutureWithOutputWithWrappedInvocationContext(
                 endpointOverride: endpointOverride,

--- a/Sources/SmokeHTTPClient/HTTPOperationsClient+executeAsEventLoopFutureWithoutOutput.swift
+++ b/Sources/SmokeHTTPClient/HTTPOperationsClient+executeAsEventLoopFutureWithoutOutput.swift
@@ -57,10 +57,12 @@ public extension HTTPOperationsClient {
         endpointOverride: URL? = nil,
         endpointPath: String,
         httpMethod: HTTPMethod,
+        operation: String? = nil,
         input: InputType,
         invocationContext: HTTPClientInvocationContext<InvocationReportingType, HandlerDelegateType>) -> EventLoopFuture<Void>
         where InputType: HTTPRequestInputProtocol {
-            let wrappingInvocationContext = invocationContext.withOutgoingRequestIdLoggerMetadata()
+            let endpoint = getEndpoint(endpointOverride: endpointOverride, path: endpointPath)
+            let wrappingInvocationContext = invocationContext.withOutgoingDecoratedLogger(endpoint: endpoint, outgoingOperation: operation)
             
             return executeAsEventLoopFutureWithoutOutputWithWrappedInvocationContext(
                 endpointOverride: endpointOverride,

--- a/Sources/SmokeHTTPClient/HTTPOperationsClient+executeAsyncRetriableWithoutOutput.swift
+++ b/Sources/SmokeHTTPClient/HTTPOperationsClient+executeAsyncRetriableWithoutOutput.swift
@@ -212,6 +212,7 @@ public extension HTTPOperationsClient {
         endpointOverride: URL? = nil,
         endpointPath: String,
         httpMethod: HTTPMethod,
+        operation: String? = nil,
         input: InputType,
         completion: @escaping (HTTPClientError?) -> (),
         invocationContext: HTTPClientInvocationContext<InvocationReportingType, HandlerDelegateType>,
@@ -222,6 +223,7 @@ public extension HTTPOperationsClient {
                 endpointOverride: endpointOverride,
                 endpointPath: endpointPath,
                 httpMethod: httpMethod,
+                operation: operation,
                 input: input,
                 completion: completion,
                 asyncResponseInvocationStrategy: GlobalDispatchQueueAsyncResponseInvocationStrategy<HTTPClientError?>(),
@@ -248,6 +250,7 @@ public extension HTTPOperationsClient {
         endpointOverride: URL? = nil,
         endpointPath: String,
         httpMethod: HTTPMethod,
+        operation: String? = nil,
         input: InputType,
         completion: @escaping (HTTPClientError?) -> (),
         asyncResponseInvocationStrategy: InvocationStrategyType,
@@ -256,7 +259,8 @@ public extension HTTPOperationsClient {
         retryOnError: @escaping (HTTPClientError) -> Bool) throws
         where InputType: HTTPRequestInputProtocol, InvocationStrategyType: AsyncResponseInvocationStrategy,
         InvocationStrategyType.OutputType == HTTPClientError? {
-            let wrappingInvocationContext = invocationContext.withOutgoingRequestIdLoggerMetadata()
+            let endpoint = getEndpoint(endpointOverride: endpointOverride, path: endpointPath)
+            let wrappingInvocationContext = invocationContext.withOutgoingDecoratedLogger(endpoint: endpoint, outgoingOperation: operation)
         
             // use the specified event loop or pick one for the client to use for all retry attempts
             let eventLoop = invocationContext.reporting.eventLoop ?? self.eventLoopGroup.next()

--- a/Sources/SmokeHTTPClient/HTTPOperationsClient+executeRetriableWithOutput.swift
+++ b/Sources/SmokeHTTPClient/HTTPOperationsClient+executeRetriableWithOutput.swift
@@ -223,12 +223,14 @@ public extension HTTPOperationsClient {
         endpointOverride: URL? = nil,
         endpointPath: String,
         httpMethod: HTTPMethod,
+        operation: String? = nil,
         input: InputType,
         invocationContext: HTTPClientInvocationContext<InvocationReportingType, HandlerDelegateType>,
         retryConfiguration: HTTPClientRetryConfiguration,
         retryOnError: @escaping (HTTPClientError) -> Bool) async throws -> OutputType
     where InputType: HTTPRequestInputProtocol, OutputType: HTTPResponseOutputProtocol {
-        let wrappingInvocationContext = invocationContext.withOutgoingRequestIdLoggerMetadata()
+        let endpoint = getEndpoint(endpointOverride: endpointOverride, path: endpointPath)
+        let wrappingInvocationContext = invocationContext.withOutgoingDecoratedLogger(endpoint: endpoint, outgoingOperation: operation)
     
         // use the specified event loop or pick one for the client to use for all retry attempts
         let eventLoop = invocationContext.reporting.eventLoop ?? self.eventLoopGroup.next()

--- a/Sources/SmokeHTTPClient/HTTPOperationsClient+executeRetriableWithoutOutput.swift
+++ b/Sources/SmokeHTTPClient/HTTPOperationsClient+executeRetriableWithoutOutput.swift
@@ -201,12 +201,14 @@ public extension HTTPOperationsClient {
         endpointOverride: URL? = nil,
         endpointPath: String,
         httpMethod: HTTPMethod,
+        operation: String? = nil,
         input: InputType,
         invocationContext: HTTPClientInvocationContext<InvocationReportingType, HandlerDelegateType>,
         retryConfiguration: HTTPClientRetryConfiguration,
         retryOnError: @escaping (HTTPClientError) -> Bool) async throws
     where InputType: HTTPRequestInputProtocol {
-        let wrappingInvocationContext = invocationContext.withOutgoingRequestIdLoggerMetadata()
+        let endpoint = getEndpoint(endpointOverride: endpointOverride, path: endpointPath)
+        let wrappingInvocationContext = invocationContext.withOutgoingDecoratedLogger(endpoint: endpoint, outgoingOperation: operation)
     
         // use the specified event loop or pick one for the client to use for all retry attempts
         let eventLoop = invocationContext.reporting.eventLoop ?? self.eventLoopGroup.next()

--- a/Sources/SmokeHTTPClient/HTTPOperationsClient+executeWithOutput.swift
+++ b/Sources/SmokeHTTPClient/HTTPOperationsClient+executeWithOutput.swift
@@ -42,10 +42,12 @@ public extension HTTPOperationsClient {
         endpointOverride: URL? = nil,
         endpointPath: String,
         httpMethod: HTTPMethod,
+        operation: String? = nil,
         input: InputType,
         invocationContext: HTTPClientInvocationContext<InvocationReportingType, HandlerDelegateType>) async throws -> OutputType
     where InputType: HTTPRequestInputProtocol, OutputType: HTTPResponseOutputProtocol {
-        let wrappingInvocationContext = invocationContext.withOutgoingRequestIdLoggerMetadata()
+        let endpoint = getEndpoint(endpointOverride: endpointOverride, path: endpointPath)
+        let wrappingInvocationContext = invocationContext.withOutgoingDecoratedLogger(endpoint: endpoint, outgoingOperation: operation)
         
         return try await executeWithOutputWithWrappedInvocationContext(
             endpointOverride: endpointOverride,

--- a/Sources/SmokeHTTPClient/HTTPOperationsClient+executeWithoutOutput.swift
+++ b/Sources/SmokeHTTPClient/HTTPOperationsClient+executeWithoutOutput.swift
@@ -41,10 +41,12 @@ public extension HTTPOperationsClient {
         endpointOverride: URL? = nil,
         endpointPath: String,
         httpMethod: HTTPMethod,
+        operation: String? = nil,
         input: InputType,
         invocationContext: HTTPClientInvocationContext<InvocationReportingType, HandlerDelegateType>) async throws
     where InputType: HTTPRequestInputProtocol {
-        let wrappingInvocationContext = invocationContext.withOutgoingRequestIdLoggerMetadata()
+        let endpoint = getEndpoint(endpointOverride: endpointOverride, path: endpointPath)
+        let wrappingInvocationContext = invocationContext.withOutgoingDecoratedLogger(endpoint: endpoint, outgoingOperation: operation)
         
         return try await executeWithoutOutputWithWrappedInvocationContext(
             endpointOverride: endpointOverride,

--- a/Sources/SmokeHTTPClient/HTTPOperationsClient.swift
+++ b/Sources/SmokeHTTPClient/HTTPOperationsClient.swift
@@ -55,6 +55,16 @@ public struct HTTPOperationsClient {
         return self.wrappedHttpClient.eventLoopGroup
     }
     
+    internal func getEndpoint(endpointOverride: URL?, path: String) -> URL? {
+        var components = URLComponents()
+        components.scheme = self.endpointScheme
+        components.host = endpointOverride?.host ?? self.endpointHostName
+        components.port = endpointOverride?.port ?? self.endpointPort
+        components.path = path
+        
+        return components.url
+    }
+    
     /**
      Initializer.
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
1. Decorate request logger with endpoint and operation; adds "outgoingEndpoint" and "outgoingOperation" as metadata on the logger.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
