### PR TITLE
Add HTTPInvocationClient, a wrapper that encompasses an HTTPOperation…

### DIFF
--- a/Sources/SmokeHTTPClient/HTTPInvocationClient.swift
+++ b/Sources/SmokeHTTPClient/HTTPInvocationClient.swift
@@ -1,0 +1,237 @@
+// Copyright 2018-2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+//  HTTPInvocationClient.swift
+//  SmokeHTTPClient
+//
+
+import Foundation
+import AsyncHTTPClient
+import NIOHTTP1
+
+public protocol HTTPInvocationClientProtocol {
+     func shutdown() async throws
+
+    func executeRetriableWithoutOutput<InputType: HTTPRequestInputProtocol>(
+        endpoint: URL?,
+        endpointPath: String,
+        httpMethod: HTTPMethod,
+        operation: String?,
+        input: InputType) async throws
+
+    func executeRetriableWithOutput<InputType: HTTPRequestInputProtocol, OutputType: HTTPResponseOutputProtocol>(
+        endpoint: URL?,
+        endpointPath: String,
+        httpMethod: HTTPMethod,
+        operation: String?,
+        input: InputType) async throws -> OutputType
+
+    func executeWithoutOutput<InputType: HTTPRequestInputProtocol>(
+        endpoint: URL?,
+        endpointPath: String,
+        httpMethod: HTTPMethod,
+        operation: String?,
+        input: InputType) async throws
+
+    func executeWithOutput<InputType: HTTPRequestInputProtocol, OutputType: HTTPResponseOutputProtocol>(
+        endpoint: URL?,
+        endpointPath: String,
+        httpMethod: HTTPMethod,
+        operation: String?,
+        input: InputType) async throws -> OutputType
+}
+
+/**
+ Provides a wrapper around a `HTTPOperationsClient` that creates its invocation context at initialization.
+ */
+public struct HTTPInvocationClient<TraceContextType: InvocationTraceContext, HandlerDelegateType: HTTPClientInvocationDelegate>: HTTPInvocationClientProtocol {
+    let httpClient: HTTPOperationsClient
+    let ownsHttpClients: Bool
+    let retryConfiguration: HTTPClientRetryConfiguration
+    let retryOnErrorProvider: (HTTPClientError) -> Bool
+    let invocationContext: HTTPClientInvocationContext<StandardHTTPClientInvocationReporting<TraceContextType>, HandlerDelegateType>
+
+    public init(
+        endpointHostName: String = "", // If empty, client will have to provide endpoint in each individual request
+        endpointPort: Int = 443,
+        contentType: String = "application/json",
+        clientDelegate: HTTPClientDelegate = HTTPClientJSONDelegate(),
+        timeoutConfiguration: HTTPClient.Configuration.Timeout = .init(
+            connect: .seconds(10), read: .seconds(10)),
+        connectionPoolConfiguration: HTTPClient.Configuration.ConnectionPool? = nil,
+        eventLoopProvider: HTTPClient.EventLoopGroupProvider = .createNew,
+        retryConfiguration: HTTPClientRetryConfiguration = .default,
+        retryOnErrorProvider: @escaping (SmokeHTTPClient.HTTPClientError) -> Bool = { error in error.isRetriable() },
+        invocationAttributes: HTTPClientInvocationAttributes,
+        invocationTraceContext: TraceContextType,
+        invocationDelegate: HandlerDelegateType = DefaultHTTPClientInvocationDelegate(),
+        invocationMetrics: HTTPClientInvocationMetrics? = nil) {
+            let httpClient = HTTPOperationsClient(
+                endpointHostName: endpointHostName,
+                endpointPort: endpointPort,
+                contentType: contentType,
+                clientDelegate: clientDelegate,
+                timeoutConfiguration: timeoutConfiguration,
+                eventLoopProvider: eventLoopProvider,
+                connectionPoolConfiguration: connectionPoolConfiguration)
+
+            self.init(
+                httpClient: httpClient,
+                ownsHttpClients: false,
+                retryConfiguration: retryConfiguration,
+                retryOnErrorProvider: retryOnErrorProvider,
+                invocationAttributes: invocationAttributes,
+                invocationTraceContext: invocationTraceContext,
+                invocationDelegate: invocationDelegate,
+                invocationMetrics: invocationMetrics)
+    }
+
+    public init(
+        httpClient: HTTPOperationsClient,
+        retryConfiguration: HTTPClientRetryConfiguration = .default,
+        retryOnErrorProvider: @escaping (SmokeHTTPClient.HTTPClientError) -> Bool = { error in error.isRetriable() },
+        invocationAttributes: HTTPClientInvocationAttributes,
+        invocationTraceContext: TraceContextType,
+        invocationDelegate: HandlerDelegateType = DefaultHTTPClientInvocationDelegate(),
+        invocationMetrics: HTTPClientInvocationMetrics? = nil) {
+            self.init(
+                httpClient: httpClient,
+                ownsHttpClients: false,
+                retryConfiguration: retryConfiguration,
+                retryOnErrorProvider: retryOnErrorProvider,
+                invocationAttributes: invocationAttributes,
+                invocationTraceContext: invocationTraceContext,
+                invocationDelegate: invocationDelegate,
+                invocationMetrics: invocationMetrics)
+    }
+
+    private init(
+        httpClient: HTTPOperationsClient,
+        ownsHttpClients: Bool,
+        retryConfiguration: HTTPClientRetryConfiguration = .default,
+        retryOnErrorProvider: @escaping (SmokeHTTPClient.HTTPClientError) -> Bool = { error in error.isRetriable() },
+        invocationAttributes: HTTPClientInvocationAttributes,
+        invocationTraceContext: TraceContextType,
+        invocationDelegate: HandlerDelegateType = DefaultHTTPClientInvocationDelegate(),
+        invocationMetrics: HTTPClientInvocationMetrics? = nil) {
+            self.httpClient = httpClient
+
+            self.ownsHttpClients = ownsHttpClients
+            self.retryConfiguration = retryConfiguration
+            self.retryOnErrorProvider = retryOnErrorProvider
+
+            let reporting = StandardHTTPClientInvocationReporting(
+                internalRequestId: invocationAttributes.internalRequestId,
+                traceContext: invocationTraceContext,
+                logger: invocationAttributes.logger,
+                eventLoop: invocationAttributes.eventLoop,
+                outwardsRequestAggregator: invocationAttributes.outwardsRequestAggregator,
+                successCounter: invocationMetrics?.successCounter,
+                failure5XXCounter: invocationMetrics?.failure5XXCounter,
+                failure4XXCounter: invocationMetrics?.failure4XXCounter,
+                retryCountRecorder: invocationMetrics?.retryCountRecorder,
+                latencyTimer: invocationMetrics?.latencyTimer)
+
+            self.invocationContext = HTTPClientInvocationContext(reporting: reporting, handlerDelegate: invocationDelegate)
+    }
+
+    /**
+     Gracefully shuts down this client. This function is idempotent and
+     will handle being called multiple times. Will return when shutdown is complete.
+     */
+    public func shutdown() async throws {
+        if self.ownsHttpClients {
+            try await self.httpClient.shutdown()
+        }
+    }
+
+    public func executeRetriableWithoutOutput<InputType: HTTPRequestInputProtocol>(
+        endpoint: URL? = nil,
+        endpointPath: String,
+        httpMethod: HTTPMethod,
+        operation: String? = nil,
+        input: InputType) async throws {
+            guard endpoint != nil || self.httpClient.endpointHostName != "" else {
+                throw HTTPError.badRequest("No endpoint host name was specified.")
+            }
+
+            try await self.httpClient.executeRetriableWithoutOutput(
+                endpointOverride: endpoint,
+                endpointPath: endpointPath,
+                httpMethod: httpMethod,
+                operation: operation,
+                input: input,
+                invocationContext: self.invocationContext,
+                retryConfiguration: self.retryConfiguration,
+                retryOnError: self.retryOnErrorProvider)
+    }
+
+    public func executeRetriableWithOutput<InputType: HTTPRequestInputProtocol, OutputType: HTTPResponseOutputProtocol>(
+        endpoint: URL? = nil,
+        endpointPath: String,
+        httpMethod: HTTPMethod,
+        operation: String? = nil,
+        input: InputType) async throws -> OutputType {
+            guard endpoint != nil || self.httpClient.endpointHostName != "" else {
+                throw HTTPError.badRequest("No endpoint host name was specified.")
+            }
+
+            return try await self.httpClient.executeRetriableWithOutput(
+                endpointOverride: endpoint,
+                endpointPath: endpointPath,
+                httpMethod: httpMethod,
+                operation: operation,
+                input: input,
+                invocationContext: self.invocationContext,
+                retryConfiguration: self.retryConfiguration,
+                retryOnError: self.retryOnErrorProvider)
+    }
+
+    public func executeWithoutOutput<InputType: HTTPRequestInputProtocol>(
+        endpoint: URL? = nil,
+        endpointPath: String,
+        httpMethod: HTTPMethod,
+        operation: String? = nil,
+        input: InputType) async throws {
+            guard endpoint != nil || self.httpClient.endpointHostName != "" else {
+                throw HTTPError.badRequest("No endpoint host name was specified.")
+            }
+
+            try await self.httpClient.executeWithoutOutput(
+                endpointOverride: endpoint,
+                endpointPath: endpointPath,
+                httpMethod: httpMethod,
+                operation: operation,
+                input: input,
+                invocationContext: self.invocationContext)
+    }
+
+    public func executeWithOutput<InputType: HTTPRequestInputProtocol, OutputType: HTTPResponseOutputProtocol>(
+        endpoint: URL? = nil,
+        endpointPath: String,
+        httpMethod: HTTPMethod,
+        operation: String? = nil,
+        input: InputType) async throws -> OutputType {
+            guard endpoint != nil || self.httpClient.endpointHostName != "" else {
+                throw HTTPError.badRequest("No endpoint host name was specified.")
+            }
+
+            return try await self.httpClient.executeWithOutput(
+                endpointOverride: endpoint,
+                endpointPath: endpointPath,
+                httpMethod: httpMethod,
+                operation: operation,
+                input: input,
+                invocationContext: self.invocationContext)
+    }
+}

