### PR TITLE
Remove conflicting copy of NIO method

### DIFF
--- a/Sources/SmokeHTTPClient/HTTPOperationsClient+executeRetriableWithOutput.swift
+++ b/Sources/SmokeHTTPClient/HTTPOperationsClient+executeRetriableWithOutput.swift
@@ -26,27 +26,6 @@ import Tracing
 
 private let millisecondsToNanoSeconds: UInt64 = 1000000
 
-// Copy of extension from SwiftNIO; can be removed when the version in SwiftNIO removes its @available attribute
-internal extension EventLoopFuture {
-    /// Get the value/error from an `EventLoopFuture` in an `async` context.
-    ///
-    /// This function can be used to bridge an `EventLoopFuture` into the `async` world. Ie. if you're in an `async`
-    /// function and want to get the result of this future.
-    @inlinable
-    func get() async throws -> Value {
-        return try await withCheckedThrowingContinuation { cont in
-            self.whenComplete { result in
-                switch result {
-                case .success(let value):
-                    cont.resume(returning: value)
-                case .failure(let error):
-                    cont.resume(throwing: error)
-                }
-            }
-        }
-    }
-}
-
 public extension HTTPOperationsClient {
     /**
      Helper type that manages the state of a retriable async request.


### PR DESCRIPTION
In #98, @tachyonics added a vendored copy of a NIO method on EventLoopFuture to avoid needing to add availability guards. I don't think that should have been necessary then, but it certainly isn't now, as smoke-http's minimum deployment targets match the extension in NIO.

This extension contravened one of NIO's requirements on its dependencies: https://github.com/apple/swift-nio/blob/main/docs/public-api.md#4-extending-nio-types. Ideally when it was added, it should have been given a different name.

This extension has been working, but it is now conflicting with NIO's main on Swift 5.9. This patch removes the now-vestigial extension, as it isn't needed.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
