### PR TITLE
Add HTTPHeadersCoding dependency in SmokeHTTPClient

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -59,6 +59,7 @@ let package = Package(
                 .product(name: "NIOSSL", package: "swift-nio-ssl"),
                 .product(name: "AsyncHTTPClient", package: "async-http-client"),
                 .product(name: "Tracing", package: "swift-distributed-tracing"),
+                .target(name: "HTTPHeadersCoding"),
             ]),
         .target(
             name: "_SmokeHTTPClientConcurrency", dependencies: [


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Add HTTPHeadersCoding dependency in SmokeHTTPClient. SmokeHTTPClient.HTTPClientDelegate depends on HTTPHeadersCoding. Sometimes build fails without explicitly declare this dependency. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
