### PR TITLE
Encode the endpoint path prior to decorating the log context

### DIFF
--- a/Sources/SmokeHTTPClient/HTTPOperationsClient +executeAsyncRetriableWithOutput.swift
+++ b/Sources/SmokeHTTPClient/HTTPOperationsClient +executeAsyncRetriableWithOutput.swift
@@ -261,10 +261,14 @@ public extension HTTPOperationsClient {
             invocationContext: HTTPClientInvocationContext<InvocationReportingType, HandlerDelegateType>,
             retryConfiguration: HTTPClientRetryConfiguration,
             retryOnError: @escaping (HTTPClientError) -> Bool) throws
-        where InputType: HTTPRequestInputProtocol, InvocationStrategyType: AsyncResponseInvocationStrategy,
+    where InputType: HTTPRequestInputProtocol, InvocationStrategyType: AsyncResponseInvocationStrategy,
         InvocationStrategyType.OutputType == Result<OutputType, HTTPClientError>,
         OutputType: HTTPResponseOutputProtocol {
-            let endpoint = getEndpoint(endpointOverride: endpointOverride, path: endpointPath)
+            let endpoint = try getEndpoint(
+                endpointOverride: endpointOverride,
+                path: endpointPath,
+                input: input,
+                invocationReporting: invocationContext.reporting)
             let wrappingInvocationContext = invocationContext.withOutgoingDecoratedLogger(endpoint: endpoint, outgoingOperation: operation)
         
             // use the specified event loop or pick one for the client to use for all retry attempts

--- a/Sources/SmokeHTTPClient/HTTPOperationsClient +executeAsyncRetriableWithOutput.swift
+++ b/Sources/SmokeHTTPClient/HTTPOperationsClient +executeAsyncRetriableWithOutput.swift
@@ -27,15 +27,14 @@ public extension HTTPOperationsClient {
     /**
      Helper type that manages the state of a retriable async request.
      */
-    private class ExecuteAsyncWithOutputRetriable<InputType, OutputType, InvocationStrategyType,
+    private class ExecuteAsyncWithOutputRetriable<OutputType, InvocationStrategyType,
         InvocationReportingType: HTTPClientInvocationReporting, HandlerDelegateType: HTTPClientInvocationDelegate>
-            where InputType: HTTPRequestInputProtocol, InvocationStrategyType: AsyncResponseInvocationStrategy,
+            where InvocationStrategyType: AsyncResponseInvocationStrategy,
             InvocationStrategyType.OutputType == Result<OutputType, HTTPClientError>,
             OutputType: HTTPResponseOutputProtocol {
         let endpointOverride: URL?
-        let endpointPath: String
+        let requestComponents: HTTPRequestComponents
         let httpMethod: HTTPMethod
-        let input: InputType
         let outerCompletion: (Result<OutputType, HTTPClientError>) -> ()
         let asyncResponseInvocationStrategy: InvocationStrategyType
         let invocationContext: HTTPClientInvocationContext<InvocationReportingType, HandlerDelegateType>
@@ -51,8 +50,8 @@ public extension HTTPOperationsClient {
         
         var retriesRemaining: Int
         
-        init(endpointOverride: URL?, endpointPath: String, httpMethod: HTTPMethod,
-             input: InputType, outerCompletion: @escaping (Result<OutputType, HTTPClientError>) -> (),
+        init(endpointOverride: URL?, requestComponents: HTTPRequestComponents, httpMethod: HTTPMethod,
+             outerCompletion: @escaping (Result<OutputType, HTTPClientError>) -> (),
              asyncResponseInvocationStrategy: InvocationStrategyType,
              invocationContext: HTTPClientInvocationContext<InvocationReportingType, HandlerDelegateType>,
              eventLoopOverride eventLoop: EventLoop,
@@ -60,9 +59,8 @@ public extension HTTPOperationsClient {
              retryConfiguration: HTTPClientRetryConfiguration,
              retryOnError: @escaping (HTTPClientError) -> Bool) {
             self.endpointOverride = endpointOverride
-            self.endpointPath = endpointPath
+            self.requestComponents = requestComponents
             self.httpMethod = httpMethod
-            self.input = input
             self.outerCompletion = outerCompletion
             self.asyncResponseInvocationStrategy = asyncResponseInvocationStrategy
             self.invocationContext = invocationContext
@@ -97,8 +95,9 @@ public extension HTTPOperationsClient {
             // submit the asynchronous request
             _ = try httpClient.executeAsyncWithOutputWithWrappedInvocationContext(
                 endpointOverride: endpointOverride,
-                endpointPath: endpointPath, httpMethod: httpMethod,
-                input: input, completion: completion,
+                requestComponents: requestComponents,
+                httpMethod: httpMethod,
+                completion: completion,
                 asyncResponseInvocationStrategy: asyncResponseInvocationStrategy,
                 invocationContext: innerInvocationContext)
         }
@@ -264,19 +263,19 @@ public extension HTTPOperationsClient {
     where InputType: HTTPRequestInputProtocol, InvocationStrategyType: AsyncResponseInvocationStrategy,
         InvocationStrategyType.OutputType == Result<OutputType, HTTPClientError>,
         OutputType: HTTPResponseOutputProtocol {
-            let endpoint = try getEndpoint(
-                endpointOverride: endpointOverride,
-                path: endpointPath,
+            let requestComponents = try clientDelegate.encodeInputAndQueryString(
                 input: input,
+                httpPath: endpointPath,
                 invocationReporting: invocationContext.reporting)
+            let endpoint = getEndpoint(endpointOverride: endpointOverride, path: requestComponents.pathWithQuery)
             let wrappingInvocationContext = invocationContext.withOutgoingDecoratedLogger(endpoint: endpoint, outgoingOperation: operation)
         
             // use the specified event loop or pick one for the client to use for all retry attempts
             let eventLoop = invocationContext.reporting.eventLoop ?? self.eventLoopGroup.next()
             
             let retriable = ExecuteAsyncWithOutputRetriable(
-                endpointOverride: endpointOverride, endpointPath: endpointPath,
-                httpMethod: httpMethod, input: input, outerCompletion: completion,
+                endpointOverride: endpointOverride, requestComponents: requestComponents,
+                httpMethod: httpMethod, outerCompletion: completion,
                 asyncResponseInvocationStrategy: asyncResponseInvocationStrategy,
                 invocationContext: wrappingInvocationContext, eventLoopOverride: eventLoop, httpClient: self,
                 retryConfiguration: retryConfiguration,

--- a/Sources/SmokeHTTPClient/HTTPOperationsClient +executeAsyncWithOutput.swift
+++ b/Sources/SmokeHTTPClient/HTTPOperationsClient +executeAsyncWithOutput.swift
@@ -82,21 +82,52 @@ public extension HTTPOperationsClient {
     where InputType: HTTPRequestInputProtocol, InvocationStrategyType: AsyncResponseInvocationStrategy,
         InvocationStrategyType.OutputType == Result<OutputType, HTTPClientError>,
         OutputType: HTTPResponseOutputProtocol {
-            let endpoint = try getEndpoint(
-                endpointOverride: endpointOverride,
-                path: endpointPath,
+            let requestComponents = try clientDelegate.encodeInputAndQueryString(
                 input: input,
+                httpPath: endpointPath,
                 invocationReporting: invocationContext.reporting)
+            let endpoint = getEndpoint(endpointOverride: endpointOverride, path: requestComponents.pathWithQuery)
             let wrappingInvocationContext = invocationContext.withOutgoingDecoratedLogger(endpoint: endpoint, outgoingOperation: operation)
             
-            return try executeAsyncWithOutputWithWrappedInvocationContext(
+            return try executeAsyncWithOutput(
                 endpointOverride: endpointOverride,
-                endpointPath: endpointPath,
+                requestComponents: requestComponents,
                 httpMethod: httpMethod,
-                input: input,
                 completion: completion,
                 asyncResponseInvocationStrategy: asyncResponseInvocationStrategy,
                 invocationContext: wrappingInvocationContext)
+    }
+
+    /**
+     Submits a request that will return a response body to this client asynchronously.
+
+     - Parameters:
+         - requestComponents: The request components for this request.
+         - httpMethod: The http method to use for this request.
+         - input: the input body data to send with this request.
+         - completion: Completion handler called with the response body or any error.
+         - asyncResponseInvocationStrategy: The invocation strategy for the response from this request.
+         - invocationContext: context to use for this invocation.
+     */
+    internal func executeAsyncWithOutput<OutputType, InvocationStrategyType,
+        InvocationReportingType: HTTPClientInvocationReporting, HandlerDelegateType: HTTPClientInvocationDelegate>(
+            endpointOverride: URL? = nil,
+            requestComponents: HTTPRequestComponents,
+            httpMethod: HTTPMethod,
+            operation: String? = nil,
+            completion: @escaping (Result<OutputType, HTTPClientError>) -> (),
+            asyncResponseInvocationStrategy: InvocationStrategyType,
+            invocationContext: HTTPClientInvocationContext<InvocationReportingType, HandlerDelegateType>) throws -> EventLoopFuture<HTTPClient.Response>
+    where InvocationStrategyType: AsyncResponseInvocationStrategy,
+        InvocationStrategyType.OutputType == Result<OutputType, HTTPClientError>,
+        OutputType: HTTPResponseOutputProtocol {            
+            return try executeAsyncWithOutputWithWrappedInvocationContext(
+                endpointOverride: endpointOverride,
+                requestComponents: requestComponents,
+                httpMethod: httpMethod,
+                completion: completion,
+                asyncResponseInvocationStrategy: asyncResponseInvocationStrategy,
+                invocationContext: invocationContext)
     }
 
     /**
@@ -110,16 +141,15 @@ public extension HTTPOperationsClient {
          - asyncResponseInvocationStrategy: The invocation strategy for the response from this request.
          - invocationContext: context to use for this invocation.
      */
-    internal func executeAsyncWithOutputWithWrappedInvocationContext<InputType, OutputType, InvocationStrategyType,
+    internal func executeAsyncWithOutputWithWrappedInvocationContext<OutputType, InvocationStrategyType,
         InvocationReportingType: HTTPClientInvocationReporting, HandlerDelegateType: HTTPClientInvocationDelegate>(
             endpointOverride: URL? = nil,
-            endpointPath: String,
+            requestComponents: HTTPRequestComponents,
             httpMethod: HTTPMethod,
-            input: InputType,
             completion: @escaping (Result<OutputType, HTTPClientError>) -> (),
             asyncResponseInvocationStrategy: InvocationStrategyType,
             invocationContext: HTTPClientInvocationContext<InvocationReportingType, HandlerDelegateType>) throws -> EventLoopFuture<HTTPClient.Response>
-            where InputType: HTTPRequestInputProtocol, InvocationStrategyType: AsyncResponseInvocationStrategy,
+            where InvocationStrategyType: AsyncResponseInvocationStrategy,
         InvocationStrategyType.OutputType == Result<OutputType, HTTPClientError>,
         OutputType: HTTPResponseOutputProtocol {
             
@@ -193,10 +223,9 @@ public extension HTTPOperationsClient {
 
         // submit the asynchronous request
         return try executeAsync(endpointOverride: endpointOverride,
-                                             endpointPath: endpointPath,
-                                             httpMethod: httpMethod,
-                                             input: input,
-                                             completion: wrappingCompletion,
-                                             invocationContext: invocationContext)
+                                requestComponents: requestComponents,
+                                httpMethod: httpMethod,
+                                completion: wrappingCompletion,
+                                invocationContext: invocationContext)
     }
 }

--- a/Sources/SmokeHTTPClient/HTTPOperationsClient +executeAsyncWithOutput.swift
+++ b/Sources/SmokeHTTPClient/HTTPOperationsClient +executeAsyncWithOutput.swift
@@ -89,45 +89,13 @@ public extension HTTPOperationsClient {
             let endpoint = getEndpoint(endpointOverride: endpointOverride, path: requestComponents.pathWithQuery)
             let wrappingInvocationContext = invocationContext.withOutgoingDecoratedLogger(endpoint: endpoint, outgoingOperation: operation)
             
-            return try executeAsyncWithOutput(
-                endpointOverride: endpointOverride,
-                requestComponents: requestComponents,
-                httpMethod: httpMethod,
-                completion: completion,
-                asyncResponseInvocationStrategy: asyncResponseInvocationStrategy,
-                invocationContext: wrappingInvocationContext)
-    }
-
-    /**
-     Submits a request that will return a response body to this client asynchronously.
-
-     - Parameters:
-         - requestComponents: The request components for this request.
-         - httpMethod: The http method to use for this request.
-         - input: the input body data to send with this request.
-         - completion: Completion handler called with the response body or any error.
-         - asyncResponseInvocationStrategy: The invocation strategy for the response from this request.
-         - invocationContext: context to use for this invocation.
-     */
-    internal func executeAsyncWithOutput<OutputType, InvocationStrategyType,
-        InvocationReportingType: HTTPClientInvocationReporting, HandlerDelegateType: HTTPClientInvocationDelegate>(
-            endpointOverride: URL? = nil,
-            requestComponents: HTTPRequestComponents,
-            httpMethod: HTTPMethod,
-            operation: String? = nil,
-            completion: @escaping (Result<OutputType, HTTPClientError>) -> (),
-            asyncResponseInvocationStrategy: InvocationStrategyType,
-            invocationContext: HTTPClientInvocationContext<InvocationReportingType, HandlerDelegateType>) throws -> EventLoopFuture<HTTPClient.Response>
-    where InvocationStrategyType: AsyncResponseInvocationStrategy,
-        InvocationStrategyType.OutputType == Result<OutputType, HTTPClientError>,
-        OutputType: HTTPResponseOutputProtocol {            
             return try executeAsyncWithOutputWithWrappedInvocationContext(
                 endpointOverride: endpointOverride,
                 requestComponents: requestComponents,
                 httpMethod: httpMethod,
                 completion: completion,
                 asyncResponseInvocationStrategy: asyncResponseInvocationStrategy,
-                invocationContext: invocationContext)
+                invocationContext: wrappingInvocationContext)
     }
 
     /**

--- a/Sources/SmokeHTTPClient/HTTPOperationsClient +executeAsyncWithOutput.swift
+++ b/Sources/SmokeHTTPClient/HTTPOperationsClient +executeAsyncWithOutput.swift
@@ -79,10 +79,14 @@ public extension HTTPOperationsClient {
             completion: @escaping (Result<OutputType, HTTPClientError>) -> (),
             asyncResponseInvocationStrategy: InvocationStrategyType,
             invocationContext: HTTPClientInvocationContext<InvocationReportingType, HandlerDelegateType>) throws -> EventLoopFuture<HTTPClient.Response>
-            where InputType: HTTPRequestInputProtocol, InvocationStrategyType: AsyncResponseInvocationStrategy,
+    where InputType: HTTPRequestInputProtocol, InvocationStrategyType: AsyncResponseInvocationStrategy,
         InvocationStrategyType.OutputType == Result<OutputType, HTTPClientError>,
         OutputType: HTTPResponseOutputProtocol {
-            let endpoint = getEndpoint(endpointOverride: endpointOverride, path: endpointPath)
+            let endpoint = try getEndpoint(
+                endpointOverride: endpointOverride,
+                path: endpointPath,
+                input: input,
+                invocationReporting: invocationContext.reporting)
             let wrappingInvocationContext = invocationContext.withOutgoingDecoratedLogger(endpoint: endpoint, outgoingOperation: operation)
             
             return try executeAsyncWithOutputWithWrappedInvocationContext(

--- a/Sources/SmokeHTTPClient/HTTPOperationsClient +executeAsyncWithoutOutput.swift
+++ b/Sources/SmokeHTTPClient/HTTPOperationsClient +executeAsyncWithoutOutput.swift
@@ -45,7 +45,7 @@ public extension HTTPOperationsClient {
         input: InputType,
         completion: @escaping (HTTPClientError?) -> (),
         invocationContext: HTTPClientInvocationContext<InvocationReportingType, HandlerDelegateType>) throws -> EventLoopFuture<HTTPClient.Response>
-        where InputType: HTTPRequestInputProtocol {
+    where InputType: HTTPRequestInputProtocol {
             return try executeAsyncWithoutOutput(
                 endpointOverride: endpointOverride,
                 endpointPath: endpointPath,
@@ -80,21 +80,50 @@ public extension HTTPOperationsClient {
         invocationContext: HTTPClientInvocationContext<InvocationReportingType, HandlerDelegateType>) throws -> EventLoopFuture<HTTPClient.Response>
     where InputType: HTTPRequestInputProtocol, InvocationStrategyType: AsyncResponseInvocationStrategy,
         InvocationStrategyType.OutputType == HTTPClientError? {
-            let endpoint = try getEndpoint(
-                endpointOverride: endpointOverride,
-                path: endpointPath,
+            let requestComponents = try clientDelegate.encodeInputAndQueryString(
                 input: input,
+                httpPath: endpointPath,
                 invocationReporting: invocationContext.reporting)
+            let endpoint = getEndpoint(endpointOverride: endpointOverride, path: requestComponents.pathWithQuery)
             let wrappingInvocationContext = invocationContext.withOutgoingDecoratedLogger(endpoint: endpoint, outgoingOperation: operation)
             
-            return try executeAsyncWithoutOutputWithWrappedInvocationContext(
+            return try executeAsyncWithoutOutput(
                 endpointOverride: endpointOverride,
-                endpointPath: endpointPath,
+                requestComponents: requestComponents,
                 httpMethod: httpMethod,
-                input: input,
                 completion: completion,
                 asyncResponseInvocationStrategy: asyncResponseInvocationStrategy,
                 invocationContext: wrappingInvocationContext)
+    }
+
+    /**
+     Submits a request that will not return a response body to this client asynchronously.
+     
+     - Parameters:
+        - requestComponents: The request components for this request.
+        - httpMethod: The http method to use for this request.
+        - completion: Completion handler called with an error if one occurs or nil otherwise.
+        - asyncResponseInvocationStrategy: The invocation strategy for the response from this request.
+        - invocationContext: context to use for this invocation.
+     */
+    internal func executeAsyncWithoutOutput<InvocationStrategyType,
+            InvocationReportingType: HTTPClientInvocationReporting, HandlerDelegateType: HTTPClientInvocationDelegate>(
+        endpointOverride: URL? = nil,
+        requestComponents: HTTPRequestComponents,
+        httpMethod: HTTPMethod,
+        operation: String? = nil,
+        completion: @escaping (HTTPClientError?) -> (),
+        asyncResponseInvocationStrategy: InvocationStrategyType,
+        invocationContext: HTTPClientInvocationContext<InvocationReportingType, HandlerDelegateType>) throws -> EventLoopFuture<HTTPClient.Response>
+    where InvocationStrategyType: AsyncResponseInvocationStrategy,
+        InvocationStrategyType.OutputType == HTTPClientError? {
+            return try executeAsyncWithoutOutputWithWrappedInvocationContext(
+                endpointOverride: endpointOverride,
+                requestComponents: requestComponents,
+                httpMethod: httpMethod,
+                completion: completion,
+                asyncResponseInvocationStrategy: asyncResponseInvocationStrategy,
+                invocationContext: invocationContext)
     }
     
     /**
@@ -108,16 +137,15 @@ public extension HTTPOperationsClient {
         - asyncResponseInvocationStrategy: The invocation strategy for the response from this request.
         - invocationContext: context to use for this invocation.
      */
-    internal func executeAsyncWithoutOutputWithWrappedInvocationContext<InputType, InvocationStrategyType,
+    internal func executeAsyncWithoutOutputWithWrappedInvocationContext<InvocationStrategyType,
             InvocationReportingType: HTTPClientInvocationReporting, HandlerDelegateType: HTTPClientInvocationDelegate>(
         endpointOverride: URL? = nil,
-        endpointPath: String,
+        requestComponents: HTTPRequestComponents,
         httpMethod: HTTPMethod,
-        input: InputType,
         completion: @escaping (HTTPClientError?) -> (),
         asyncResponseInvocationStrategy: InvocationStrategyType,
         invocationContext: HTTPClientInvocationContext<InvocationReportingType, HandlerDelegateType>) throws -> EventLoopFuture<HTTPClient.Response>
-        where InputType: HTTPRequestInputProtocol, InvocationStrategyType: AsyncResponseInvocationStrategy,
+        where InvocationStrategyType: AsyncResponseInvocationStrategy,
         InvocationStrategyType.OutputType == HTTPClientError? {
             
             let durationMetricDetails: (Date, Metrics.Timer?, OutwardsRequestAggregator?)?
@@ -173,10 +201,9 @@ public extension HTTPOperationsClient {
             
             // submit the asynchronous request
             return try executeAsync(endpointOverride: endpointOverride,
-                                                 endpointPath: endpointPath,
-                                                 httpMethod: httpMethod,
-                                                 input: input,
-                                                 completion: wrappingCompletion,
-                                                 invocationContext: invocationContext)
+                                    requestComponents: requestComponents,
+                                    httpMethod: httpMethod,
+                                    completion: wrappingCompletion,
+                                    invocationContext: invocationContext)
     }
 }

--- a/Sources/SmokeHTTPClient/HTTPOperationsClient +executeAsyncWithoutOutput.swift
+++ b/Sources/SmokeHTTPClient/HTTPOperationsClient +executeAsyncWithoutOutput.swift
@@ -78,9 +78,13 @@ public extension HTTPOperationsClient {
         completion: @escaping (HTTPClientError?) -> (),
         asyncResponseInvocationStrategy: InvocationStrategyType,
         invocationContext: HTTPClientInvocationContext<InvocationReportingType, HandlerDelegateType>) throws -> EventLoopFuture<HTTPClient.Response>
-        where InputType: HTTPRequestInputProtocol, InvocationStrategyType: AsyncResponseInvocationStrategy,
+    where InputType: HTTPRequestInputProtocol, InvocationStrategyType: AsyncResponseInvocationStrategy,
         InvocationStrategyType.OutputType == HTTPClientError? {
-            let endpoint = getEndpoint(endpointOverride: endpointOverride, path: endpointPath)
+            let endpoint = try getEndpoint(
+                endpointOverride: endpointOverride,
+                path: endpointPath,
+                input: input,
+                invocationReporting: invocationContext.reporting)
             let wrappingInvocationContext = invocationContext.withOutgoingDecoratedLogger(endpoint: endpoint, outgoingOperation: operation)
             
             return try executeAsyncWithoutOutputWithWrappedInvocationContext(

--- a/Sources/SmokeHTTPClient/HTTPOperationsClient +executeAsyncWithoutOutput.swift
+++ b/Sources/SmokeHTTPClient/HTTPOperationsClient +executeAsyncWithoutOutput.swift
@@ -87,43 +87,13 @@ public extension HTTPOperationsClient {
             let endpoint = getEndpoint(endpointOverride: endpointOverride, path: requestComponents.pathWithQuery)
             let wrappingInvocationContext = invocationContext.withOutgoingDecoratedLogger(endpoint: endpoint, outgoingOperation: operation)
             
-            return try executeAsyncWithoutOutput(
-                endpointOverride: endpointOverride,
-                requestComponents: requestComponents,
-                httpMethod: httpMethod,
-                completion: completion,
-                asyncResponseInvocationStrategy: asyncResponseInvocationStrategy,
-                invocationContext: wrappingInvocationContext)
-    }
-
-    /**
-     Submits a request that will not return a response body to this client asynchronously.
-     
-     - Parameters:
-        - requestComponents: The request components for this request.
-        - httpMethod: The http method to use for this request.
-        - completion: Completion handler called with an error if one occurs or nil otherwise.
-        - asyncResponseInvocationStrategy: The invocation strategy for the response from this request.
-        - invocationContext: context to use for this invocation.
-     */
-    internal func executeAsyncWithoutOutput<InvocationStrategyType,
-            InvocationReportingType: HTTPClientInvocationReporting, HandlerDelegateType: HTTPClientInvocationDelegate>(
-        endpointOverride: URL? = nil,
-        requestComponents: HTTPRequestComponents,
-        httpMethod: HTTPMethod,
-        operation: String? = nil,
-        completion: @escaping (HTTPClientError?) -> (),
-        asyncResponseInvocationStrategy: InvocationStrategyType,
-        invocationContext: HTTPClientInvocationContext<InvocationReportingType, HandlerDelegateType>) throws -> EventLoopFuture<HTTPClient.Response>
-    where InvocationStrategyType: AsyncResponseInvocationStrategy,
-        InvocationStrategyType.OutputType == HTTPClientError? {
             return try executeAsyncWithoutOutputWithWrappedInvocationContext(
                 endpointOverride: endpointOverride,
                 requestComponents: requestComponents,
                 httpMethod: httpMethod,
                 completion: completion,
                 asyncResponseInvocationStrategy: asyncResponseInvocationStrategy,
-                invocationContext: invocationContext)
+                invocationContext: wrappingInvocationContext)
     }
     
     /**

--- a/Sources/SmokeHTTPClient/HTTPOperationsClient +executeSyncRetriableWithOutput.swift
+++ b/Sources/SmokeHTTPClient/HTTPOperationsClient +executeSyncRetriableWithOutput.swift
@@ -210,9 +210,13 @@ public extension HTTPOperationsClient {
         invocationContext: HTTPClientInvocationContext<InvocationReportingType, HandlerDelegateType>,
         retryConfiguration: HTTPClientRetryConfiguration,
         retryOnError: @escaping (HTTPClientError) -> Bool) throws -> OutputType
-        where InputType: HTTPRequestInputProtocol,
+    where InputType: HTTPRequestInputProtocol,
         OutputType: HTTPResponseOutputProtocol {
-            let endpoint = getEndpoint(endpointOverride: endpointOverride, path: endpointPath)
+            let endpoint = try getEndpoint(
+                endpointOverride: endpointOverride,
+                path: endpointPath,
+                input: input,
+                invocationReporting: invocationContext.reporting)
             let wrappingInvocationContext = invocationContext.withOutgoingDecoratedLogger(endpoint: endpoint, outgoingOperation: operation)
         
             // use the specified event loop or pick one for the client to use for all retry attempts
@@ -240,9 +244,13 @@ public extension HTTPOperationsClient {
         invocationContext: HTTPClientInvocationContext<InvocationReportingType, HandlerDelegateType>,
         retryConfiguration: HTTPClientRetryConfiguration,
         retryOnError: @escaping (Swift.Error) -> Bool) throws -> OutputType
-        where InputType: HTTPRequestInputProtocol,
+    where InputType: HTTPRequestInputProtocol,
         OutputType: HTTPResponseOutputProtocol {
-            let endpoint = getEndpoint(endpointOverride: endpointOverride, path: endpointPath)
+            let endpoint = try getEndpoint(
+                endpointOverride: endpointOverride,
+                path: endpointPath,
+                input: input,
+                invocationReporting: invocationContext.reporting)
             let wrappingInvocationContext = invocationContext.withOutgoingDecoratedLogger(endpoint: endpoint, outgoingOperation: operation)
         
             // use the specified event loop or pick one for the client to use for all retry attempts

--- a/Sources/SmokeHTTPClient/HTTPOperationsClient +executeSyncRetriableWithoutOutput.swift
+++ b/Sources/SmokeHTTPClient/HTTPOperationsClient +executeSyncRetriableWithoutOutput.swift
@@ -212,21 +212,25 @@ public extension HTTPOperationsClient {
         invocationContext: HTTPClientInvocationContext<InvocationReportingType, HandlerDelegateType>,
         retryConfiguration: HTTPClientRetryConfiguration,
         retryOnError: @escaping (HTTPClientError) -> Bool) throws
-        where InputType: HTTPRequestInputProtocol {
-            let endpoint = getEndpoint(endpointOverride: endpointOverride, path: endpointPath)
-            let wrappingInvocationContext = invocationContext.withOutgoingDecoratedLogger(endpoint: endpoint, outgoingOperation: operation)
-        
-            // use the specified event loop or pick one for the client to use for all retry attempts
-            let eventLoop = invocationContext.reporting.eventLoop ?? self.eventLoopGroup.next()
+    where InputType: HTTPRequestInputProtocol {
+        let endpoint = try getEndpoint(
+            endpointOverride: endpointOverride,
+            path: endpointPath,
+            input: input,
+            invocationReporting: invocationContext.reporting)
+        let wrappingInvocationContext = invocationContext.withOutgoingDecoratedLogger(endpoint: endpoint, outgoingOperation: operation)
+    
+        // use the specified event loop or pick one for the client to use for all retry attempts
+        let eventLoop = invocationContext.reporting.eventLoop ?? self.eventLoopGroup.next()
 
-            let retriable = ExecuteSyncWithoutOutputRetriable(
-                endpointOverride: endpointOverride, endpointPath: endpointPath,
-                httpMethod: httpMethod, input: input,
-                invocationContext: wrappingInvocationContext, eventLoopOverride: eventLoop, httpClient: self,
-                retryConfiguration: retryConfiguration,
-                retryOnError: retryOnError)
-            
-            return try retriable.executeSyncWithoutOutput()
+        let retriable = ExecuteSyncWithoutOutputRetriable(
+            endpointOverride: endpointOverride, endpointPath: endpointPath,
+            httpMethod: httpMethod, input: input,
+            invocationContext: wrappingInvocationContext, eventLoopOverride: eventLoop, httpClient: self,
+            retryConfiguration: retryConfiguration,
+            retryOnError: retryOnError)
+        
+        return try retriable.executeSyncWithoutOutput()
     }
     
     @available(swift, deprecated: 3.0, message: "Provide a `retryOnError` handler that accepts a HTTPClientError instance.")
@@ -240,20 +244,24 @@ public extension HTTPOperationsClient {
         invocationContext: HTTPClientInvocationContext<InvocationReportingType, HandlerDelegateType>,
         retryConfiguration: HTTPClientRetryConfiguration,
         retryOnError: @escaping (Swift.Error) -> Bool) throws
-        where InputType: HTTPRequestInputProtocol {
-            let endpoint = getEndpoint(endpointOverride: endpointOverride, path: endpointPath)
-            let wrappingInvocationContext = invocationContext.withOutgoingDecoratedLogger(endpoint: endpoint, outgoingOperation: operation)
-        
-            // use the specified event loop or pick one for the client to use for all retry attempts
-            let eventLoop = invocationContext.reporting.eventLoop ?? self.eventLoopGroup.next()
+    where InputType: HTTPRequestInputProtocol {
+        let endpoint = try getEndpoint(
+            endpointOverride: endpointOverride,
+            path: endpointPath,
+            input: input,
+            invocationReporting: invocationContext.reporting)
+        let wrappingInvocationContext = invocationContext.withOutgoingDecoratedLogger(endpoint: endpoint, outgoingOperation: operation)
+    
+        // use the specified event loop or pick one for the client to use for all retry attempts
+        let eventLoop = invocationContext.reporting.eventLoop ?? self.eventLoopGroup.next()
 
-            let retriable = ExecuteSyncWithoutOutputRetriable(
-                endpointOverride: endpointOverride, endpointPath: endpointPath,
-                httpMethod: httpMethod, input: input,
-                invocationContext: wrappingInvocationContext, eventLoopOverride: eventLoop, httpClient: self,
-                retryConfiguration: retryConfiguration,
-                retryOnError: retryOnError)
-            
-            return try retriable.executeSyncWithoutOutput()
+        let retriable = ExecuteSyncWithoutOutputRetriable(
+            endpointOverride: endpointOverride, endpointPath: endpointPath,
+            httpMethod: httpMethod, input: input,
+            invocationContext: wrappingInvocationContext, eventLoopOverride: eventLoop, httpClient: self,
+            retryConfiguration: retryConfiguration,
+            retryOnError: retryOnError)
+        
+        return try retriable.executeSyncWithoutOutput()
     }
 }

--- a/Sources/SmokeHTTPClient/HTTPOperationsClient +executeSyncWithOutput.swift
+++ b/Sources/SmokeHTTPClient/HTTPOperationsClient +executeSyncWithOutput.swift
@@ -84,7 +84,7 @@ public extension HTTPOperationsClient {
                 completedSemaphore.signal()
             }
             
-            _ = try executeAsyncWithOutput(
+            _ = try executeAsyncWithOutputWithWrappedInvocationContext(
                 endpointOverride: endpointOverride,
                 requestComponents: requestComponents,
                 httpMethod: httpMethod,

--- a/Sources/SmokeHTTPClient/HTTPOperationsClient +executeSyncWithOutput.swift
+++ b/Sources/SmokeHTTPClient/HTTPOperationsClient +executeSyncWithOutput.swift
@@ -41,9 +41,13 @@ public extension HTTPOperationsClient {
         operation: String? = nil,
         input: InputType,
         invocationContext: HTTPClientInvocationContext<InvocationReportingType, HandlerDelegateType>) throws -> OutputType
-        where InputType: HTTPRequestInputProtocol,
+    where InputType: HTTPRequestInputProtocol,
         OutputType: HTTPResponseOutputProtocol {
-            let endpoint = getEndpoint(endpointOverride: endpointOverride, path: endpointPath)
+            let endpoint = try getEndpoint(
+                endpointOverride: endpointOverride,
+                path: endpointPath,
+                input: input,
+                invocationReporting: invocationContext.reporting)
             let wrappingInvocationContext = invocationContext.withOutgoingDecoratedLogger(endpoint: endpoint, outgoingOperation: operation)
             
             return try executeSyncWithOutputWithWrappedInvocationContext(

--- a/Sources/SmokeHTTPClient/HTTPOperationsClient +executeSyncWithoutOutput.swift
+++ b/Sources/SmokeHTTPClient/HTTPOperationsClient +executeSyncWithoutOutput.swift
@@ -82,7 +82,7 @@ public extension HTTPOperationsClient {
                 completedSemaphore.signal()
             }
             
-            _ = try executeAsyncWithoutOutput(
+            _ = try executeAsyncWithoutOutputWithWrappedInvocationContext(
                 endpointOverride: endpointOverride,
                 requestComponents: requestComponents,
                 httpMethod: httpMethod,

--- a/Sources/SmokeHTTPClient/HTTPOperationsClient +executeSyncWithoutOutput.swift
+++ b/Sources/SmokeHTTPClient/HTTPOperationsClient +executeSyncWithoutOutput.swift
@@ -41,16 +41,20 @@ public extension HTTPOperationsClient {
         operation: String? = nil,
         input: InputType,
         invocationContext: HTTPClientInvocationContext<InvocationReportingType, HandlerDelegateType>) throws
-        where InputType: HTTPRequestInputProtocol {
-            let endpoint = getEndpoint(endpointOverride: endpointOverride, path: endpointPath)
-            let wrappingInvocationContext = invocationContext.withOutgoingDecoratedLogger(endpoint: endpoint, outgoingOperation: operation)
-        
-            try executeSyncWithoutOutputWithWrappedInvocationContext(
-                endpointOverride: endpointOverride,
-                endpointPath: endpointPath,
-                httpMethod: httpMethod,
-                input: input,
-                invocationContext: wrappingInvocationContext)
+    where InputType: HTTPRequestInputProtocol {
+        let endpoint = try getEndpoint(
+            endpointOverride: endpointOverride,
+            path: endpointPath,
+            input: input,
+            invocationReporting: invocationContext.reporting)
+        let wrappingInvocationContext = invocationContext.withOutgoingDecoratedLogger(endpoint: endpoint, outgoingOperation: operation)
+    
+        try executeSyncWithoutOutputWithWrappedInvocationContext(
+            endpointOverride: endpointOverride,
+            endpointPath: endpointPath,
+            httpMethod: httpMethod,
+            input: input,
+            invocationContext: wrappingInvocationContext)
     }
     
     /**

--- a/Sources/SmokeHTTPClient/HTTPOperationsClient+executeAsEventLoopFutureRetriableWithOutput.swift
+++ b/Sources/SmokeHTTPClient/HTTPOperationsClient+executeAsEventLoopFutureRetriableWithOutput.swift
@@ -27,13 +27,12 @@ public extension HTTPOperationsClient {
     /**
      Helper type that manages the state of a retriable async request.
      */
-    private class ExecuteAsEventLoopFutureWithOutputRetriable<InputType, OutputType,
+    private class ExecuteAsEventLoopFutureWithOutputRetriable<OutputType,
         InvocationReportingType: HTTPClientInvocationReporting, HandlerDelegateType: HTTPClientInvocationDelegate>
-            where InputType: HTTPRequestInputProtocol, OutputType: HTTPResponseOutputProtocol {
+            where OutputType: HTTPResponseOutputProtocol {
         let endpointOverride: URL?
-        let endpointPath: String
+        let requestComponents: HTTPRequestComponents
         let httpMethod: HTTPMethod
-        let input: InputType
         let invocationContext: HTTPClientInvocationContext<InvocationReportingType, HandlerDelegateType>
         let eventLoop: EventLoop
         let innerInvocationContext:
@@ -47,16 +46,15 @@ public extension HTTPOperationsClient {
         
         var retriesRemaining: Int
         
-        init(endpointOverride: URL?, endpointPath: String, httpMethod: HTTPMethod, input: InputType,
+        init(endpointOverride: URL?, requestComponents: HTTPRequestComponents, httpMethod: HTTPMethod,
              invocationContext: HTTPClientInvocationContext<InvocationReportingType, HandlerDelegateType>,
              eventLoopOverride eventLoop: EventLoop,
              httpClient: HTTPOperationsClient,
              retryConfiguration: HTTPClientRetryConfiguration,
              retryOnError: @escaping (HTTPClientError) -> Bool) {
             self.endpointOverride = endpointOverride
-            self.endpointPath = endpointPath
+            self.requestComponents = requestComponents
             self.httpMethod = httpMethod
-            self.input = input
             self.invocationContext = invocationContext
             self.eventLoop = eventLoop
             self.httpClient = httpClient
@@ -89,8 +87,8 @@ public extension HTTPOperationsClient {
             // submit the asynchronous request
             let future: EventLoopFuture<OutputType> = httpClient.executeAsEventLoopFutureWithOutputWithWrappedInvocationContext(
                 endpointOverride: endpointOverride,
-                endpointPath: endpointPath, httpMethod: httpMethod,
-                input: input, invocationContext: innerInvocationContext).flatMapError { error -> EventLoopFuture<OutputType> in
+                requestComponents: requestComponents, httpMethod: httpMethod,
+                invocationContext: innerInvocationContext).flatMapError { error -> EventLoopFuture<OutputType> in
                 let httpClientError: HTTPClientError
                 if let typedError = error as? HTTPClientError {
                     httpClientError = typedError
@@ -232,22 +230,22 @@ public extension HTTPOperationsClient {
     where InputType: HTTPRequestInputProtocol, OutputType: HTTPResponseOutputProtocol {
         // use the specified event loop or pick one for the client to use for all retry attempts
         let eventLoop = invocationContext.reporting.eventLoop ?? self.eventLoopGroup.next()
-        let endpoint: URL?
+        let requestComponents: HTTPRequestComponents
         do {
-            endpoint = try getEndpoint(
-                endpointOverride: endpointOverride,
-                path: endpointPath,
+            requestComponents = try clientDelegate.encodeInputAndQueryString(
                 input: input,
+                httpPath: endpointPath,
                 invocationReporting: invocationContext.reporting)
         } catch {
             return eventLoop.makeFailedFuture(error)
         }
 
+        let endpoint = getEndpoint(endpointOverride: endpointOverride, path: requestComponents.pathWithQuery)
         let wrappingInvocationContext = invocationContext.withOutgoingDecoratedLogger(endpoint: endpoint, outgoingOperation: operation)
         
-        let retriable = ExecuteAsEventLoopFutureWithOutputRetriable<InputType, OutputType, StandardHTTPClientInvocationReporting<InvocationReportingType.TraceContextType>, HandlerDelegateType>(
-            endpointOverride: endpointOverride, endpointPath: endpointPath,
-            httpMethod: httpMethod, input: input,
+        let retriable = ExecuteAsEventLoopFutureWithOutputRetriable<OutputType, StandardHTTPClientInvocationReporting<InvocationReportingType.TraceContextType>, HandlerDelegateType>(
+            endpointOverride: endpointOverride, requestComponents: requestComponents,
+            httpMethod: httpMethod,
             invocationContext: wrappingInvocationContext, eventLoopOverride: eventLoop, httpClient: self,
             retryConfiguration: retryConfiguration,
             retryOnError: retryOnError)

--- a/Sources/SmokeHTTPClient/HTTPOperationsClient+executeAsEventLoopFutureRetriableWithoutOutput.swift
+++ b/Sources/SmokeHTTPClient/HTTPOperationsClient+executeAsEventLoopFutureRetriableWithoutOutput.swift
@@ -27,13 +27,10 @@ public extension HTTPOperationsClient {
     /**
      Helper type that manages the state of a retriable async request.
      */
-    private class ExecuteAsEventLoopFutureWithoutOutputRetriable<InputType,
-        InvocationReportingType: HTTPClientInvocationReporting, HandlerDelegateType: HTTPClientInvocationDelegate>
-            where InputType: HTTPRequestInputProtocol {
+    private class ExecuteAsEventLoopFutureWithoutOutputRetriable<InvocationReportingType: HTTPClientInvocationReporting, HandlerDelegateType: HTTPClientInvocationDelegate> {
         let endpointOverride: URL?
-        let endpointPath: String
+        let requestComponents: HTTPRequestComponents
         let httpMethod: HTTPMethod
-        let input: InputType
         let invocationContext: HTTPClientInvocationContext<InvocationReportingType, HandlerDelegateType>
         let eventLoop: EventLoop
         let innerInvocationContext:
@@ -47,16 +44,15 @@ public extension HTTPOperationsClient {
         
         var retriesRemaining: Int
         
-        init(endpointOverride: URL?, endpointPath: String, httpMethod: HTTPMethod, input: InputType,
+        init(endpointOverride: URL?, requestComponents: HTTPRequestComponents, httpMethod: HTTPMethod,
              invocationContext: HTTPClientInvocationContext<InvocationReportingType, HandlerDelegateType>,
              eventLoopOverride eventLoop: EventLoop,
              httpClient: HTTPOperationsClient,
              retryConfiguration: HTTPClientRetryConfiguration,
              retryOnError: @escaping (HTTPClientError) -> Bool) {
             self.endpointOverride = endpointOverride
-            self.endpointPath = endpointPath
+            self.requestComponents = requestComponents
             self.httpMethod = httpMethod
-            self.input = input
             self.invocationContext = invocationContext
             self.eventLoop = eventLoop
             self.httpClient = httpClient
@@ -89,8 +85,9 @@ public extension HTTPOperationsClient {
             // submit the asynchronous request
             let future: EventLoopFuture<Void> = httpClient.executeAsEventLoopFutureWithoutOutputWithWrappedInvocationContext(
                 endpointOverride: endpointOverride,
-                endpointPath: endpointPath, httpMethod: httpMethod,
-                input: input, invocationContext: innerInvocationContext).flatMapError { error -> EventLoopFuture<Void> in
+                requestComponents: requestComponents,
+                httpMethod: httpMethod,
+                invocationContext: innerInvocationContext).flatMapError { error -> EventLoopFuture<Void> in
                 let httpClientError: HTTPClientError
                 if let typedError = error as? HTTPClientError {
                     httpClientError = typedError
@@ -232,22 +229,22 @@ public extension HTTPOperationsClient {
     where InputType: HTTPRequestInputProtocol {
         // use the specified event loop or pick one for the client to use for all retry attempts
         let eventLoop = invocationContext.reporting.eventLoop ?? self.eventLoopGroup.next()
-        let endpoint: URL?
+        let requestComponents: HTTPRequestComponents
         do {
-            endpoint = try getEndpoint(
-                endpointOverride: endpointOverride,
-                path: endpointPath,
+            requestComponents = try clientDelegate.encodeInputAndQueryString(
                 input: input,
+                httpPath: endpointPath,
                 invocationReporting: invocationContext.reporting)
         } catch {
             return eventLoop.makeFailedFuture(error)
         }
 
+        let endpoint = getEndpoint(endpointOverride: endpointOverride, path: requestComponents.pathWithQuery)
         let wrappingInvocationContext = invocationContext.withOutgoingDecoratedLogger(endpoint: endpoint, outgoingOperation: operation)
     
-        let retriable = ExecuteAsEventLoopFutureWithoutOutputRetriable<InputType, StandardHTTPClientInvocationReporting<InvocationReportingType.TraceContextType>, HandlerDelegateType>(
-            endpointOverride: endpointOverride, endpointPath: endpointPath,
-            httpMethod: httpMethod, input: input,
+        let retriable = ExecuteAsEventLoopFutureWithoutOutputRetriable<StandardHTTPClientInvocationReporting<InvocationReportingType.TraceContextType>, HandlerDelegateType>(
+            endpointOverride: endpointOverride, requestComponents: requestComponents,
+            httpMethod: httpMethod,
             invocationContext: wrappingInvocationContext, eventLoopOverride: eventLoop, httpClient: self,
             retryConfiguration: retryConfiguration,
             retryOnError: retryOnError)

--- a/Sources/SmokeHTTPClient/HTTPOperationsClient+executeAsEventLoopFutureWithOutput.swift
+++ b/Sources/SmokeHTTPClient/HTTPOperationsClient+executeAsEventLoopFutureWithOutput.swift
@@ -61,24 +61,23 @@ public extension HTTPOperationsClient {
             invocationContext: HTTPClientInvocationContext<InvocationReportingType, HandlerDelegateType>)
     -> EventLoopFuture<OutputType> where InputType: HTTPRequestInputProtocol, OutputType: HTTPResponseOutputProtocol {
         let eventLoop = invocationContext.reporting.eventLoop ?? self.eventLoopGroup.next()
-        let endpoint: URL?
+        let requestComponents: HTTPRequestComponents
         do {
-            endpoint = try getEndpoint(
-                endpointOverride: endpointOverride,
-                path: endpointPath,
+            requestComponents = try clientDelegate.encodeInputAndQueryString(
                 input: input,
+                httpPath: endpointPath,
                 invocationReporting: invocationContext.reporting)
         } catch {
             return eventLoop.makeFailedFuture(error)
         }
 
+        let endpoint = getEndpoint(endpointOverride: endpointOverride, path: requestComponents.pathWithQuery)
         let wrappingInvocationContext = invocationContext.withOutgoingDecoratedLogger(endpoint: endpoint, outgoingOperation: operation)
         
         return executeAsEventLoopFutureWithOutputWithWrappedInvocationContext(
             endpointOverride: endpointOverride,
-            endpointPath: endpointPath,
+            requestComponents: requestComponents,
             httpMethod: httpMethod,
-            input: input,
             invocationContext: wrappingInvocationContext)
     }
 
@@ -94,14 +93,13 @@ public extension HTTPOperationsClient {
          - invocationContext: context to use for this invocation.
         - Returns: A future that will produce the execution result or failure.
      */
-    internal func executeAsEventLoopFutureWithOutputWithWrappedInvocationContext<InputType, OutputType,
+    internal func executeAsEventLoopFutureWithOutputWithWrappedInvocationContext< OutputType,
         InvocationReportingType: HTTPClientInvocationReporting, HandlerDelegateType: HTTPClientInvocationDelegate>(
             endpointOverride: URL? = nil,
-            endpointPath: String,
+            requestComponents: HTTPRequestComponents,
             httpMethod: HTTPMethod,
-            input: InputType,
             invocationContext: HTTPClientInvocationContext<InvocationReportingType, HandlerDelegateType>) -> EventLoopFuture<OutputType>
-            where InputType: HTTPRequestInputProtocol, OutputType: HTTPResponseOutputProtocol {
+    where OutputType: HTTPResponseOutputProtocol {
         let durationMetricDetails: (Date, Metrics.Timer?, OutwardsRequestAggregator?)?
         
         if invocationContext.reporting.outwardsRequestAggregator != nil ||
@@ -116,8 +114,8 @@ public extension HTTPOperationsClient {
         // that will decode the returned body into the desired decodable type.
         
         let future = executeAsEventLoopFuture(endpointOverride: endpointOverride,
-                                              endpointPath: endpointPath, httpMethod: httpMethod,
-                                              input: input, invocationContext: invocationContext)
+                                              requestComponents: requestComponents, httpMethod: httpMethod,
+                                              invocationContext: invocationContext)
             .flatMapThrowing { (response) -> OutputType in
                 do {
                     // decode the provided body into the desired type

--- a/Sources/SmokeHTTPClient/HTTPOperationsClient+executeAsEventLoopFutureWithoutOutput.swift
+++ b/Sources/SmokeHTTPClient/HTTPOperationsClient+executeAsEventLoopFutureWithoutOutput.swift
@@ -60,16 +60,27 @@ public extension HTTPOperationsClient {
         operation: String? = nil,
         input: InputType,
         invocationContext: HTTPClientInvocationContext<InvocationReportingType, HandlerDelegateType>) -> EventLoopFuture<Void>
-        where InputType: HTTPRequestInputProtocol {
-            let endpoint = getEndpoint(endpointOverride: endpointOverride, path: endpointPath)
-            let wrappingInvocationContext = invocationContext.withOutgoingDecoratedLogger(endpoint: endpoint, outgoingOperation: operation)
-            
-            return executeAsEventLoopFutureWithoutOutputWithWrappedInvocationContext(
+    where InputType: HTTPRequestInputProtocol {
+        let eventLoop = invocationContext.reporting.eventLoop ?? self.eventLoopGroup.next()
+        let endpoint: URL?
+        do {
+            endpoint = try getEndpoint(
                 endpointOverride: endpointOverride,
-                endpointPath: endpointPath,
-                httpMethod: httpMethod,
+                path: endpointPath,
                 input: input,
-                invocationContext: wrappingInvocationContext)
+                invocationReporting: invocationContext.reporting)
+        } catch {
+            return eventLoop.makeFailedFuture(error)
+        }
+
+        let wrappingInvocationContext = invocationContext.withOutgoingDecoratedLogger(endpoint: endpoint, outgoingOperation: operation)
+        
+        return executeAsEventLoopFutureWithoutOutputWithWrappedInvocationContext(
+            endpointOverride: endpointOverride,
+            endpointPath: endpointPath,
+            httpMethod: httpMethod,
+            input: input,
+            invocationContext: wrappingInvocationContext)
     }
     
     /**

--- a/Sources/SmokeHTTPClient/HTTPOperationsClient+executeAsyncRetriableWithoutOutput.swift
+++ b/Sources/SmokeHTTPClient/HTTPOperationsClient+executeAsyncRetriableWithoutOutput.swift
@@ -27,14 +27,13 @@ public extension HTTPOperationsClient {
     /**
      Helper type that manages the state of a retriable async request.
      */
-    private class ExecuteAsyncWithoutOutputRetriable<InputType, InvocationStrategyType,
+    private class ExecuteAsyncWithoutOutputRetriable<InvocationStrategyType,
         InvocationReportingType: HTTPClientInvocationReporting, HandlerDelegateType: HTTPClientInvocationDelegate>
-            where InputType: HTTPRequestInputProtocol, InvocationStrategyType: AsyncResponseInvocationStrategy,
+            where InvocationStrategyType: AsyncResponseInvocationStrategy,
             InvocationStrategyType.OutputType == HTTPClientError? {
         let endpointOverride: URL?
-        let endpointPath: String
+        let requestComponents: HTTPRequestComponents
         let httpMethod: HTTPMethod
-        let input: InputType
         let outerCompletion: (HTTPClientError?) -> ()
         let asyncResponseInvocationStrategy: InvocationStrategyType
         let invocationContext: HTTPClientInvocationContext<InvocationReportingType, HandlerDelegateType>
@@ -49,8 +48,8 @@ public extension HTTPOperationsClient {
         
         var retriesRemaining: Int
         
-        init(endpointOverride: URL?, endpointPath: String, httpMethod: HTTPMethod,
-             input: InputType, outerCompletion: @escaping (HTTPClientError?) -> (),
+        init(endpointOverride: URL?, requestComponents: HTTPRequestComponents, httpMethod: HTTPMethod,
+             outerCompletion: @escaping (HTTPClientError?) -> (),
              asyncResponseInvocationStrategy: InvocationStrategyType,
              invocationContext: HTTPClientInvocationContext<InvocationReportingType, HandlerDelegateType>,
              eventLoopOverride eventLoop: EventLoop,
@@ -58,9 +57,8 @@ public extension HTTPOperationsClient {
              retryConfiguration: HTTPClientRetryConfiguration,
              retryOnError: @escaping (HTTPClientError) -> Bool) {
             self.endpointOverride = endpointOverride
-            self.endpointPath = endpointPath
+            self.requestComponents = requestComponents
             self.httpMethod = httpMethod
-            self.input = input
             self.outerCompletion = outerCompletion
             self.asyncResponseInvocationStrategy = asyncResponseInvocationStrategy
             self.invocationContext = invocationContext
@@ -94,8 +92,7 @@ public extension HTTPOperationsClient {
             // submit the asynchronous request
             _ = try httpClient.executeAsyncWithoutOutputWithWrappedInvocationContext(
                 endpointOverride: endpointOverride,
-                endpointPath: endpointPath, httpMethod: httpMethod,
-                input: input, completion: completion,
+                requestComponents: requestComponents, httpMethod: httpMethod, completion: completion,
                 asyncResponseInvocationStrategy: asyncResponseInvocationStrategy,
                 invocationContext: innerInvocationContext)
         }
@@ -259,19 +256,19 @@ public extension HTTPOperationsClient {
         retryOnError: @escaping (HTTPClientError) -> Bool) throws
     where InputType: HTTPRequestInputProtocol, InvocationStrategyType: AsyncResponseInvocationStrategy,
         InvocationStrategyType.OutputType == HTTPClientError? {
-            let endpoint = try getEndpoint(
-                endpointOverride: endpointOverride,
-                path: endpointPath,
+            let requestComponents = try clientDelegate.encodeInputAndQueryString(
                 input: input,
+                httpPath: endpointPath,
                 invocationReporting: invocationContext.reporting)
+            let endpoint = getEndpoint(endpointOverride: endpointOverride, path: requestComponents.pathWithQuery)
             let wrappingInvocationContext = invocationContext.withOutgoingDecoratedLogger(endpoint: endpoint, outgoingOperation: operation)
         
             // use the specified event loop or pick one for the client to use for all retry attempts
             let eventLoop = invocationContext.reporting.eventLoop ?? self.eventLoopGroup.next()
 
             let retriable = ExecuteAsyncWithoutOutputRetriable(
-                endpointOverride: endpointOverride, endpointPath: endpointPath,
-                httpMethod: httpMethod, input: input, outerCompletion: completion,
+                endpointOverride: endpointOverride, requestComponents: requestComponents,
+                httpMethod: httpMethod, outerCompletion: completion,
                 asyncResponseInvocationStrategy: asyncResponseInvocationStrategy,
                 invocationContext: wrappingInvocationContext, eventLoopOverride: eventLoop, httpClient: self,
                 retryConfiguration: retryConfiguration,

--- a/Sources/SmokeHTTPClient/HTTPOperationsClient+executeAsyncRetriableWithoutOutput.swift
+++ b/Sources/SmokeHTTPClient/HTTPOperationsClient+executeAsyncRetriableWithoutOutput.swift
@@ -257,9 +257,13 @@ public extension HTTPOperationsClient {
         invocationContext: HTTPClientInvocationContext<InvocationReportingType, HandlerDelegateType>,
         retryConfiguration: HTTPClientRetryConfiguration,
         retryOnError: @escaping (HTTPClientError) -> Bool) throws
-        where InputType: HTTPRequestInputProtocol, InvocationStrategyType: AsyncResponseInvocationStrategy,
+    where InputType: HTTPRequestInputProtocol, InvocationStrategyType: AsyncResponseInvocationStrategy,
         InvocationStrategyType.OutputType == HTTPClientError? {
-            let endpoint = getEndpoint(endpointOverride: endpointOverride, path: endpointPath)
+            let endpoint = try getEndpoint(
+                endpointOverride: endpointOverride,
+                path: endpointPath,
+                input: input,
+                invocationReporting: invocationContext.reporting)
             let wrappingInvocationContext = invocationContext.withOutgoingDecoratedLogger(endpoint: endpoint, outgoingOperation: operation)
         
             // use the specified event loop or pick one for the client to use for all retry attempts

--- a/Sources/SmokeHTTPClient/HTTPOperationsClient+executeRetriableWithOutput.swift
+++ b/Sources/SmokeHTTPClient/HTTPOperationsClient+executeRetriableWithOutput.swift
@@ -229,7 +229,11 @@ public extension HTTPOperationsClient {
         retryConfiguration: HTTPClientRetryConfiguration,
         retryOnError: @escaping (HTTPClientError) -> Bool) async throws -> OutputType
     where InputType: HTTPRequestInputProtocol, OutputType: HTTPResponseOutputProtocol {
-        let endpoint = getEndpoint(endpointOverride: endpointOverride, path: endpointPath)
+        let endpoint = try getEndpoint(
+            endpointOverride: endpointOverride,
+            path: endpointPath,
+            input: input,
+            invocationReporting: invocationContext.reporting)
         let wrappingInvocationContext = invocationContext.withOutgoingDecoratedLogger(endpoint: endpoint, outgoingOperation: operation)
     
         // use the specified event loop or pick one for the client to use for all retry attempts

--- a/Sources/SmokeHTTPClient/HTTPOperationsClient+executeRetriableWithoutOutput.swift
+++ b/Sources/SmokeHTTPClient/HTTPOperationsClient+executeRetriableWithoutOutput.swift
@@ -28,13 +28,10 @@ public extension HTTPOperationsClient {
     /**
      Helper type that manages the state of a retriable async request.
      */
-    private class ExecuteWithoutOutputRetriable<InputType,
-        InvocationReportingType: HTTPClientInvocationReporting, HandlerDelegateType: HTTPClientInvocationDelegate>
-            where InputType: HTTPRequestInputProtocol {
+    private class ExecuteWithoutOutputRetriable<InvocationReportingType: HTTPClientInvocationReporting, HandlerDelegateType: HTTPClientInvocationDelegate> {
         let endpointOverride: URL?
-        let endpointPath: String
+        let requestComponents: HTTPRequestComponents
         let httpMethod: HTTPMethod
-        let input: InputType
         let invocationContext: HTTPClientInvocationContext<InvocationReportingType, HandlerDelegateType>
         let eventLoop: EventLoop
         let innerInvocationContext:
@@ -48,16 +45,15 @@ public extension HTTPOperationsClient {
         
         var retriesRemaining: Int
         
-        init(endpointOverride: URL?, endpointPath: String, httpMethod: HTTPMethod, input: InputType,
+        init(endpointOverride: URL?, requestComponents: HTTPRequestComponents, httpMethod: HTTPMethod,
              invocationContext: HTTPClientInvocationContext<InvocationReportingType, HandlerDelegateType>,
              eventLoopOverride eventLoop: EventLoop,
              httpClient: HTTPOperationsClient,
              retryConfiguration: HTTPClientRetryConfiguration,
              retryOnError: @escaping (HTTPClientError) -> Bool) {
             self.endpointOverride = endpointOverride
-            self.endpointPath = endpointPath
+            self.requestComponents = requestComponents
             self.httpMethod = httpMethod
-            self.input = input
             self.invocationContext = invocationContext
             self.eventLoop = eventLoop
             self.httpClient = httpClient
@@ -91,8 +87,8 @@ public extension HTTPOperationsClient {
             do {
                 try await httpClient.executeWithoutOutputWithWrappedInvocationContext(
                     endpointOverride: endpointOverride,
-                    endpointPath: endpointPath, httpMethod: httpMethod,
-                    input: input, invocationContext: innerInvocationContext)
+                    requestComponents: requestComponents, httpMethod: httpMethod,
+                    invocationContext: innerInvocationContext)
             } catch {
                 let httpClientError: HTTPClientError
                 if let typedError = error as? HTTPClientError {
@@ -207,19 +203,19 @@ public extension HTTPOperationsClient {
         retryConfiguration: HTTPClientRetryConfiguration,
         retryOnError: @escaping (HTTPClientError) -> Bool) async throws
     where InputType: HTTPRequestInputProtocol {
-        let endpoint = try getEndpoint(
-            endpointOverride: endpointOverride,
-            path: endpointPath,
+        let requestComponents = try clientDelegate.encodeInputAndQueryString(
             input: input,
+            httpPath: endpointPath,
             invocationReporting: invocationContext.reporting)
+        let endpoint = getEndpoint(endpointOverride: endpointOverride, path: requestComponents.pathWithQuery)
         let wrappingInvocationContext = invocationContext.withOutgoingDecoratedLogger(endpoint: endpoint, outgoingOperation: operation)
     
         // use the specified event loop or pick one for the client to use for all retry attempts
         let eventLoop = invocationContext.reporting.eventLoop ?? self.eventLoopGroup.next()
         
-        let retriable = ExecuteWithoutOutputRetriable<InputType, StandardHTTPClientInvocationReporting<InvocationReportingType.TraceContextType>, HandlerDelegateType>(
-            endpointOverride: endpointOverride, endpointPath: endpointPath,
-            httpMethod: httpMethod, input: input,
+        let retriable = ExecuteWithoutOutputRetriable<StandardHTTPClientInvocationReporting<InvocationReportingType.TraceContextType>, HandlerDelegateType>(
+            endpointOverride: endpointOverride, requestComponents: requestComponents,
+            httpMethod: httpMethod,
             invocationContext: wrappingInvocationContext, eventLoopOverride: eventLoop, httpClient: self,
             retryConfiguration: retryConfiguration,
             retryOnError: retryOnError)

--- a/Sources/SmokeHTTPClient/HTTPOperationsClient+executeRetriableWithoutOutput.swift
+++ b/Sources/SmokeHTTPClient/HTTPOperationsClient+executeRetriableWithoutOutput.swift
@@ -207,7 +207,11 @@ public extension HTTPOperationsClient {
         retryConfiguration: HTTPClientRetryConfiguration,
         retryOnError: @escaping (HTTPClientError) -> Bool) async throws
     where InputType: HTTPRequestInputProtocol {
-        let endpoint = getEndpoint(endpointOverride: endpointOverride, path: endpointPath)
+        let endpoint = try getEndpoint(
+            endpointOverride: endpointOverride,
+            path: endpointPath,
+            input: input,
+            invocationReporting: invocationContext.reporting)
         let wrappingInvocationContext = invocationContext.withOutgoingDecoratedLogger(endpoint: endpoint, outgoingOperation: operation)
     
         // use the specified event loop or pick one for the client to use for all retry attempts

--- a/Sources/SmokeHTTPClient/HTTPOperationsClient+executeWithOutput.swift
+++ b/Sources/SmokeHTTPClient/HTTPOperationsClient+executeWithOutput.swift
@@ -46,7 +46,11 @@ public extension HTTPOperationsClient {
         input: InputType,
         invocationContext: HTTPClientInvocationContext<InvocationReportingType, HandlerDelegateType>) async throws -> OutputType
     where InputType: HTTPRequestInputProtocol, OutputType: HTTPResponseOutputProtocol {
-        let endpoint = getEndpoint(endpointOverride: endpointOverride, path: endpointPath)
+        let endpoint = try getEndpoint(
+            endpointOverride: endpointOverride,
+            path: endpointPath,
+            input: input,
+            invocationReporting: invocationContext.reporting)
         let wrappingInvocationContext = invocationContext.withOutgoingDecoratedLogger(endpoint: endpoint, outgoingOperation: operation)
         
         return try await executeWithOutputWithWrappedInvocationContext(

--- a/Sources/SmokeHTTPClient/HTTPOperationsClient+executeWithoutOutput.swift
+++ b/Sources/SmokeHTTPClient/HTTPOperationsClient+executeWithoutOutput.swift
@@ -45,7 +45,11 @@ public extension HTTPOperationsClient {
         input: InputType,
         invocationContext: HTTPClientInvocationContext<InvocationReportingType, HandlerDelegateType>) async throws
     where InputType: HTTPRequestInputProtocol {
-        let endpoint = getEndpoint(endpointOverride: endpointOverride, path: endpointPath)
+        let endpoint = try getEndpoint(
+            endpointOverride: endpointOverride,
+            path: endpointPath,
+            input: input,
+            invocationReporting: invocationContext.reporting)
         let wrappingInvocationContext = invocationContext.withOutgoingDecoratedLogger(endpoint: endpoint, outgoingOperation: operation)
         
         return try await executeWithoutOutputWithWrappedInvocationContext(

--- a/Sources/SmokeHTTPClient/HTTPOperationsClient+executeWithoutOutput.swift
+++ b/Sources/SmokeHTTPClient/HTTPOperationsClient+executeWithoutOutput.swift
@@ -45,18 +45,17 @@ public extension HTTPOperationsClient {
         input: InputType,
         invocationContext: HTTPClientInvocationContext<InvocationReportingType, HandlerDelegateType>) async throws
     where InputType: HTTPRequestInputProtocol {
-        let endpoint = try getEndpoint(
-            endpointOverride: endpointOverride,
-            path: endpointPath,
+        let requestComponents = try clientDelegate.encodeInputAndQueryString(
             input: input,
+            httpPath: endpointPath,
             invocationReporting: invocationContext.reporting)
+        let endpoint = getEndpoint(endpointOverride: endpointOverride, path: requestComponents.pathWithQuery)
         let wrappingInvocationContext = invocationContext.withOutgoingDecoratedLogger(endpoint: endpoint, outgoingOperation: operation)
         
         return try await executeWithoutOutputWithWrappedInvocationContext(
             endpointOverride: endpointOverride,
-            endpointPath: endpointPath,
+            requestComponents: requestComponents,
             httpMethod: httpMethod,
-            input: input,
             invocationContext: wrappingInvocationContext)
     }
     
@@ -71,60 +70,58 @@ public extension HTTPOperationsClient {
         - invocationContext: context to use for this invocation.
      - Returns: A future that will produce a Void result or failure.
      */
-    internal func executeWithoutOutputWithWrappedInvocationContext<InputType,
-            InvocationReportingType: HTTPClientInvocationReporting, HandlerDelegateType: HTTPClientInvocationDelegate>(
+    internal func executeWithoutOutputWithWrappedInvocationContext<
+            InvocationReportingType: HTTPClientInvocationReporting,
+            HandlerDelegateType: HTTPClientInvocationDelegate>(
         endpointOverride: URL? = nil,
-        endpointPath: String,
+        requestComponents: HTTPRequestComponents,
         httpMethod: HTTPMethod,
-        input: InputType,
-        invocationContext: HTTPClientInvocationContext<InvocationReportingType, HandlerDelegateType>) async throws
-    where InputType: HTTPRequestInputProtocol {
+        invocationContext: HTTPClientInvocationContext<InvocationReportingType, HandlerDelegateType>) async throws {
         
-        let durationMetricDetails: (Date, Metrics.Timer?, OutwardsRequestAggregator?)?
-        
-        if invocationContext.reporting.outwardsRequestAggregator != nil ||
-            invocationContext.reporting.latencyTimer != nil {
-            durationMetricDetails = (Date(), invocationContext.reporting.latencyTimer, invocationContext.reporting.outwardsRequestAggregator)
-        } else {
-            durationMetricDetails = nil
-        }
-        
-        // submit the asynchronous request
-        do {
-            _ = try await execute(endpointOverride: endpointOverride,
-                                  endpointPath: endpointPath,
-                                  httpMethod: httpMethod,
-                                  input: input,
-                                  invocationContext: invocationContext)
-        } catch {
-            if let typedError = error as? HTTPClientError {
-                // report failure metric
-                switch typedError.category {
-                case .clientError:
-                    invocationContext.reporting.failure4XXCounter?.increment()
-                case .serverError:
-                    invocationContext.reporting.failure5XXCounter?.increment()
+            let durationMetricDetails: (Date, Metrics.Timer?, OutwardsRequestAggregator?)?
+            
+            if invocationContext.reporting.outwardsRequestAggregator != nil ||
+                invocationContext.reporting.latencyTimer != nil {
+                durationMetricDetails = (Date(), invocationContext.reporting.latencyTimer, invocationContext.reporting.outwardsRequestAggregator)
+            } else {
+                durationMetricDetails = nil
+            }
+            
+            // submit the asynchronous request
+            do {
+                _ = try await execute(endpointOverride: endpointOverride,
+                                    requestComponents: requestComponents,
+                                    httpMethod: httpMethod,
+                                    invocationContext: invocationContext)
+            } catch {
+                if let typedError = error as? HTTPClientError {
+                    // report failure metric
+                    switch typedError.category {
+                    case .clientError:
+                        invocationContext.reporting.failure4XXCounter?.increment()
+                    case .serverError:
+                        invocationContext.reporting.failure5XXCounter?.increment()
+                    }
+                }
+                
+                // rethrow the error
+                throw error
+            }
+            
+            invocationContext.reporting.successCounter?.increment()
+            
+            if let durationMetricDetails = durationMetricDetails {
+                let timeInterval = Date().timeIntervalSince(durationMetricDetails.0)
+                
+                if let latencyTimer = durationMetricDetails.1 {
+                    latencyTimer.recordMilliseconds(timeInterval.milliseconds)
+                }
+                
+                if let outwardsRequestAggregator = durationMetricDetails.2 {
+                    await outwardsRequestAggregator.recordOutwardsRequest(
+                        outputRequestRecord: StandardOutputRequestRecord(requestLatency: timeInterval))
                 }
             }
-            
-            // rethrow the error
-            throw error
-        }
-        
-        invocationContext.reporting.successCounter?.increment()
-        
-        if let durationMetricDetails = durationMetricDetails {
-            let timeInterval = Date().timeIntervalSince(durationMetricDetails.0)
-            
-            if let latencyTimer = durationMetricDetails.1 {
-                latencyTimer.recordMilliseconds(timeInterval.milliseconds)
-            }
-            
-            if let outwardsRequestAggregator = durationMetricDetails.2 {
-                await outwardsRequestAggregator.recordOutwardsRequest(
-                    outputRequestRecord: StandardOutputRequestRecord(requestLatency: timeInterval))
-            }
-        }
     }
 }
 

--- a/Sources/SmokeHTTPClient/HTTPOperationsClient.swift
+++ b/Sources/SmokeHTTPClient/HTTPOperationsClient.swift
@@ -54,13 +54,21 @@ public struct HTTPOperationsClient {
     public var eventLoopGroup: EventLoopGroup {
         return self.wrappedHttpClient.eventLoopGroup
     }
-    
-    internal func getEndpoint(endpointOverride: URL?, path: String) -> URL? {
+
+    internal func getEndpoint<InputType, InvocationReportingType: HTTPClientInvocationReporting>(
+        endpointOverride: URL?,
+        path: String,
+        input: InputType,
+        invocationReporting: InvocationReportingType) throws -> URL?
+    where InputType: HTTPRequestInputProtocol {
         var components = URLComponents()
         components.scheme = self.endpointScheme
         components.host = endpointOverride?.host ?? self.endpointHostName
         components.port = endpointOverride?.port ?? self.endpointPort
-        components.path = path
+        components.path = try clientDelegate.encodeInputAndQueryString(
+            input: input,
+            httpPath: path,
+            invocationReporting: invocationReporting).pathWithQuery
         
         return components.url
     }

--- a/Sources/SmokeHTTPClient/HTTPOperationsClient.swift
+++ b/Sources/SmokeHTTPClient/HTTPOperationsClient.swift
@@ -55,20 +55,12 @@ public struct HTTPOperationsClient {
         return self.wrappedHttpClient.eventLoopGroup
     }
 
-    internal func getEndpoint<InputType, InvocationReportingType: HTTPClientInvocationReporting>(
-        endpointOverride: URL?,
-        path: String,
-        input: InputType,
-        invocationReporting: InvocationReportingType) throws -> URL?
-    where InputType: HTTPRequestInputProtocol {
+    internal func getEndpoint(endpointOverride: URL?, path: String) -> URL? {
         var components = URLComponents()
         components.scheme = self.endpointScheme
         components.host = endpointOverride?.host ?? self.endpointHostName
         components.port = endpointOverride?.port ?? self.endpointPort
-        components.path = try clientDelegate.encodeInputAndQueryString(
-            input: input,
-            httpPath: path,
-            invocationReporting: invocationReporting).pathWithQuery
+        components.path = path
         
         return components.url
     }
@@ -200,18 +192,16 @@ public struct HTTPOperationsClient {
 }
  
 extension HTTPOperationsClient {
-    func executeAsync<InputType, InvocationReportingType: HTTPClientInvocationReporting, HandlerDelegateType: HTTPClientInvocationDelegate>(
-            endpointOverride: URL? = nil,
-            endpointPath: String,
-            httpMethod: HTTPMethod,
-            input: InputType,
-            completion: @escaping (Result<HTTPResponseComponents, HTTPClientError>) -> (),
-            invocationContext: HTTPClientInvocationContext<InvocationReportingType, HandlerDelegateType>) throws -> EventLoopFuture<HTTPClient.Response>
-            where InputType: HTTPRequestInputProtocol {
+    func executeAsync<InvocationReportingType: HTTPClientInvocationReporting, HandlerDelegateType: HTTPClientInvocationDelegate>(
+        endpointOverride: URL? = nil,
+        requestComponents: HTTPRequestComponents,
+        httpMethod: HTTPMethod,
+        completion: @escaping (Result<HTTPResponseComponents, HTTPClientError>) -> (),
+        invocationContext: HTTPClientInvocationContext<InvocationReportingType, HandlerDelegateType>) throws 
+    -> EventLoopFuture<HTTPClient.Response> {
         let (responseFuture, outwardsRequestContext) = try performExecuteAsync(endpointOverride: endpointOverride,
-                                                                               endpointPath: endpointPath,
+                                                                               requestComponents: requestComponents,
                                                                                httpMethod: httpMethod,
-                                                                               input: input,
                                                                                invocationContext: invocationContext)
 
         responseFuture.whenComplete { result in
@@ -232,18 +222,16 @@ extension HTTPOperationsClient {
         return responseFuture
     }
     
-    func executeAsEventLoopFuture<InputType, InvocationReportingType: HTTPClientInvocationReporting, HandlerDelegateType: HTTPClientInvocationDelegate>(
-            endpointOverride: URL? = nil,
-            endpointPath: String,
-            httpMethod: HTTPMethod,
-            input: InputType,
-            invocationContext: HTTPClientInvocationContext<InvocationReportingType, HandlerDelegateType>) -> EventLoopFuture<HTTPResponseComponents>
-            where InputType: HTTPRequestInputProtocol {
+    func executeAsEventLoopFuture<InvocationReportingType: HTTPClientInvocationReporting, HandlerDelegateType: HTTPClientInvocationDelegate>(
+        endpointOverride: URL? = nil,
+        requestComponents: HTTPRequestComponents,
+        httpMethod: HTTPMethod,
+        invocationContext: HTTPClientInvocationContext<InvocationReportingType, HandlerDelegateType>)
+    -> EventLoopFuture<HTTPResponseComponents> {
         do {
             let (responseFuture, outwardsRequestContext) = try performExecuteAsync(endpointOverride: endpointOverride,
-                                                                                   endpointPath: endpointPath,
+                                                                                   requestComponents: requestComponents,
                                                                                    httpMethod: httpMethod,
-                                                                                   input: input,
                                                                                    invocationContext: invocationContext)
             return responseFuture.flatMapThrowing { successResult in
                 // a response has been successfully received; this reponse may be a successful response
@@ -276,17 +264,15 @@ extension HTTPOperationsClient {
         }
     }
     
-    func execute<InputType, InvocationReportingType: HTTPClientInvocationReporting, HandlerDelegateType: HTTPClientInvocationDelegate>(
-            endpointOverride: URL? = nil,
-            endpointPath: String,
-            httpMethod: HTTPMethod,
-            input: InputType,
-            invocationContext: HTTPClientInvocationContext<InvocationReportingType, HandlerDelegateType>) async throws
-    -> HTTPResponseComponents where InputType: HTTPRequestInputProtocol {
+    func execute< InvocationReportingType: HTTPClientInvocationReporting, HandlerDelegateType: HTTPClientInvocationDelegate>(
+        endpointOverride: URL? = nil,
+        requestComponents: HTTPRequestComponents,
+        httpMethod: HTTPMethod,
+        invocationContext: HTTPClientInvocationContext<InvocationReportingType, HandlerDelegateType>) async throws
+    -> HTTPResponseComponents  {
         let (responseFuture, outwardsRequestContext) = try performExecuteAsync(endpointOverride: endpointOverride,
-                                                                               endpointPath: endpointPath,
+                                                                               requestComponents: requestComponents,
                                                                                httpMethod: httpMethod,
-                                                                               input: input,
                                                                                invocationContext: invocationContext)
         
         do {
@@ -315,22 +301,15 @@ extension HTTPOperationsClient {
     
     // To maintain the existing behaviour of async functions, this function will throw for synchronous setup errors and fail
     // the future otherwise.
-    private func performExecuteAsync<InputType, InvocationReportingType: HTTPClientInvocationReporting, HandlerDelegateType: HTTPClientInvocationDelegate>(
-            endpointOverride: URL? = nil,
-            endpointPath: String,
-            httpMethod: HTTPMethod,
-            input: InputType,
-            invocationContext: HTTPClientInvocationContext<InvocationReportingType, HandlerDelegateType>) throws
-        -> (EventLoopFuture<HTTPClient.Response>, InvocationReportingType.TraceContextType.OutwardsRequestContext)
-            where InputType: HTTPRequestInputProtocol {
+    private func performExecuteAsync<InvocationReportingType: HTTPClientInvocationReporting, HandlerDelegateType: HTTPClientInvocationDelegate>(
+        endpointOverride: URL? = nil,
+        requestComponents: HTTPRequestComponents,
+        httpMethod: HTTPMethod,
+        invocationContext: HTTPClientInvocationContext<InvocationReportingType, HandlerDelegateType>) throws
+    -> (EventLoopFuture<HTTPClient.Response>, InvocationReportingType.TraceContextType.OutwardsRequestContext) {
 
         let endpointHostName = endpointOverride?.host ?? self.endpointHostName
         let endpointPort = endpointOverride?.port ?? self.endpointPort
-
-        let requestComponents = try clientDelegate.encodeInputAndQueryString(
-            input: input,
-            httpPath: endpointPath,
-            invocationReporting: invocationContext.reporting)
 
         let pathWithQuery = requestComponents.pathWithQuery
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

During outgoing requests, if the endpoint path contains tokens, the `outgoingEndpoint` log decoration would contain the unresolved tokens (ex. `"https://s3.us-west-2.amazonaws.com:443/%7BBucket%7D/%7BKey+%7D"`). This change ensure that the log is decorated with the encoded version of the endpoint path. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
