### PR TITLE
Correctly throw HTTPError.unauthorized

### DIFF
--- a/Sources/SmokeHTTPClient/HTTPError.swift
+++ b/Sources/SmokeHTTPClient/HTTPError.swift
@@ -39,5 +39,6 @@ public enum HTTPError: Error {
 
     // Other
     case validationError(reason: String)
+    case deserializationError(cause: Swift.Error)
     case unknownError(String)
 }

--- a/Sources/SmokeHTTPClient/HTTPOperationsClient.swift
+++ b/Sources/SmokeHTTPClient/HTTPOperationsClient.swift
@@ -521,7 +521,7 @@ extension HTTPOperationsClient {
     private func getResponseErrorFromProviderError(response: HTTPClient.Response, bodyData: Data?,
                                                    providerError: Swift.Error) -> Error {
         if case .forbidden = response.status {
-            if let bodyData {
+            if let bodyData = bodyData {
                 do {
                     let unauthorizedBody = try JSONDecoder().decode(UnauthorizedBody.self, from: bodyData)
                     


### PR DESCRIPTION

*Issue #, if available:*

*Description of changes:* Correctly throw HTTPError.unauthorized when the forbidden error code is returned. If possible will decode the response to return the message returned.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
