### PR TITLE
Fix errors and warnings from Swift 5.8

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/swift-server/async-http-client.git",
         "state": {
           "branch": null,
-          "revision": "fc510a39cff61b849bf5cdff17eb2bd6d0777b49",
-          "version": "1.11.5"
+          "revision": "864c8d9e0ead5de7ba70b61c8982f89126710863",
+          "version": "1.15.0"
         }
       },
       {
@@ -15,8 +15,17 @@
         "repositoryURL": "https://github.com/apple/swift-atomics.git",
         "state": {
           "branch": null,
-          "revision": "919eb1d83e02121cdb434c7bfc1f0c66ef17febe",
-          "version": "1.0.2"
+          "revision": "ff3d2212b6b093db7f177d0855adbc4ef9c5f036",
+          "version": "1.0.3"
+        }
+      },
+      {
+        "package": "swift-collections",
+        "repositoryURL": "https://github.com/apple/swift-collections.git",
+        "state": {
+          "branch": null,
+          "revision": "937e904258d22af6e447a0b72c0bc67583ef64a2",
+          "version": "1.0.4"
         }
       },
       {
@@ -24,8 +33,8 @@
         "repositoryURL": "https://github.com/apple/swift-log.git",
         "state": {
           "branch": null,
-          "revision": "6fe203dc33195667ce1759bf0182975e4653ba1c",
-          "version": "1.4.4"
+          "revision": "32e8d724467f8fe623624570367e3d50c5638e46",
+          "version": "1.5.2"
         }
       },
       {
@@ -33,8 +42,8 @@
         "repositoryURL": "https://github.com/apple/swift-metrics.git",
         "state": {
           "branch": null,
-          "revision": "53be78637ecd165d1ddedc4e20de69b8f43ec3b7",
-          "version": "2.3.2"
+          "revision": "e8bced74bc6d747745935e469f45d03f048d6cbd",
+          "version": "2.3.4"
         }
       },
       {
@@ -42,8 +51,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio.git",
         "state": {
           "branch": null,
-          "revision": "b4e0a274f7f34210e97e2f2c50ab02a10b549250",
-          "version": "2.41.1"
+          "revision": "9b2848d76f5caad08b97e71a04345aa5bdb23a06",
+          "version": "2.49.0"
         }
       },
       {
@@ -51,8 +60,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio-extras.git",
         "state": {
           "branch": null,
-          "revision": "a75e92bde3683241c15df3dd905b7a6dcac4d551",
-          "version": "1.12.1"
+          "revision": "cc1e5275079380c859417dbea8588531f1a90ec3",
+          "version": "1.18.0"
         }
       },
       {
@@ -60,8 +69,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio-http2.git",
         "state": {
           "branch": null,
-          "revision": "f9ab1c94c80d568efd762d2a638f25162691d766",
-          "version": "1.22.1"
+          "revision": "38feec96bcd929028939107684073554bf01abeb",
+          "version": "1.25.2"
         }
       },
       {
@@ -69,8 +78,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio-ssl.git",
         "state": {
           "branch": null,
-          "revision": "0265283d3539ced108b9b8287eb3328c9d85acdc",
-          "version": "2.21.0"
+          "revision": "4fb7ead803e38949eb1d6fabb849206a72c580f3",
+          "version": "2.23.0"
         }
       },
       {
@@ -78,8 +87,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio-transport-services.git",
         "state": {
           "branch": null,
-          "revision": "4e02d9cf35cabfb538c96613272fb027dd0c8692",
-          "version": "1.13.1"
+          "revision": "c0d9a144cfaec8d3d596aadde3039286a266c15c",
+          "version": "1.15.0"
         }
       }
     ]

--- a/Sources/SmokeHTTPClient/HTTPClientInvocationDelegate.swift
+++ b/Sources/SmokeHTTPClient/HTTPClientInvocationDelegate.swift
@@ -73,7 +73,11 @@ public protocol HTTPClientInvocationDelegate {
 }
 
 public struct DefaultHTTPClientInvocationDelegate: HTTPClientInvocationDelegate {
-    public let specifyContentHeadersForZeroLengthBody: Bool = true
+    public let specifyContentHeadersForZeroLengthBody: Bool
+
+    public init(specifyContentHeadersForZeroLengthBody: Bool = true) {
+        self.specifyContentHeadersForZeroLengthBody = specifyContentHeadersForZeroLengthBody
+    }
 
     public func addClientSpecificHeaders<InvocationReportingType: HTTPClientInvocationReporting>(
             parameters: HTTPRequestParameters,

--- a/Sources/SmokeHTTPClient/HTTPInvocationClient.swift
+++ b/Sources/SmokeHTTPClient/HTTPInvocationClient.swift
@@ -17,6 +17,7 @@
 
 import Foundation
 import AsyncHTTPClient
+import NIOCore
 import NIOHTTP1
 
 public protocol HTTPInvocationClientProtocol {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Swift 5.8 introduced compilation errors and warnings. This change fixes them.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