--- a/Sources/SmokeHTTPClient/HTTPInvocationClient.swift
+++ b/Sources/SmokeHTTPClient/HTTPInvocationClient.swift
@@ -20,7 +20,7 @@ import AsyncHTTPClient
 import NIOHTTP1
 
 public protocol HTTPInvocationClientProtocol {
-     func shutdown() async throws
+    func shutdown() async throws
 
     func executeRetriableWithoutOutput<InputType: HTTPRequestInputProtocol>(
         endpoint: URL?,
@@ -218,6 +218,8 @@ public struct HTTPInvocationClient<TraceContextType: InvocationTraceContext, Han
         httpMethod: HTTPMethod,
         operation: String? = nil,
         input: InputType) async throws {
+            // Users can either specify a default endpoint for the `HTTPInvocationClient` instance
+            // or pass in an request-specific endpoint. Doing neither is an error.
             guard endpoint != nil || self.httpClient.endpointHostName != "" else {
                 throw HTTPError.badRequest("No endpoint host name was specified.")
             }
@@ -239,6 +241,8 @@ public struct HTTPInvocationClient<TraceContextType: InvocationTraceContext, Han
         httpMethod: HTTPMethod,
         operation: String? = nil,
         input: InputType) async throws -> OutputType {
+            // Users can either specify a default endpoint for the `HTTPInvocationClient` instance
+            // or pass in an request-specific endpoint. Doing neither is an error.
             guard endpoint != nil || self.httpClient.endpointHostName != "" else {
                 throw HTTPError.badRequest("No endpoint host name was specified.")
             }
@@ -260,6 +264,8 @@ public struct HTTPInvocationClient<TraceContextType: InvocationTraceContext, Han
         httpMethod: HTTPMethod,
         operation: String? = nil,
         input: InputType) async throws {
+            // Users can either specify a default endpoint for the `HTTPInvocationClient` instance
+            // or pass in an request-specific endpoint. Doing neither is an error.
             guard endpoint != nil || self.httpClient.endpointHostName != "" else {
                 throw HTTPError.badRequest("No endpoint host name was specified.")
             }
@@ -279,6 +285,8 @@ public struct HTTPInvocationClient<TraceContextType: InvocationTraceContext, Han
         httpMethod: HTTPMethod,
         operation: String? = nil,
         input: InputType) async throws -> OutputType {
+            // Users can either specify a default endpoint for the `HTTPInvocationClient` instance
+            // or pass in an request-specific endpoint. Doing neither is an error.
             guard endpoint != nil || self.httpClient.endpointHostName != "" else {
                 throw HTTPError.badRequest("No endpoint host name was specified.")
             }

--- a/Sources/SmokeHTTPClient/MockHTTPInvocationClient.swift
+++ b/Sources/SmokeHTTPClient/MockHTTPInvocationClient.swift
@@ -1,0 +1,136 @@
+// Copyright 2018-2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+//  MockHTTPInvocationClient.swift
+//  SmokeHTTPClient
+//
+
+import Foundation
+import NIOHTTP1
+
+public protocol EmptyInitializable {
+    init()
+}
+
+public enum MockHTTPInvocationClientErrors: Error {
+    case cannotInitializeEmptyOutput(outputType: String)
+    case mismatchingOutputTypes(outputType: String, overrideOutputType: String)
+}
+
+public struct MockHTTPInvocationClient<OverrideInputType: HTTPRequestInputProtocol, OverrideOutputType: HTTPResponseOutputProtocol>: HTTPInvocationClientProtocol {
+    public typealias ExecuteWithoutOutputFunctionType = (
+        _ endpoint: URL?,
+        _ endpointPath: String,
+        _ httpMethod: HTTPMethod,
+        _ operation: String?,
+        _ input: OverrideInputType) async throws -> Void
+
+    public typealias ExecuteWithOutputFunctionType = (
+        _ endpoint: URL?,
+        _ endpointPath: String,
+        _ httpMethod: HTTPMethod,
+        _ operation: String?,
+        _ input: OverrideInputType) async throws -> OverrideOutputType
+
+    let executeWithoutOutputOverride: ExecuteWithoutOutputFunctionType?
+    let executeWithOutputOverride: ExecuteWithOutputFunctionType?
+
+    public init(
+        executeWithoutOutputOverride: ExecuteWithoutOutputFunctionType? = nil,
+        executeWithOutputOverride: ExecuteWithOutputFunctionType? = nil) {
+            self.executeWithoutOutputOverride = executeWithoutOutputOverride
+            self.executeWithOutputOverride = executeWithOutputOverride
+    }
+    
+    public func shutdown() async throws {}
+
+    public func executeRetriableWithoutOutput<InputType: HTTPRequestInputProtocol>(
+        endpoint: URL?,
+        endpointPath: String,
+        httpMethod: HTTPMethod,
+        operation: String?,
+        input: InputType) async throws {
+            if let executeWithoutOutputOverride, let convertedInput = input as? OverrideInputType {
+                try await executeWithoutOutputOverride(endpoint, endpointPath, httpMethod, operation, convertedInput)
+            }
+    }
+
+    public func executeRetriableWithOutput<InputType: HTTPRequestInputProtocol, OutputType: HTTPResponseOutputProtocol>(
+        endpoint: URL?,
+        endpointPath: String,
+        httpMethod: HTTPMethod,
+        operation: String?,
+        input: InputType) async throws -> OutputType {
+            if let executeWithOutputOverride, let convertedInput = input as? OverrideInputType {
+                let output = try await executeWithOutputOverride(endpoint, endpointPath, httpMethod, operation, convertedInput) as? OutputType
+                guard let output else {
+                    throw MockHTTPInvocationClientErrors.mismatchingOutputTypes(outputType: String(describing: OutputType.self), overrideOutputType: String(describing: OverrideOutputType.self))
+                }
+
+                return output
+            }
+
+            return try getDefaultOutput()
+    }
+
+    public func executeWithoutOutput<InputType: HTTPRequestInputProtocol>(
+        endpoint: URL?,
+        endpointPath: String,
+        httpMethod: HTTPMethod,
+        operation: String?,
+        input: InputType) async throws {
+            if let executeWithoutOutputOverride, let convertedInput = input as? OverrideInputType {
+                try await executeWithoutOutputOverride(endpoint, endpointPath, httpMethod, operation, convertedInput)
+            }
+    }
+
+    public func executeWithOutput<InputType: HTTPRequestInputProtocol, OutputType: HTTPResponseOutputProtocol>(
+        endpoint: URL?,
+        endpointPath: String,
+        httpMethod: HTTPMethod,
+        operation: String?,
+        input: InputType) async throws -> OutputType {
+            if let executeWithOutputOverride, let convertedInput = input as? OverrideInputType {
+                let output = try await executeWithOutputOverride(endpoint, endpointPath, httpMethod, operation, convertedInput) as? OutputType
+                guard let output else {
+                    throw MockHTTPInvocationClientErrors.mismatchingOutputTypes(outputType: String(describing: OutputType.self), overrideOutputType: String(describing: OverrideOutputType.self))
+                }
+
+                return output
+            }
+
+            return try getDefaultOutput()
+    }
+
+    private func getDefaultOutput<OutputType: HTTPResponseOutputProtocol>() throws -> OutputType {
+        guard let initializableType = OutputType.self as? EmptyInitializable.Type,
+            let initializedInstance = initializableType.init() as? OutputType else {
+            throw MockHTTPInvocationClientErrors.cannotInitializeEmptyOutput(outputType: String(describing: OutputType.self))
+        }
+
+        return initializedInstance
+    }
+}
+
+public struct MockNoHTTPOutput: HTTPResponseOutputProtocol, EmptyInitializable {
+    public typealias BodyType = String
+    public typealias HeadersType = String
+
+    public static func compose(bodyDecodableProvider: () throws -> BodyType, headersDecodableProvider: () throws -> HeadersType) throws -> MockNoHTTPOutput {
+        return Self()
+    }
+
+    public init() {}
+}
+
+public typealias DefaultMockHTTPInvocationClient = MockHTTPInvocationClient<NoHTTPRequestInput, MockNoHTTPOutput>

--- a/Sources/SmokeHTTPClient/MockHTTPInvocationClient.swift
+++ b/Sources/SmokeHTTPClient/MockHTTPInvocationClient.swift
@@ -60,7 +60,8 @@ public struct MockHTTPInvocationClient<OverrideInputType: HTTPRequestInputProtoc
         httpMethod: HTTPMethod,
         operation: String?,
         input: InputType) async throws {
-            if let executeWithoutOutputOverride, let convertedInput = input as? OverrideInputType {
+            if let executeWithoutOutputOverride = executeWithoutOutputOverride,
+                let convertedInput = input as? OverrideInputType {
                 try await executeWithoutOutputOverride(endpoint, endpointPath, httpMethod, operation, convertedInput)
             }
     }
@@ -71,9 +72,10 @@ public struct MockHTTPInvocationClient<OverrideInputType: HTTPRequestInputProtoc
         httpMethod: HTTPMethod,
         operation: String?,
         input: InputType) async throws -> OutputType {
-            if let executeWithOutputOverride, let convertedInput = input as? OverrideInputType {
+            if let executeWithOutputOverride = executeWithOutputOverride,
+                let convertedInput = input as? OverrideInputType {
                 let output = try await executeWithOutputOverride(endpoint, endpointPath, httpMethod, operation, convertedInput) as? OutputType
-                guard let output else {
+                guard let output = output else {
                     throw MockHTTPInvocationClientErrors.mismatchingOutputTypes(outputType: String(describing: OutputType.self), overrideOutputType: String(describing: OverrideOutputType.self))
                 }
 
@@ -89,7 +91,8 @@ public struct MockHTTPInvocationClient<OverrideInputType: HTTPRequestInputProtoc
         httpMethod: HTTPMethod,
         operation: String?,
         input: InputType) async throws {
-            if let executeWithoutOutputOverride, let convertedInput = input as? OverrideInputType {
+            if let executeWithoutOutputOverride = executeWithoutOutputOverride,
+                let convertedInput = input as? OverrideInputType {
                 try await executeWithoutOutputOverride(endpoint, endpointPath, httpMethod, operation, convertedInput)
             }
     }
@@ -100,9 +103,10 @@ public struct MockHTTPInvocationClient<OverrideInputType: HTTPRequestInputProtoc
         httpMethod: HTTPMethod,
         operation: String?,
         input: InputType) async throws -> OutputType {
-            if let executeWithOutputOverride, let convertedInput = input as? OverrideInputType {
+            if let executeWithOutputOverride = executeWithOutputOverride,
+                let convertedInput = input as? OverrideInputType {
                 let output = try await executeWithOutputOverride(endpoint, endpointPath, httpMethod, operation, convertedInput) as? OutputType
-                guard let output else {
+                guard let output = output else {
                     throw MockHTTPInvocationClientErrors.mismatchingOutputTypes(outputType: String(describing: OutputType.self), overrideOutputType: String(describing: OverrideOutputType.self))
                 }
 

--- a/Tests/SmokeHTTPClientTests/MockHTTPClientInvocationClientTests.swift
+++ b/Tests/SmokeHTTPClientTests/MockHTTPClientInvocationClientTests.swift
@@ -1,0 +1,402 @@
+// Copyright 2018-2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// A copy of the License is located at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+//
+//  MockHTTPClientInvocationClientTests.swift
+//  SmokeHTTPClientTests
+//
+
+import XCTest
+@testable import SmokeHTTPClient
+@testable import NIOHTTP1
+
+private struct TestHTTPRequestInput: HTTPRequestInputProtocol, Equatable {
+    typealias QueryType = String
+    typealias PathType = String
+    typealias BodyType = String
+    typealias AdditionalHeadersType = String
+
+    let queryEncodable: QueryType?
+    let pathEncodable: PathType?
+    let bodyEncodable: BodyType?
+    let additionalHeadersEncodable: AdditionalHeadersType?
+    let pathPostfix: String?
+
+    init(body: String) {
+        self.queryEncodable = nil
+        self.pathEncodable = nil
+        self.bodyEncodable = body
+        self.additionalHeadersEncodable = nil
+        self.pathPostfix = nil
+    }
+
+    static func == (lhs: TestHTTPRequestInput, rhs: TestHTTPRequestInput) -> Bool {
+        lhs.queryEncodable == rhs.queryEncodable &&
+            lhs.pathEncodable == rhs.pathEncodable &&
+            lhs.bodyEncodable == rhs.bodyEncodable &&
+            lhs.additionalHeadersEncodable == rhs.additionalHeadersEncodable &&
+            lhs.pathPostfix == rhs.pathPostfix
+    }
+}
+
+private struct TestHTTPResponseOutput: HTTPResponseOutputProtocol, Equatable {
+    typealias BodyType = String
+    typealias HeadersType = String
+
+    let body: String
+    let headers: String
+
+    static func compose(bodyDecodableProvider: () throws -> BodyType, headersDecodableProvider: () throws -> HeadersType) throws -> Self {
+        return try Self(body: bodyDecodableProvider(), headers: headersDecodableProvider())
+    }
+
+    init(body: String, headers: String) {
+        self.body = body
+        self.headers = headers
+    }
+
+    static func == (lhs: TestHTTPResponseOutput, rhs: TestHTTPResponseOutput) -> Bool {
+        lhs.body == rhs.body &&
+            lhs.headers == rhs.headers
+    }
+}
+
+final class MockHTTPClientInvocationClientTests: XCTestCase {
+    func testExecuteWithoutOutput() async {
+        let expectedEndpoint = URL(string: "http://www.amazon.com")
+        let expectedEndpointPath = "/p/a/t/h"
+        let expectedHTTPMethod = HTTPMethod.GET
+        let expectedOperation = "operation"
+
+        let expectedInput = TestHTTPRequestInput(body: "input")
+
+        var executeWithoutOutputCalled = false
+        func executeWithoutOutput(
+            endpoint: URL?,
+            endpointPath: String,
+            httpMethod: HTTPMethod,
+            operation: String?,
+            input: TestHTTPRequestInput) {
+                executeWithoutOutputCalled = true
+                XCTAssertEqual(endpoint, expectedEndpoint)
+                XCTAssertEqual(endpointPath, expectedEndpointPath)
+                XCTAssertEqual(httpMethod, expectedHTTPMethod)
+                XCTAssertEqual(operation, expectedOperation)
+                XCTAssertEqual(input, expectedInput)
+        }
+
+        let mockWithOverride = MockHTTPInvocationClient<TestHTTPRequestInput, TestHTTPResponseOutput>(executeWithoutOutputOverride: executeWithoutOutput)
+        let mockWithoutOverride = MockHTTPInvocationClient<TestHTTPRequestInput, TestHTTPResponseOutput>()
+
+        do {
+            try await mockWithOverride.executeRetriableWithoutOutput(
+                endpoint: expectedEndpoint,
+                endpointPath: expectedEndpointPath,
+                httpMethod: expectedHTTPMethod,
+                operation: expectedOperation,
+                input: expectedInput)
+            XCTAssertTrue(executeWithoutOutputCalled)
+
+            executeWithoutOutputCalled = false
+            try await mockWithOverride.executeWithoutOutput(
+                endpoint: expectedEndpoint,
+                endpointPath: expectedEndpointPath,
+                httpMethod: expectedHTTPMethod,
+                operation: expectedOperation,
+                input: expectedInput)
+            XCTAssertTrue(executeWithoutOutputCalled)
+
+            executeWithoutOutputCalled = false
+            try await mockWithoutOverride.executeRetriableWithoutOutput(
+                endpoint: expectedEndpoint,
+                endpointPath: expectedEndpointPath,
+                httpMethod: expectedHTTPMethod,
+                operation: expectedOperation,
+                input: expectedInput)
+            XCTAssertFalse(executeWithoutOutputCalled)
+
+            try await mockWithoutOverride.executeWithoutOutput(
+                endpoint: expectedEndpoint,
+                endpointPath: expectedEndpointPath,
+                httpMethod: expectedHTTPMethod,
+                operation: expectedOperation,
+                input: expectedInput)
+            XCTAssertFalse(executeWithoutOutputCalled)
+        } catch {
+            XCTFail("Unexpected error \(error)")
+        }
+    }
+
+    func testExecuteWithOutput() async {
+        let expectedEndpoint = URL(string: "http://www.amazon.com")
+        let expectedEndpointPath = "/p/a/t/h"
+        let expectedHTTPMethod = HTTPMethod.GET
+        let expectedOperation = "operation"
+
+        let expectedInput = TestHTTPRequestInput(body: "input")
+        let expectedOutput = TestHTTPResponseOutput(body: "output", headers: "")
+
+        func executeWithOutput(
+            _ endpoint: URL?,
+            _ endpointPath: String,
+            _ httpMethod: HTTPMethod,
+            _ operation: String?,
+            _ input: TestHTTPRequestInput) async throws -> TestHTTPResponseOutput {
+                XCTAssertEqual(endpoint, expectedEndpoint)
+                XCTAssertEqual(endpointPath, expectedEndpointPath)
+                XCTAssertEqual(httpMethod, expectedHTTPMethod)
+                XCTAssertEqual(operation, expectedOperation)
+                XCTAssertEqual(input, expectedInput)
+
+                return expectedOutput
+        }
+
+        let mockWithOverrides = MockHTTPInvocationClient<TestHTTPRequestInput, TestHTTPResponseOutput>(executeWithOutputOverride: executeWithOutput)
+        let mockWithoutOverrides = MockHTTPInvocationClient<TestHTTPRequestInput, TestHTTPResponseOutput>()
+
+        do {
+            let output1: TestHTTPResponseOutput = try await mockWithOverrides.executeRetriableWithOutput(
+                endpoint: expectedEndpoint,
+                endpointPath: expectedEndpointPath,
+                httpMethod: expectedHTTPMethod,
+                operation: expectedOperation,
+                input: expectedInput)
+            XCTAssertEqual(expectedOutput, output1)
+
+            let output2: TestHTTPResponseOutput = try await mockWithOverrides.executeWithOutput(
+                endpoint: expectedEndpoint,
+                endpointPath: expectedEndpointPath,
+                httpMethod: expectedHTTPMethod,
+                operation: expectedOperation,
+                input: expectedInput)
+            XCTAssertEqual(expectedOutput, output2)
+        } catch {
+            XCTFail("Unexpected error \(error)")
+        }
+
+        do {
+            // Cannot implicitly initialize an output
+            let _: TestHTTPResponseOutput = try await mockWithoutOverrides.executeRetriableWithOutput(
+                endpoint: expectedEndpoint,
+                endpointPath: expectedEndpointPath,
+                httpMethod: expectedHTTPMethod,
+                operation: expectedOperation,
+                input: expectedInput)
+            XCTFail("Expected error not thrown")
+        } catch MockHTTPInvocationClientErrors.cannotInitializeEmptyOutput {
+            // Expected error
+        } catch {
+            XCTFail("Unexpected error \(error)")
+        }
+
+        do {
+            // Cannot implicitly initialize an output
+            let _: TestHTTPResponseOutput = try await mockWithoutOverrides.executeWithOutput(
+                endpoint: expectedEndpoint,
+                endpointPath: expectedEndpointPath,
+                httpMethod: expectedHTTPMethod,
+                operation: expectedOperation,
+                input: expectedInput)
+            XCTFail("Expected error not thrown")
+        } catch MockHTTPInvocationClientErrors.cannotInitializeEmptyOutput {
+            // Expected error
+        } catch {
+            XCTFail("Unexpected error \(error)")
+        }
+    }
+
+    func testExecuteWithAndWithoutOutput() async {
+        let expectedEndpoint = URL(string: "http://www.amazon.com")
+        let expectedEndpointPath = "/p/a/t/h"
+        let expectedHTTPMethod = HTTPMethod.GET
+        let expectedOperation = "operation"
+
+        let expectedInput = TestHTTPRequestInput(body: "input")
+        var executeWithoutOutputCalled = false
+        func executeWithoutOutput(
+            endpoint: URL?,
+            endpointPath: String,
+            httpMethod: HTTPMethod,
+            operation: String?,
+            input: TestHTTPRequestInput) {
+                executeWithoutOutputCalled = true
+                XCTAssertEqual(endpoint, expectedEndpoint)
+                XCTAssertEqual(endpointPath, expectedEndpointPath)
+                XCTAssertEqual(httpMethod, expectedHTTPMethod)
+                XCTAssertEqual(operation, expectedOperation)
+                XCTAssertEqual(input, expectedInput)
+        }        
+        
+        let expectedOutput = TestHTTPResponseOutput(body: "output", headers: "")
+        func executeWithOutput(
+            _ endpoint: URL?,
+            _ endpointPath: String,
+            _ httpMethod: HTTPMethod,
+            _ operation: String?,
+            _ input: TestHTTPRequestInput) async throws -> TestHTTPResponseOutput {
+                XCTAssertEqual(endpoint, expectedEndpoint)
+                XCTAssertEqual(endpointPath, expectedEndpointPath)
+                XCTAssertEqual(httpMethod, expectedHTTPMethod)
+                XCTAssertEqual(operation, expectedOperation)
+                XCTAssertEqual(input, expectedInput)
+
+                return expectedOutput
+        }
+
+        let mock = MockHTTPInvocationClient(
+            executeWithoutOutputOverride: executeWithoutOutput,
+            executeWithOutputOverride: executeWithOutput)
+
+        do {
+            try await mock.executeWithoutOutput(
+                endpoint: expectedEndpoint,
+                endpointPath: expectedEndpointPath,
+                httpMethod: expectedHTTPMethod,
+                operation: expectedOperation,
+                input: expectedInput)
+            XCTAssertTrue(executeWithoutOutputCalled)
+
+            let output: TestHTTPResponseOutput = try await mock.executeWithOutput(
+                endpoint: expectedEndpoint,
+                endpointPath: expectedEndpointPath,
+                httpMethod: expectedHTTPMethod,
+                operation: expectedOperation,
+                input: expectedInput)
+            XCTAssertEqual(expectedOutput, output)
+        } catch {
+            XCTFail("Unexpected error \(error)")
+        }
+    }
+
+    func testDefaultMock() async {
+        let endpoint = URL(string: "http://www.amazon.com")
+        let endpointPath = "/p/a/t/h"
+        let httpMethod = HTTPMethod.GET
+        let operation = "operation"
+        
+        let mock = DefaultMockHTTPInvocationClient()
+
+        do {
+            try await mock.executeRetriableWithoutOutput(
+                endpoint: endpoint,
+                endpointPath: endpointPath,
+                httpMethod: httpMethod,
+                operation: operation,
+                input: NoHTTPRequestInput())
+
+            try await mock.executeWithoutOutput(
+                endpoint: endpoint,
+                endpointPath: endpointPath,
+                httpMethod: httpMethod,
+                operation: operation,
+                input: NoHTTPRequestInput())
+
+            let _: MockNoHTTPOutput = try await mock.executeRetriableWithOutput(
+                endpoint: endpoint,
+                endpointPath: endpointPath,
+                httpMethod: httpMethod,
+                operation: operation,
+                input: NoHTTPRequestInput())
+
+            let _: MockNoHTTPOutput = try await mock.executeWithOutput(
+                endpoint: endpoint,
+                endpointPath: endpointPath,
+                httpMethod: httpMethod,
+                operation: operation,
+                input: NoHTTPRequestInput())
+        } catch {
+            XCTFail("Unexpected error \(error)")
+        }
+    }
+
+    func testExecuteWithTypeMismatch() async {
+        let endpoint = URL(string: "http://www.amazon.com")
+        let endpointPath = "/p/a/t/h"
+        let httpMethod = HTTPMethod.GET
+        let operation = "operation"
+
+        var executeWithoutOutputCalled = false
+        func executeWithoutOutput(
+            endpoint: URL?,
+            endpointPath: String,
+            httpMethod: HTTPMethod,
+            operation: String?,
+            input: TestHTTPRequestInput) {
+                executeWithoutOutputCalled = true
+        }        
+        
+        let expectedOutput = TestHTTPResponseOutput(body: "output", headers: "")
+        func executeWithOutput(
+            _ endpoint: URL?,
+            _ endpointPath: String,
+            _ httpMethod: HTTPMethod,
+            _ operation: String?,
+            _ input: TestHTTPRequestInput) async throws -> TestHTTPResponseOutput {
+                return expectedOutput
+        }
+
+        let mock = MockHTTPInvocationClient(
+            executeWithoutOutputOverride: executeWithoutOutput,
+            executeWithOutputOverride: executeWithOutput)
+
+        do {
+            // The override generic type doesn't match the request, the override is not executed
+            try await mock.executeWithoutOutput(
+                endpoint: endpoint,
+                endpointPath: endpointPath,
+                httpMethod: httpMethod,
+                operation: operation,
+                input: NoHTTPRequestInput())
+            XCTAssertFalse(executeWithoutOutputCalled)
+
+            // The override generic input type doesn't match the request, the override is not executed.
+            // The output is empty-initializable, so the request still succeeds
+            let _: MockNoHTTPOutput = try await mock.executeWithOutput(
+                endpoint: endpoint,
+                endpointPath: endpointPath,
+                httpMethod: httpMethod,
+                operation: operation,
+                input: NoHTTPRequestInput())
+        } catch {
+            XCTFail("Unexpected error \(error)")
+        }
+
+        do {
+            // The override generic input type doesn't match the request, the override is not executed.
+            // The output is not empty-initializable, so the request fails
+            let _: TestHTTPResponseOutput = try await mock.executeWithOutput(
+                endpoint: endpoint,
+                endpointPath: endpointPath,
+                httpMethod: httpMethod,
+                operation: operation,
+                input: NoHTTPRequestInput())
+        } catch MockHTTPInvocationClientErrors.cannotInitializeEmptyOutput {
+            // Expected error
+        } catch {
+            XCTFail("Unexpected error \(error)")
+        }
+
+        do {
+            // The override generic output type doesn't match the request, the request fails.
+            let _: MockNoHTTPOutput = try await mock.executeWithOutput(
+                endpoint: endpoint,
+                endpointPath: endpointPath,
+                httpMethod: httpMethod,
+                operation: operation,
+                input: TestHTTPRequestInput(body: "input"))
+        } catch MockHTTPInvocationClientErrors.mismatchingOutputTypes {
+            // Expected error
+        } catch {
+            XCTFail("Unexpected error \(error)")
+        }
+    }
+}


### PR DESCRIPTION
…s client with the invocation context and retry strategy

*Issue #, if available:*

*Description of changes:*

The main goal of this change is to add `HTTPInvocationClient`, which is an utility wrapper over a `HTTPOperationsClient` object. The invocation client is encompasses the retry strategy and invocation context, which are stored at initialization and used for each request.

Ancillary changes:
- Add a default `HTTPClientDelegate` for JSON requests/responses.
- Add a mock version of `HTTPInvocationClient` so that it can be used in unit tests.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
