### PR TITLE
Treat AsyncHTTPClient.HTTPClientError.cancelled as a connection failure.

### DIFF
--- a/Sources/SmokeHTTPClient/HTTPOperationsClient.swift
+++ b/Sources/SmokeHTTPClient/HTTPOperationsClient.swift
@@ -582,9 +582,10 @@ extension HTTPOperationsClient {
                 || clientError == AsyncHTTPClient.HTTPClientError.connectTimeout
                 || clientError == AsyncHTTPClient.HTTPClientError.getConnectionFromPoolTimeout {
             return clientError
-        // special case tls handshake timeouts and remote connection closed errors, treat as a connection failures
+        // special case tls handshake timeouts, remote connection closed and cancelled errors, treat as a connection failures
         } else if clientError == AsyncHTTPClient.HTTPClientError.tlsHandshakeTimeout
-                || clientError == AsyncHTTPClient.HTTPClientError.remoteConnectionClosed {
+                || clientError == AsyncHTTPClient.HTTPClientError.remoteConnectionClosed
+                || clientError == AsyncHTTPClient.HTTPClientError.cancelled {
             return HTTPError.connectionFailure(cause: clientError)
         }
         


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Treat AsyncHTTPClient.HTTPClientError.cancelled as a connection failure so it gets retried.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
