### PR TITLE
Add 429 errors as retryable client errors

### DIFF
--- a/Sources/SmokeHTTPClient/HTTPOperationsClient +executeAsyncRetriableWithOutput.swift
+++ b/Sources/SmokeHTTPClient/HTTPOperationsClient +executeAsyncRetriableWithOutput.swift
@@ -158,7 +158,7 @@ public extension HTTPOperationsClient {
                 
                 // report failure metric
                 switch error.category {
-                case .clientError:
+                case .clientError, .clientRetryableError:
                     invocationContext.reporting.failure4XXCounter?.increment()
                 case .serverError:
                     invocationContext.reporting.failure5XXCounter?.increment()

--- a/Sources/SmokeHTTPClient/HTTPOperationsClient +executeAsyncWithOutput.swift
+++ b/Sources/SmokeHTTPClient/HTTPOperationsClient +executeAsyncWithOutput.swift
@@ -143,7 +143,7 @@ public extension HTTPOperationsClient {
                 
                 // report failure metric
                 switch error.category {
-                case .clientError:
+                case .clientError, .clientRetryableError:
                     invocationContext.reporting.failure4XXCounter?.increment()
                 case .serverError:
                     invocationContext.reporting.failure5XXCounter?.increment()

--- a/Sources/SmokeHTTPClient/HTTPOperationsClient +executeAsyncWithoutOutput.swift
+++ b/Sources/SmokeHTTPClient/HTTPOperationsClient +executeAsyncWithoutOutput.swift
@@ -138,7 +138,7 @@ public extension HTTPOperationsClient {
                     
                     // report failure metric
                     switch error.category {
-                    case .clientError:
+                    case .clientError, .clientRetryableError:
                         invocationContext.reporting.failure4XXCounter?.increment()
                     case .serverError:
                         invocationContext.reporting.failure5XXCounter?.increment()

--- a/Sources/SmokeHTTPClient/HTTPOperationsClient +executeSyncRetriableWithOutput.swift
+++ b/Sources/SmokeHTTPClient/HTTPOperationsClient +executeSyncRetriableWithOutput.swift
@@ -124,7 +124,7 @@ public extension HTTPOperationsClient {
             } catch let error as HTTPClientError {
                 // report failure metric
                 switch error.category {
-                case .clientError:
+                case .clientError, .clientRetryableError:
                     invocationContext.reporting.failure4XXCounter?.increment()
                 case .serverError:
                     invocationContext.reporting.failure5XXCounter?.increment()
@@ -145,7 +145,7 @@ public extension HTTPOperationsClient {
             case .clientError:
                 // never retry
                 shouldRetryOnError = false
-            case .serverError:
+            case .serverError, .clientRetryableError:
                 shouldRetryOnError = retryOnError(error)
             }
             let logger = invocationContext.reporting.logger

--- a/Sources/SmokeHTTPClient/HTTPOperationsClient +executeSyncRetriableWithoutOutput.swift
+++ b/Sources/SmokeHTTPClient/HTTPOperationsClient +executeSyncRetriableWithoutOutput.swift
@@ -125,7 +125,7 @@ public extension HTTPOperationsClient {
             } catch let error as HTTPClientError {
                 // report failure metric
                 switch error.category {
-                case .clientError:
+                case .clientError, .clientRetryableError:
                     invocationContext.reporting.failure4XXCounter?.increment()
                 case .serverError:
                     invocationContext.reporting.failure5XXCounter?.increment()
@@ -146,7 +146,7 @@ public extension HTTPOperationsClient {
             case .clientError:
                 // never retry
                 shouldRetryOnError = false
-            case .serverError:
+            case .serverError, .clientRetryableError:
                 shouldRetryOnError = retryOnError(error)
             }
             let logger = invocationContext.reporting.logger

--- a/Sources/SmokeHTTPClient/HTTPOperationsClient+executeAsEventLoopFutureRetriableWithOutput.swift
+++ b/Sources/SmokeHTTPClient/HTTPOperationsClient+executeAsEventLoopFutureRetriableWithOutput.swift
@@ -165,7 +165,7 @@ public extension HTTPOperationsClient {
             
             // report failure metric
             switch error.category {
-            case .clientError:
+            case .clientError, .clientRetryableError:
                 invocationContext.reporting.failure4XXCounter?.increment()
             case .serverError:
                 invocationContext.reporting.failure5XXCounter?.increment()

--- a/Sources/SmokeHTTPClient/HTTPOperationsClient+executeAsEventLoopFutureRetriableWithoutOutput.swift
+++ b/Sources/SmokeHTTPClient/HTTPOperationsClient+executeAsEventLoopFutureRetriableWithoutOutput.swift
@@ -165,7 +165,7 @@ public extension HTTPOperationsClient {
             
             // report failure metric
             switch error.category {
-            case .clientError:
+            case .clientError, .clientRetryableError:
                 invocationContext.reporting.failure4XXCounter?.increment()
             case .serverError:
                 invocationContext.reporting.failure5XXCounter?.increment()

--- a/Sources/SmokeHTTPClient/HTTPOperationsClient+executeAsEventLoopFutureWithOutput.swift
+++ b/Sources/SmokeHTTPClient/HTTPOperationsClient+executeAsEventLoopFutureWithOutput.swift
@@ -137,7 +137,7 @@ public extension HTTPOperationsClient {
                 if let typedError = error as? HTTPClientError {
                     // report failure metric
                     switch typedError.category {
-                    case .clientError:
+                    case .clientError, .clientRetryableError:
                         invocationContext.reporting.failure4XXCounter?.increment()
                     case .serverError:
                         invocationContext.reporting.failure5XXCounter?.increment()

--- a/Sources/SmokeHTTPClient/HTTPOperationsClient+executeAsEventLoopFutureWithoutOutput.swift
+++ b/Sources/SmokeHTTPClient/HTTPOperationsClient+executeAsEventLoopFutureWithoutOutput.swift
@@ -121,7 +121,7 @@ public extension HTTPOperationsClient {
                     if let typedError = error as? HTTPClientError {
                         // report failure metric
                         switch typedError.category {
-                        case .clientError:
+                        case .clientError, .clientRetryableError:
                             invocationContext.reporting.failure4XXCounter?.increment()
                         case .serverError:
                             invocationContext.reporting.failure5XXCounter?.increment()

--- a/Sources/SmokeHTTPClient/HTTPOperationsClient+executeAsyncRetriableWithoutOutput.swift
+++ b/Sources/SmokeHTTPClient/HTTPOperationsClient+executeAsyncRetriableWithoutOutput.swift
@@ -152,7 +152,7 @@ public extension HTTPOperationsClient {
                 
                 // report failure metric
                 switch innerError.category {
-                case .clientError:
+                case .clientError, .clientRetryableError:
                     invocationContext.reporting.failure4XXCounter?.increment()
                 case .serverError:
                     invocationContext.reporting.failure5XXCounter?.increment()

--- a/Sources/SmokeHTTPClient/HTTPOperationsClient+executeRetriableWithOutput.swift
+++ b/Sources/SmokeHTTPClient/HTTPOperationsClient+executeRetriableWithOutput.swift
@@ -191,7 +191,7 @@ public extension HTTPOperationsClient {
             
             // report failure metric
             switch error.category {
-            case .clientError:
+            case .clientError, .clientRetryableError:
                 invocationContext.reporting.failure4XXCounter?.increment()
             case .serverError:
                 invocationContext.reporting.failure5XXCounter?.increment()

--- a/Sources/SmokeHTTPClient/HTTPOperationsClient+executeRetriableWithoutOutput.swift
+++ b/Sources/SmokeHTTPClient/HTTPOperationsClient+executeRetriableWithoutOutput.swift
@@ -170,7 +170,7 @@ public extension HTTPOperationsClient {
             
             // report failure metric
             switch error.category {
-            case .clientError:
+            case .clientError, .clientRetryableError:
                 invocationContext.reporting.failure4XXCounter?.increment()
             case .serverError:
                 invocationContext.reporting.failure5XXCounter?.increment()

--- a/Sources/SmokeHTTPClient/HTTPOperationsClient+executeWithOutput.swift
+++ b/Sources/SmokeHTTPClient/HTTPOperationsClient+executeWithOutput.swift
@@ -124,7 +124,7 @@ public extension HTTPOperationsClient {
             if let typedError = error as? HTTPClientError {
                 // report failure metric
                 switch typedError.category {
-                case .clientError:
+                case .clientError, .clientRetryableError:
                     invocationContext.reporting.failure4XXCounter?.increment()
                 case .serverError:
                     invocationContext.reporting.failure5XXCounter?.increment()

--- a/Sources/SmokeHTTPClient/HTTPOperationsClient+executeWithoutOutput.swift
+++ b/Sources/SmokeHTTPClient/HTTPOperationsClient+executeWithoutOutput.swift
@@ -106,7 +106,7 @@ public extension HTTPOperationsClient {
                 if let typedError = error as? HTTPClientError {
                     // report failure metric
                     switch typedError.category {
-                    case .clientError:
+                    case .clientError, .clientRetryableError:
                         invocationContext.reporting.failure4XXCounter?.increment()
                     case .serverError:
                         invocationContext.reporting.failure5XXCounter?.increment()

--- a/Sources/SmokeHTTPClient/HttpClientError.swift
+++ b/Sources/SmokeHTTPClient/HttpClientError.swift
@@ -21,6 +21,7 @@ public struct HTTPClientError: Error {
     
     public enum Category {
         case clientError
+        case clientRetryableError
         case serverError
     }
     
@@ -32,7 +33,11 @@ public struct HTTPClientError: Error {
     public var category: Category {
         switch responseCode {
         case 400...499:
-            return .clientError
+            if(responseCode == 429) {
+                return .clientRetryableError
+            } else {
+                return .clientError
+            }
         default:
             return .serverError
         }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Add retry support for error status code 429. This is usually a throttling error status code and can be retried.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
