### PR TITLE
Identify connection failures so they can be retried uniformly.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -42,7 +42,6 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.33.0"),
-        .package(url: "https://github.com/apple/swift-nio-http2.git", from: "1.19.0"),
         .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.14.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-metrics.git", "1.0.0"..<"3.0.0"),
@@ -56,7 +55,6 @@ let package = Package(
                 .product(name: "Metrics", package: "swift-metrics"),
                 .product(name: "NIO", package: "swift-nio"),
                 .product(name: "NIOHTTP1", package: "swift-nio"),
-                .product(name: "NIOHTTP2", package: "swift-nio-http2"),
                 .product(name: "NIOFoundationCompat", package: "swift-nio"),
                 .product(name: "NIOSSL", package: "swift-nio-ssl"),
                 .product(name: "AsyncHTTPClient", package: "async-http-client"),

--- a/Sources/SmokeHTTPClient/HTTPError.swift
+++ b/Sources/SmokeHTTPClient/HTTPError.swift
@@ -34,6 +34,7 @@ public enum HTTPError: Error {
 
     // 5xx
     case connectionError(String)
+    case connectionFailure(cause: Swift.Error)
     case internalServerError(String)
     case invalidRequest(String)
 

--- a/Sources/SmokeHTTPClient/HTTPOperationsClient+executeRetriableWithOutput.swift
+++ b/Sources/SmokeHTTPClient/HTTPOperationsClient+executeRetriableWithOutput.swift
@@ -21,7 +21,6 @@ import Foundation
 import AsyncHTTPClient
 import NIO
 import NIOHTTP1
-import NIOHTTP2
 import Metrics
 import Tracing
 
@@ -222,9 +221,7 @@ public extension HTTPOperationsClient {
         }
         
         func treatAsAbortedAttempt(cause: Swift.Error) -> Bool {
-            if cause is NIOHTTP2Errors.StreamClosed {
-                return true
-            } else if let clientError = cause as? AsyncHTTPClient.HTTPClientError, clientError == .remoteConnectionClosed {
+            if let httpError = cause as? HTTPError, case .connectionFailure = httpError {
                 return true
             }
             

--- a/Sources/SmokeHTTPClient/HTTPOperationsClient+executeRetriableWithoutOutput.swift
+++ b/Sources/SmokeHTTPClient/HTTPOperationsClient+executeRetriableWithoutOutput.swift
@@ -21,7 +21,6 @@ import Foundation
 import AsyncHTTPClient
 import NIO
 import NIOHTTP1
-import NIOHTTP2
 import Metrics
 import Tracing
 
@@ -201,9 +200,7 @@ public extension HTTPOperationsClient {
         }
         
         func treatAsAbortedAttempt(cause: Swift.Error) -> Bool {
-            if cause is NIOHTTP2Errors.StreamClosed {
-                return true
-            } else if let clientError = cause as? AsyncHTTPClient.HTTPClientError, clientError == .remoteConnectionClosed {
+            if let httpError = cause as? HTTPError, case .connectionFailure = httpError {
                 return true
             }
             


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Wrap any http failures that we want to treat specially as transient connection issues in `HTTPError.connectionFailure`, allowing the retry logic to easily identify this class of failure and apply custom retry behaviour.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
